### PR TITLE
Convert main.js to TypeScript

### DIFF
--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -2,10 +2,28 @@ declare const require: any;
 declare module 'fs' {
   export function existsSync(path: string): boolean;
   export function readFileSync(path: string, options?: any): string;
+  export function readFile(path: string, callback: (err: any, data: string) => void): void;
   export function writeFileSync(path: string, data: string): void;
+}
+declare module 'url' {
+  export function format(urlObject: any): string;
 }
 declare module 'electron' {
   export const app: any;
+  export class BrowserWindow {
+    constructor(options?: any);
+    loadURL(url: string): void;
+    show(): void;
+    once(event: string, listener: (...args: any[]) => void): void;
+    on(event: string, listener: (...args: any[]) => void): void;
+    minimize(): void;
+    toggleDevTools(): void;
+  }
+  export const BrowserWindow: any;
+  export const Menu: any;
+  export interface IpcMainEvent {}
+  export const ipcMain: any;
+  export const dialog: any;
   export const remote: any;
 }
 declare module 'debug' {
@@ -28,4 +46,8 @@ declare module 'whois' {
 declare module 'app/js/common/parseRawData' {
   const parseRawData: any;
   export default parseRawData;
+}
+
+interface String {
+  format(...args: any[]): string;
 }


### PR DESCRIPTION
## Summary
- port `app/js/main.js` to TypeScript
- define type interfaces for settings used in the main process
- update local typings for Electron modules and String helpers

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68586b5bd0f48325b3dd7d2c9a95c07c