### PR TITLE
Convert appsettings to TypeScript

### DIFF
--- a/app/html/tabs/he.html
+++ b/app/html/tabs/he.html
@@ -28,6 +28,6 @@
     <p><strong>Q: What is the monitor?</strong></p>
     <p>The monitor tab allows you to bulk monitor your domain choices whether is some expriring domain or to keep an eye on prospecting domains</p>
     <p><strong>Q: Can i load custom configurations?</strong></p>
-    <p>Yes custom configurations can be loaded via appsettings.js file</p>
+    <p>Yes custom configurations can be loaded via appsettings.ts file</p>
   </div>
 </section>

--- a/app/js/appsettings.ts
+++ b/app/js/appsettings.ts
@@ -1,9 +1,9 @@
 // jshint esversion: 8
 
-const path = require('path');
+import * as path from 'path';
 
 // Default application settings
-module.exports = {
+const appSettings = {
   'settings': {
     'app.window': { // Application window
       'frame': false, // Is basic frame shown (default: false)
@@ -145,3 +145,5 @@ module.exports = {
     }
   }
 };
+
+export default appSettings;

--- a/app/js/common/settings.ts
+++ b/app/js/common/settings.ts
@@ -29,9 +29,9 @@ export interface Settings {
   [key: string]: any;
 }
 
-const settingsModule: { settings: Settings } = fs.existsSync('./appSettings') ?
-  require('./appSettings') :
-  require('../appSettings');
+const settingsModule: { settings: Settings } = fs.existsSync('./appsettings') ?
+  require('./appsettings') :
+  require('../appsettings');
 let { settings } = settingsModule;
 export { settings };
 export default settings;

--- a/readme.md
+++ b/readme.md
@@ -161,7 +161,7 @@ Errors during bulk lookups are pretty common due to sheer request volume, this m
 
 ## Settings
 
-Whoisdigger uses a settings file that rules how the application behaves overall, this can be achieved by either using the preload settings file or change the `appSettings.js` inside `js`.
+Whoisdigger uses a settings file that rules how the application behaves overall, this can be achieved by either using the preload settings file or change the `appsettings.ts` inside `js`.
 
 ### Assumptions
 


### PR DESCRIPTION
## Summary
- rename `app/js/appsettings.js` to TypeScript
- export default object
- update settings loader
- refresh docs mentioning the file

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68586e4a26ac83259a67d146c1b0b3e9