### PR TITLE
Fix cross-platform postbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "package-linux": "npm run build && npm run postbuild && electron-packager . whoisdigger --overwrite --asar --platform=linux --arch=x64 --icon=app/icons/app.png --prune=true --out=release_builds",
     "package-all": "npm run build && npm run postbuild && electron-packager . --all --overwrite --asar --icon=app/icons/app.png --prune=true --out=release_builds",
     "build": "tsc",
-    "postbuild": "cp -r app/{html,css,fonts,icons} dist/app/",
+    "postbuild": "node postbuild.js",
     "watch": "tsc -w",
     "lint": "eslint app/ts/common/conversions.ts test/**/*.ts",
     "test": "jest"

--- a/postbuild.js
+++ b/postbuild.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+
+const folders = ['html', 'css', 'fonts', 'icons'];
+const appDir = path.join(__dirname, 'app');
+const distDir = path.join(__dirname, 'dist', 'app');
+
+for (const folder of folders) {
+  const src = path.join(appDir, folder);
+  const dest = path.join(distDir, folder);
+  fs.mkdirSync(dest, { recursive: true });
+  fs.cpSync(src, dest, { recursive: true });
+}


### PR DESCRIPTION
## Summary
- copy resources with Node's fs instead of `cp`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685881380fa88325a34a5b4b37a3d689