### PR TITLE
Fix getRandomInt range handling

### DIFF
--- a/app/ts/common/whoiswrapper.ts
+++ b/app/ts/common/whoiswrapper.ts
@@ -393,7 +393,10 @@ function getWhoisParameters(parameter: string): number | undefined {
     max (integer) - Maximum value
  */
 function getRandomInt(min: number, max: number): number {
-  return Math.floor(Math.random() * parseInt(String(max)) + parseInt(String(min)));
+  min = Math.floor(min);
+  max = Math.floor(max);
+  if (min > max) [min, max] = [max, min];
+  return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
 /*


### PR DESCRIPTION
## Summary
- fix `getRandomInt` so it always returns a value inside `[min, max]`
- keep usage in `whoiswrapper` the same

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685885f047848325bb271b70c86d6448