### PR TITLE
Fix psl lookup handling

### DIFF
--- a/app/ts/common/dnsLookup.ts
+++ b/app/ts/common/dnsLookup.ts
@@ -42,7 +42,10 @@ export async function nsLookup(host: string): Promise<string[] | 'error'> {
   } = settings;
 
   host = conversion.enabled ? convertDomain(host) : host;
-  host = general.psl ? psl.get(host).replace(/((\*\.)*)/g, '') : host;
+  if (general.psl) {
+    const clean = psl.get(host);
+    host = clean ? clean.replace(/((\*\.)*)/g, '') : host;
+  }
 
   try {
     result = await dnsResolvePromise(host, 'NS');
@@ -72,7 +75,10 @@ export async function hasNsServers(host: string): Promise<boolean> {
   } = settings;
 
   host = conversion.enabled ? convertDomain(host) : host;
-  host = general.psl ? psl.get(host).replace(/((\*\.)*)/g, '') : host;
+  if (general.psl) {
+    const clean = psl.get(host);
+    host = clean ? clean.replace(/((\*\.)*)/g, '') : host;
+  }
 
   try {
     result = await dnsResolvePromise(host, 'NS');

--- a/test/dnsLookup.test.ts
+++ b/test/dnsLookup.test.ts
@@ -1,0 +1,31 @@
+jest.mock('electron', () => ({
+  app: undefined,
+  remote: { app: { getPath: jest.fn().mockReturnValue('') } }
+}));
+
+import dns from 'dns';
+import { nsLookup, hasNsServers } from '../app/ts/common/dnsLookup';
+
+describe('dnsLookup', () => {
+  let resolveMock: jest.SpyInstance;
+
+  beforeAll(() => {
+    resolveMock = jest.spyOn(dns, 'resolve').mockImplementation((_: string, __: string, cb: Function) => {
+      cb(new Error('ENOTFOUND'));
+    });
+  });
+
+  afterAll(() => {
+    resolveMock.mockRestore();
+  });
+
+  test('nsLookup handles invalid domain', async () => {
+    const result = await nsLookup('invalid_domain');
+    expect(result).toBe('error');
+  });
+
+  test('hasNsServers handles invalid domain', async () => {
+    const result = await hasNsServers('invalid_domain');
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- avoid calling `replace` on a null psl result
- test dns lookup helpers with invalid domains

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68588605cefc8325a5dafa2b7fcb76de