### PR TITLE
Trim compiled time strings

### DIFF
--- a/app/ts/common/conversions.ts
+++ b/app/ts/common/conversions.ts
@@ -88,7 +88,7 @@ function compileString(parsedTime: ParsedTime): string {
     if (parsedTime[parcel] > 0)
       compiledString += `${parsedTime[parcel]} ${suffixes[parcel]} `;
 
-  return compiledString;
+  return compiledString.trim();
 }
 
 /*

--- a/test/conversions.test.ts
+++ b/test/conversions.test.ts
@@ -6,7 +6,7 @@ describe('conversions', () => {
   });
 
   test('msToHumanTime converts milliseconds', () => {
-    expect(msToHumanTime(62000)).toBe('1 m 2 s ');
+    expect(msToHumanTime(62000)).toBe('1 m 2 s');
   });
 
   test('getDate parses valid dates', () => {


### PR DESCRIPTION
## Summary
- ensure compileString trims whitespace
- update msToHumanTime unit test for trimmed output

## Testing
- `npm install --silent`
- `./node_modules/.bin/jest --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_685886507f80832597986d8c5073e38a