### PR TITLE
Fix renderer script paths

### DIFF
--- a/app/html/mainPanel.html
+++ b/app/html/mainPanel.html
@@ -20,7 +20,7 @@
   <link href="../css/style.css" rel="stylesheet">
   <link href="../css/tables.css" rel="stylesheet">
   <!--<link href="../css/fontawesome/all.min.css" rel="stylesheet">-->
-  <script defer src="../js/common/fontawesome/all.min.js"></script>
+  <script defer src="../ts/common/fontawesome/all.min.js"></script>
 
   <script>
     window.$ = window.jQuery = require('jquery');
@@ -113,8 +113,10 @@
 
 </body>
 <footer>
-  <script src="../js/renderer/loadContents.js"></script>
-  <script defer src="../js/renderer.js"></script>
+  <script src="../ts/renderer/loadcontents.js"></script>
+  <script defer>
+    require('../ts/renderer.js');
+  </script>
   <!--<script defer src="../js/renderer/singlewhois.js"></script>-->
 </footer>
 


### PR DESCRIPTION
## Summary
- reference TS assets instead of nonexistent JS ones
- load the renderer using `require` so CommonJS modules work

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685886a0dc54832599d357a7627bb11f