### PR TITLE
Fix property name casing in file input

### DIFF
--- a/app/ts/renderer/bw/fileinput.ts
+++ b/app/ts/renderer/bw/fileinput.ts
@@ -44,13 +44,13 @@ ipcRenderer.on('bw:fileinput.confirmation', function(event, filePath = null, isD
       $('#bwFileinputloading').removeClass('is-hidden');
       bwFileStats = fs.statSync(filePath);
       bwFileStats['filename'] = filePath.replace(/^.*[\\\/]/, '');
-      bwFileStats['humansize'] = conversions.byteToHumanFileSize(bwFileStats['size'], misc.usestandardsize);
+      bwFileStats['humansize'] = conversions.byteToHumanFileSize(bwFileStats['size'], misc.useStandardSize);
       $('#bwFileSpanInfo').text('Loading file contents...');
       bwFileContents = fs.readFileSync(filePath);
     } else {
       bwFileStats = fs.statSync(filePath[0]);
       bwFileStats['filename'] = filePath[0].replace(/^.*[\\\/]/, '');
-      bwFileStats['humansize'] = conversions.byteToHumanFileSize(bwFileStats['size'], misc.usestandardsize);
+      bwFileStats['humansize'] = conversions.byteToHumanFileSize(bwFileStats['size'], misc.useStandardSize);
       $('#bwFileSpanInfo').text('Loading file contents...');
       bwFileContents = fs.readFileSync(filePath[0]);
     }


### PR DESCRIPTION
## Summary
- fix casing for `useStandardSize` setting

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685886ccbca48325b62817e57bd2f020