### PR TITLE
Fix deprecation warning from punycode module

### DIFF
--- a/app/ts/common/whoiswrapper.ts
+++ b/app/ts/common/whoiswrapper.ts
@@ -2,7 +2,7 @@
 /** global: conversion, general, assumptions, timeout, follow, timeBetween */
 
 import psl from 'psl';
-import puny from 'punycode';
+import puny from 'punycode/';
 import uts46 from 'idna-uts46';
 import whois from 'whois';
 import parseRawData from './parseRawData';

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -44,6 +44,9 @@ declare module 'psl' {
 declare module 'punycode' {
   export function encode(input: string): string;
 }
+declare module 'punycode/' {
+  export function encode(input: string): string;
+}
 declare module 'idna-uts46' {
   const uts46: { toAscii(domain: string, options?: any): string };
   export default uts46;


### PR DESCRIPTION
## Summary
- reference the userland `punycode` package instead of Node's deprecated built‑in module
- add a TypeScript declaration for `punycode/`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685888a4f1388325ab8f6df204123b55