### PR TITLE
Fix estimate when randomization off

### DIFF
--- a/app/ts/renderer/bw/fileinput.ts
+++ b/app/ts/renderer/bw/fileinput.ts
@@ -65,9 +65,13 @@ ipcRenderer.on('bw:fileinput.confirmation', function(event, filePath = null, isD
       $('#bwFileSpanTimebetweenmax').text('/ {0}ms'.format(lookup.randomize.timeBetween.maximum));
       $('#bwFileTdEstimate').text('{0} to {1}'.format(bwFileStats['minestimate'], bwFileStats['maxestimate']));
     } else {
-      bwFileStats['minestimate'] = conversions.msToHumanTime(bwFileStats['linecount'] * lookup.randomize.timeBetween.minimum);
+      bwFileStats['minestimate'] = conversions.msToHumanTime(
+        bwFileStats['linecount'] * settings['lookup.general'].timeBetween
+      );
       $('#bwFileSpanTimebetweenminmax').addClass('is-hidden');
-      $('#bwFileSpanTimebetweenmin').text(lookup.randomize.timeBetween.minimum + 'ms');
+      $('#bwFileSpanTimebetweenmin').text(
+        settings['lookup.general'].timeBetween + 'ms'
+      );
       $('#bwFileTdEstimate').text('> {0}'.format(bwFileStats['minestimate']));
     }
 


### PR DESCRIPTION
## Summary
- calculate min estimate with `lookup.general.timeBetween` when randomization is off
- display the correct value in the file input estimate

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685888fd810483259afcec8e434746d9