### PR TITLE
Fix runtime errors and enable remote

### DIFF
--- a/app/html/mainPanel.html
+++ b/app/html/mainPanel.html
@@ -113,7 +113,9 @@
 
 </body>
 <footer>
-  <script src="../ts/renderer/loadcontents.js"></script>
+  <script>
+    require('../ts/renderer/loadcontents.js');
+  </script>
   <script defer>
     require('../ts/renderer.js');
   </script>

--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -6,13 +6,14 @@ import {
   Menu,
   ipcMain,
   dialog,
-  remote
+  
 } from 'electron';
 import * as url from 'url';
 import debugModule from 'debug';
 import * as fs from 'fs';
 import { loadSettings } from './common/settings';
 import type { Settings as BaseSettings } from './common/settings';
+import { initialize as initializeRemote, enable as enableRemote } from '@electron/remote/main';
 import type { IpcMainEvent } from 'electron';
 
 const debug = debugModule('main');
@@ -79,6 +80,7 @@ let mainWindow: BrowserWindow;
     When application is ready
  */
 app.on('ready', function() {
+  initializeRemote();
   const {
     'custom.configuration': configuration,
     'app.window': appWindow,
@@ -133,6 +135,7 @@ app.on('ready', function() {
       spellcheck: webPreferences.spellcheck // Enable builtin spellchecker
     }
   });
+  enableRemote(mainWindow.webContents);
 
   // mainWindow, Main window URL load
   mainWindow.loadURL(url.format({

--- a/app/ts/renderer.ts
+++ b/app/ts/renderer.ts
@@ -1,7 +1,8 @@
 // jshint esversion: 8, -W104, -W069
 
 // Base path --> assets/html
-import { ipcRenderer, remote, dialog } from 'electron';
+import { ipcRenderer, dialog } from 'electron';
+import * as remote from '@electron/remote';
 import type { IpcRendererEvent } from 'electron';
 import * as fs from 'fs';
 import * as $ from 'jquery';
@@ -11,6 +12,9 @@ import { loadSettings, Settings } from './common/settings';
 
 (window as any).$ = $;
 (window as any).jQuery = $;
+(window as any).ipcRenderer = ipcRenderer;
+(window as any).dialog = dialog;
+(window as any).remote = remote;
 
 let settings: Settings = loadSettings();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
+        "@electron/remote": "^2.1.2",
         "bulma": "^0.9.2",
         "change-case": "^4.1.2",
         "cp": "^0.2.0",
@@ -742,6 +743,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/remote": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@electron/remote/-/remote-2.1.2.tgz",
+      "integrity": "sha512-EPwNx+nhdrTBxyCqXt/pftoQg/ybtWDW3DUWHafejvnB1ZGGfMpv6e15D8KeempocjXe78T7WreyGGb3mlZxdA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "electron": ">= 13.0.0"
       }
     },
     "node_modules/@electron/universal": {
@@ -3683,7 +3693,6 @@
       "version": "36.5.0",
       "resolved": "https://registry.npmjs.org/electron/-/electron-36.5.0.tgz",
       "integrity": "sha512-ouVtHbHDFsRBHPGx9G6RDm4ccPaSCmrrR8tbUGZuqbJhqIClVBkVMz94Spjihag2Zo1eHtYD+KevALrc/94g1g==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3794,7 +3803,6 @@
       "version": "22.15.32",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.32.tgz",
       "integrity": "sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -3804,7 +3812,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/emittery": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "author": "supermarsx",
   "license": "MIT",
   "dependencies": {
+    "@electron/remote": "^2.1.2",
     "bulma": "^0.9.2",
     "change-case": "^4.1.2",
     "cp": "^0.2.0",


### PR DESCRIPTION
## Summary
- load renderer contents via require instead of script tag
- initialize `@electron/remote` in the main process and expose it to renderer
- expose Electron APIs globally in `renderer.ts`
- include `@electron/remote` dependency

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68588820bfa483258d668f7dcb06aeb7