### PR TITLE
Add Node module stubs and update BrowserWindow type

### DIFF
--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -26,6 +26,9 @@ declare module 'electron' {
     on(event: string, listener: (...args: any[]) => void): void;
     minimize(): void;
     toggleDevTools(): void;
+    webContents: {
+      toggleDevTools(): void;
+    };
   }
   export const Menu: any;
   export interface IpcMainEvent {}

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -6,9 +6,34 @@ declare module 'fs' {
   export function writeFileSync(path: string, data: string): void;
   export function createReadStream(path: string): any;
 }
+declare module 'path' {
+  export function join(...paths: string[]): string;
+}
+declare module 'dns' {
+  export function resolve(
+    hostname: string,
+    rrtype: string,
+    callback: (err: any, addresses: any) => void
+  ): void;
+}
 declare module 'readline' {
   export function createInterface(options: any): any;
 }
 declare module 'url' {
   export function format(urlObject: any): string;
 }
+
+interface NodeModule {
+  exports: any;
+  require: any;
+  id: string;
+  filename: string;
+  loaded: boolean;
+  parent: NodeModule | null;
+  children: NodeModule[];
+  paths: string[];
+}
+
+declare var module: NodeModule;
+
+export { NodeModule };


### PR DESCRIPTION
## Summary
- stub out `path` and `dns` modules in our custom Node types
- declare the global `module` variable and `NodeModule` interface
- expose `webContents.toggleDevTools()` on Electron `BrowserWindow`

## Testing
- `npm run build` *(fails: Cannot find module 'path' or 'dns' etc.)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685888edc39c832581e1e878d4d69ea2