### PR TITLE
Fix randomization flags passed to getDomainSetup

### DIFF
--- a/app/ts/main/bw/process.ts
+++ b/app/ts/main/bw/process.ts
@@ -93,9 +93,9 @@ ipcMain.on('bw:lookup', function(event, domains, tlds) {
   for (var domain in domainsPending) {
 
     domainSetup = getDomainSetup({
-      timeBetween: settings['lookup.general'].timeBetween,
-      followDepth: settings['lookup.general'].follow,
-      timeout: settings['lookup.general'].timeout
+      timeBetween: settings['lookup.randomize.timeBetween'].randomize,
+      followDepth: settings['lookup.randomize.follow'].randomize,
+      timeout: settings['lookup.randomize.timeout'].randomize
     });
     domainSetup.timebetween = settings['lookup.general'].useDnsTimeBetweenOverride ? settings['lookup.general'].dnsTimeBetween : domainSetup.timebetween;
     domainSetup.domain = domainsPending[domain];
@@ -199,9 +199,9 @@ ipcMain.on('bw:lookup.continue', function(event) {
   for (var domain = stats.domains.sent; domain < domainsPending.length; domain++) {
 
     domainSetup = getDomainSetup({
-      timeBetween: settings['lookup.general'].timeBetween,
-      followDepth: settings['lookup.general'].follow,
-      timeout: settings['lookup.general'].timeout
+      timeBetween: settings['lookup.randomize.timeBetween'].randomize,
+      followDepth: settings['lookup.randomize.follow'].randomize,
+      timeout: settings['lookup.randomize.timeout'].randomize
     });
     domainSetup.timebetween = settings['lookup.general'].useDnsTimeBetweenOverride ? settings['lookup.general'].dnsTimeBetween : domainSetup.timebetween;
     domainSetup.domain = domainsPending[domain];


### PR DESCRIPTION
## Summary
- pass correct boolean flags into `getDomainSetup`
- keep domain setup logic identical for resume path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68588921fb04832594252a3a83fddc9c