### PR TITLE
Fix line helper newline handling

### DIFF
--- a/app/ts/common/lineHelper.ts
+++ b/app/ts/common/lineHelper.ts
@@ -9,8 +9,11 @@
  */
 export function lineCount(text: string, newLineChar = '\n'): number { // '\n' unix; '\r' macos; '\r\n' windows
   let lines = 0;
-  for (let char = 0; char < text.length; char++) {
-    if (text[char] === newLineChar) lines++;
+  for (let char = 0; char <= text.length - newLineChar.length; char++) {
+    if (text.substr(char, newLineChar.length) === newLineChar) {
+      lines++;
+      char += newLineChar.length - 1;
+    }
   }
 
   return lines;
@@ -26,7 +29,7 @@ export function lineCount(text: string, newLineChar = '\n'): number { // '\n' un
  */
 export function fileReadLines(filePath: string, lines = 2, startLine = 0): Promise<string[]> {
   return new Promise((resolve, reject) => {
-    let lineCounter = startLine;
+    let lineCounter = 0;
     const linesRead: string[] = [];
     const readline = require('readline');
     const fs = require('fs');
@@ -35,9 +38,14 @@ export function fileReadLines(filePath: string, lines = 2, startLine = 0): Promi
     });
 
     lineReader.on('line', (line: string) => {
+      if (lineCounter >= startLine && linesRead.length < lines) {
+        linesRead.push(line);
+        if (linesRead.length >= lines) {
+          lineReader.close();
+          return;
+        }
+      }
       lineCounter++;
-      linesRead.push(line);
-      if (lineCounter === lines) lineReader.close();
     });
 
     lineReader.on('close', () => {

--- a/test/lineHelper.test.ts
+++ b/test/lineHelper.test.ts
@@ -1,0 +1,18 @@
+import fs from 'fs';
+import path from 'path';
+import { lineCount, fileReadLines } from '../app/ts/common/lineHelper';
+
+describe('lineHelper', () => {
+  test('lineCount handles Windows newline sequences', () => {
+    const text = 'a\r\nb\r\nc\r\n';
+    expect(lineCount(text, '\r\n')).toBe(3);
+  });
+
+  test('fileReadLines respects startLine parameter', async () => {
+    const tmpPath = path.join(__dirname, 'tmpfile.txt');
+    fs.writeFileSync(tmpPath, 'first\nsecond\nthird\nfourth\n');
+    const result = await fileReadLines(tmpPath, 2, 1);
+    expect(result).toEqual(['second', 'third']);
+    fs.unlinkSync(tmpPath);
+  });
+});


### PR DESCRIPTION
## Summary
- improve `lineCount` to support multi-character line breaks
- correct `fileReadLines` counting logic
- add tests for Windows line endings and skipping lines

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68588931608c83259e77dcdd157d2273