### PR TITLE
Fix TypeScript build by adding remote module declarations

### DIFF
--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -104,3 +104,16 @@ declare global {
     jQuery: any;
   }
 }
+
+declare module '@electron/remote' {
+  export const app: any;
+  export const dialog: any;
+  export const BrowserWindow: any;
+  export function getCurrentWindow(): any;
+  export function getCurrentWebContents(): any;
+}
+
+declare module '@electron/remote/main' {
+  export function initialize(): void;
+  export function enable(webContents: any): void;
+}


### PR DESCRIPTION
## Summary
- add declaration stubs for `@electron/remote` and `@electron/remote/main`

## Testing
- `npx tsc --noEmit`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68588a7b44488325843dd280de6546b8