### PR TITLE
Fix remote module runtime error

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,16 @@ npm start
 ```
 which will compile the source to `dist` and launch the application.
 
+### Troubleshooting
+
+If Electron fails to start with an error similar to:
+
+```
+Error: Cannot find module '@electron/remote/main'
+```
+
+your dependencies are missing. Run `npm install` in the project root and try again.
+
 ### Debug
 
 Windows Powershell


### PR DESCRIPTION
## Summary
- add a troubleshooting section about `@electron/remote`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68588bbea3e88325ad0cc84fab9a9a4e