### PR TITLE
Fix DNS availability logic

### DIFF
--- a/app/ts/common/dnsLookup.ts
+++ b/app/ts/common/dnsLookup.ts
@@ -101,12 +101,23 @@ export async function hasNsServers(host: string): Promise<boolean> {
   isDomainAvailable
     Check if a domain is available
   .parameters
-    data (string) - Domain lookup response
+    data (boolean | string) - Domain lookup response. 'error' indicates DNS resolution failure
   .returns
-    data (string) - Return 'available' if function returned true, false any other
+    result (string) - Availability status
  */
-export function isDomainAvailable(data: any): string {
-  var result = (data === true) ? 'unavailable' : 'available';
+export function isDomainAvailable(data: boolean | string): string {
+  var result: string;
+
+  if (data === true) {
+    result = 'unavailable';
+  } else if (data === false) {
+    result = 'available';
+  } else if (data === 'error') {
+    result = 'error';
+  } else {
+    result = 'error';
+  }
+
   debug(`Checked for availability from data ${data} with result: ${result}`);
   return result;
 }

--- a/test/dnsLookup.test.ts
+++ b/test/dnsLookup.test.ts
@@ -4,7 +4,7 @@ jest.mock('electron', () => ({
 }));
 
 import dns from 'dns';
-import { nsLookup, hasNsServers } from '../app/ts/common/dnsLookup';
+import { nsLookup, hasNsServers, isDomainAvailable } from '../app/ts/common/dnsLookup';
 
 describe('dnsLookup', () => {
   let resolveMock: jest.SpyInstance;
@@ -27,5 +27,21 @@ describe('dnsLookup', () => {
   test('hasNsServers handles invalid domain', async () => {
     const result = await hasNsServers('invalid_domain');
     expect(result).toBe(false);
+  });
+
+  test('isDomainAvailable returns unavailable for true', () => {
+    expect(isDomainAvailable(true)).toBe('unavailable');
+  });
+
+  test('isDomainAvailable returns available for false', () => {
+    expect(isDomainAvailable(false)).toBe('available');
+  });
+
+  test("isDomainAvailable returns 'error' on error string", () => {
+    expect(isDomainAvailable('error')).toBe('error');
+  });
+
+  test('isDomainAvailable treats unknown strings as error', () => {
+    expect(isDomainAvailable('unknown')).toBe('error');
   });
 });


### PR DESCRIPTION
## Summary
- handle unexpected strings in `isDomainAvailable`
- test dns availability helper

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68588c41f63483259c005a13e7b88cb2