### PR TITLE
Fix psl null handling

### DIFF
--- a/app/ts/common/whoiswrapper.ts
+++ b/app/ts/common/whoiswrapper.ts
@@ -56,7 +56,10 @@ export async function lookup(domain: string, options = getWhoisOptions()): Promi
 
   try {
     domain = conversion.enabled ? convertDomain(domain) : domain;
-    domain = general.psl ? psl.get(domain).replace(/((\*\.)*)/g, '') : domain;
+    if (general.psl) {
+      const clean = psl.get(domain);
+      domain = clean ? clean.replace(/((\*\.)*)/g, '') : domain;
+    }
 
     debug(`Looking up for ${domain}`);
     domainResults = await lookupPromise(domain, options);

--- a/test/whoiswrapper.test.ts
+++ b/test/whoiswrapper.test.ts
@@ -1,0 +1,28 @@
+jest.mock('electron', () => ({
+  app: undefined,
+  remote: { app: { getPath: jest.fn().mockReturnValue('') } }
+}));
+
+import whois from 'whois';
+import { lookup } from '../app/ts/common/whoiswrapper';
+
+describe('whoiswrapper', () => {
+  let lookupMock: jest.SpyInstance;
+
+  beforeAll(() => {
+    lookupMock = jest
+      .spyOn(whois, 'lookup')
+      .mockImplementation((...args: any[]) => {
+        const cb = args[args.length - 1] as Function;
+        cb(new Error('lookup failed'));
+      });
+  });
+
+  afterAll(() => {
+    lookupMock.mockRestore();
+  });
+
+  test('lookup handles invalid domain', async () => {
+    await expect(lookup('invalid_domain')).resolves.toContain('Whois lookup error');
+  });
+});


### PR DESCRIPTION
## Summary
- avoid calling `.replace` on null for psl-cleaned domains
- add regression test for invalid domain handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68588c56431c8325ad4d62be459b7c76