### PR TITLE
Fix punycode conversion and add test

### DIFF
--- a/app/ts/common/whoiswrapper.ts
+++ b/app/ts/common/whoiswrapper.ts
@@ -2,7 +2,7 @@
 /** global: conversion, general, assumptions, timeout, follow, timeBetween */
 
 import psl from 'psl';
-import puny from 'punycode/';
+import puny from 'punycode';
 import uts46 from 'idna-uts46';
 import whois from 'whois';
 import parseRawData from './parseRawData';
@@ -312,7 +312,7 @@ export function convertDomain(domain: string, mode?: string): string {
 
   switch (mode) {
     case 'punycode':
-      return puny.encode(domain);
+      return puny.toASCII(domain);
     case 'uts46':
       return uts46.toAscii(domain);
     case 'uts46-transitional':

--- a/test/convertDomain.test.ts
+++ b/test/convertDomain.test.ts
@@ -1,0 +1,13 @@
+jest.mock('electron', () => ({
+  app: undefined,
+  remote: { app: { getPath: jest.fn().mockReturnValue('') } }
+}));
+
+import { convertDomain } from '../app/ts/common/whoiswrapper';
+
+describe('convertDomain', () => {
+  test('punycode conversion handles unicode domains', () => {
+    const result = convertDomain('t\u00E4st.de', 'punycode');
+    expect(result).toBe('xn--tst-qla.de');
+  });
+});


### PR DESCRIPTION
## Summary
- fix domain conversion to use `punycode.toASCII`
- test unicode domain conversion to punycode

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68588cc809b88325aad408c55d9ebfd0