### PR TITLE
Improve settings load resilience

### DIFF
--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -67,8 +67,13 @@ export function load(): Settings {
 
   if (configuration.load) {
     try {
-      settings = JSON.parse(fs.readFileSync(filePath, 'utf8')) as Settings;
-      debug(`Loaded custom configuration at ${filePath}`);
+      const raw = fs.readFileSync(filePath, 'utf8');
+      try {
+        settings = JSON.parse(raw) as Settings;
+        debug(`Loaded custom configuration at ${filePath}`);
+      } catch (parseError) {
+        debug(`Failed to parse custom configuration with error: ${parseError}`);
+      }
     } catch (e) {
       debug(`Failed to load custom configuration with error: ${e}`);
     }

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import path from 'path';
+
+const mockGetPath = jest.fn();
+
+jest.mock('electron', () => ({
+  app: undefined,
+  remote: { app: { getPath: mockGetPath } }
+}));
+
+import { loadSettings, settings } from '../app/ts/common/settings';
+
+
+describe('settings load', () => {
+  test('falls back to defaults when config is corrupt', () => {
+    const tmpDir = fs.mkdtempSync(path.join(__dirname, 'config')); 
+    mockGetPath.mockReturnValue(tmpDir);
+
+    const original = JSON.parse(JSON.stringify(settings));
+    const configName = '/bad.json';
+    settings['custom.configuration'].filepath = configName;
+    fs.writeFileSync(path.join(tmpDir, 'bad.json'), '{ invalid json');
+
+    const loaded = loadSettings();
+
+    original['custom.configuration'].filepath = configName;
+    expect(loaded).toEqual(original);
+
+    fs.unlinkSync(path.join(tmpDir, 'bad.json'));
+    fs.rmdirSync(tmpDir, { recursive: true });
+  });
+});


### PR DESCRIPTION
## Summary
- handle corrupt configuration files when loading settings
- test fallback to default settings when configuration is invalid

## Testing
- `npm install`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68588c7ebccc832580c9277c9c5d5d13