### PR TITLE
Fix toJSON return

### DIFF
--- a/app/ts/common/whoiswrapper.ts
+++ b/app/ts/common/whoiswrapper.ts
@@ -85,11 +85,10 @@ export function toJSON(resultsText: any): any {
       data.data = parseRawData(data.data);
       return data;
     });
+    return resultsText;
   } else {
     return parseRawData(preStringStrip(resultsText));
   }
-
-  return undefined;
 }
 
 /*

--- a/test/whoiswrapper.test.ts
+++ b/test/whoiswrapper.test.ts
@@ -4,7 +4,7 @@ jest.mock('electron', () => ({
 }));
 
 import whois from 'whois';
-import { lookup } from '../app/ts/common/whoiswrapper';
+import { lookup, toJSON } from '../app/ts/common/whoiswrapper';
 
 describe('whoiswrapper', () => {
   let lookupMock: jest.SpyInstance;
@@ -24,5 +24,16 @@ describe('whoiswrapper', () => {
 
   test('lookup handles invalid domain', async () => {
     await expect(lookup('invalid_domain')).resolves.toContain('Whois lookup error');
+  });
+
+  test('toJSON parses object arrays', () => {
+    const input = [{ data: 'Domain Name: example.com\nRegistrar: Example' }];
+    const result = toJSON(input);
+    expect(result).toEqual([{ data: { domainName: 'example.com', registrar: 'Example' } }]);
+  });
+
+  test('toJSON returns "timeout" for timeout strings', () => {
+    const result = toJSON('lookup: timeout');
+    expect(result).toBe('timeout');
   });
 });


### PR DESCRIPTION
## Summary
- ensure `toJSON` always returns parsed data or timeout
- test that object inputs are returned and timeout string works

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68588dcbe78c83259d7abd563657df69