### PR TITLE
fix postbuild for older Node

### DIFF
--- a/postbuild.js
+++ b/postbuild.js
@@ -5,9 +5,22 @@ const folders = ['html', 'css', 'fonts', 'icons'];
 const appDir = path.join(__dirname, 'app');
 const distDir = path.join(__dirname, 'dist', 'app');
 
+function copyRecursiveSync(src, dest) {
+  const stat = fs.statSync(src);
+  if (stat.isDirectory()) {
+    fs.mkdirSync(dest, { recursive: true });
+    for (const entry of fs.readdirSync(src)) {
+      const srcPath = path.join(src, entry);
+      const destPath = path.join(dest, entry);
+      copyRecursiveSync(srcPath, destPath);
+    }
+  } else {
+    fs.copyFileSync(src, dest);
+  }
+}
+
 for (const folder of folders) {
   const src = path.join(appDir, folder);
   const dest = path.join(distDir, folder);
-  fs.mkdirSync(dest, { recursive: true });
-  fs.cpSync(src, dest, { recursive: true });
+  copyRecursiveSync(src, dest);
 }


### PR DESCRIPTION
## Summary
- implement recursive copy without `fs.cpSync`
- keep postbuild assets copying compatible with Node <16

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68588dcf8f348325831c1e7b61376537