### PR TITLE
Improve file IO error handling

### DIFF
--- a/app/ts/common/lineHelper.ts
+++ b/app/ts/common/lineHelper.ts
@@ -33,9 +33,15 @@ export function fileReadLines(filePath: string, lines = 2, startLine = 0): Promi
     const linesRead: string[] = [];
     const readline = require('readline');
     const fs = require('fs');
-    const lineReader = readline.createInterface({
-      input: fs.createReadStream(filePath),
-    });
+    let lineReader;
+    try {
+      lineReader = readline.createInterface({
+        input: fs.createReadStream(filePath),
+      });
+    } catch (err: any) {
+      reject(err);
+      return;
+    }
 
     lineReader.on('line', (line: string) => {
       if (lineCounter >= startLine && linesRead.length < lines) {

--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -2,7 +2,7 @@
 
 import * as fs from 'fs';
 import * as electron from 'electron';
-const { app, remote } = electron;
+const { app, remote, dialog } = electron;
 import debugModule from 'debug';
 const debug = debugModule('common.settings');
 
@@ -93,7 +93,8 @@ export function save(settings: Settings): string | Error | undefined {
       fs.writeFileSync(filePath, JSON.stringify(settings));
       debug(`Saved custom configuration at ${filePath}`);
       return 'SAVED';
-    } catch (e) {
+    } catch (e: any) {
+      dialog.showErrorBox('Save Error', e.message);
       debug(`Failed to save custom configuration with error: ${e}`);
       return e as Error;
     }

--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -91,9 +91,13 @@ app.on('ready', function() {
   // Custom application settings startup
   if (fs.existsSync(app.getPath('userData') + configuration.filepath)) {
     debug("Reading persistent configurations");
-    settings = JSON.parse(
-      fs.readFileSync(app.getPath('userData') + configuration.filepath, 'utf8')
-    ) as MainSettings;
+    try {
+      settings = JSON.parse(
+        fs.readFileSync(app.getPath('userData') + configuration.filepath, 'utf8')
+      ) as MainSettings;
+    } catch (err: any) {
+      dialog.showErrorBox('Configuration Error', err.message);
+    }
   } else {
     debug("Using default configurations");
   }

--- a/app/ts/main/bw/export.ts
+++ b/app/ts/main/bw/export.ts
@@ -163,6 +163,7 @@ ipcMain.on('bw:export', function(event, results, options) {
       contentsCompile = contentsHeader + contentsExport;
       fs.writeFile(filePath, contentsCompile, function(err) {
         if (err) {
+          dialog.showErrorBox('Export Error', err.message);
           return debug(err);
         }
         debug("File was saved, {0}".format(filePath));
@@ -179,6 +180,7 @@ ipcMain.on('bw:export', function(event, results, options) {
           }).then(function(content) {
             fs.writeFile(filePath + zip, content, function(err) {
               if (err) {
+                dialog.showErrorBox('Export Error', err.message);
                 return debug(err);
               }
             });
@@ -192,6 +194,7 @@ ipcMain.on('bw:export', function(event, results, options) {
           }).then(function(content) {
             fs.writeFile(filePath + zip, content, function(err) {
               if (err) {
+                dialog.showErrorBox('Export Error', err.message);
                 return debug(err);
               }
             });

--- a/app/ts/renderer.ts
+++ b/app/ts/renderer.ts
@@ -42,7 +42,13 @@ $(document).ready(function() {
   // Load custom configuration at startup
   if (fs.existsSync(remote.app.getPath('userData') + configuration.filepath)) {
     sendDebug('Reading persistent configurations');
-    settings = JSON.parse(fs.readFileSync(remote.app.getPath('userData') + configuration.filepath, 'utf8')) as Settings;
+    try {
+      settings = JSON.parse(
+        fs.readFileSync(remote.app.getPath('userData') + configuration.filepath, 'utf8')
+      ) as Settings;
+    } catch (err: any) {
+      dialog.showErrorBox('Configuration Error', err.message);
+    }
   } else {
     sendDebug('Using default configurations');
   }

--- a/app/ts/renderer/bw/fileinput.ts
+++ b/app/ts/renderer/bw/fileinput.ts
@@ -6,7 +6,8 @@ const whois = require('../../common/whoiswrapper'),
   fs = require('fs');
 
 const {
-  ipcRenderer
+  ipcRenderer,
+  dialog
 } = require('electron'), {
   tableReset
 } = require('./auxiliary');
@@ -42,17 +43,31 @@ ipcRenderer.on('bw:fileinput.confirmation', function(event, filePath = null, isD
     if (isDragDrop === true) {
       $('#bwEntry').addClass('is-hidden');
       $('#bwFileinputloading').removeClass('is-hidden');
-      bwFileStats = fs.statSync(filePath);
-      bwFileStats['filename'] = filePath.replace(/^.*[\\\/]/, '');
-      bwFileStats['humansize'] = conversions.byteToHumanFileSize(bwFileStats['size'], misc.useStandardSize);
-      $('#bwFileSpanInfo').text('Loading file contents...');
-      bwFileContents = fs.readFileSync(filePath);
+      try {
+        bwFileStats = fs.statSync(filePath);
+        bwFileStats['filename'] = filePath.replace(/^.*[\\\/]/, '');
+        bwFileStats['humansize'] = conversions.byteToHumanFileSize(bwFileStats['size'], misc.useStandardSize);
+        $('#bwFileSpanInfo').text('Loading file contents...');
+        bwFileContents = fs.readFileSync(filePath);
+      } catch (err: any) {
+        dialog.showErrorBox('File Error', err.message);
+        $('#bwFileinputloading').addClass('is-hidden');
+        $('#bwEntry').removeClass('is-hidden');
+        return;
+      }
     } else {
-      bwFileStats = fs.statSync(filePath[0]);
-      bwFileStats['filename'] = filePath[0].replace(/^.*[\\\/]/, '');
-      bwFileStats['humansize'] = conversions.byteToHumanFileSize(bwFileStats['size'], misc.useStandardSize);
-      $('#bwFileSpanInfo').text('Loading file contents...');
-      bwFileContents = fs.readFileSync(filePath[0]);
+      try {
+        bwFileStats = fs.statSync(filePath[0]);
+        bwFileStats['filename'] = filePath[0].replace(/^.*[\\\/]/, '');
+        bwFileStats['humansize'] = conversions.byteToHumanFileSize(bwFileStats['size'], misc.useStandardSize);
+        $('#bwFileSpanInfo').text('Loading file contents...');
+        bwFileContents = fs.readFileSync(filePath[0]);
+      } catch (err: any) {
+        dialog.showErrorBox('File Error', err.message);
+        $('#bwFileinputloading').addClass('is-hidden');
+        $('#bwEntry').removeClass('is-hidden');
+        return;
+      }
     }
     $('#bwFileSpanInfo').text('Getting line count...');
     bwFileStats['linecount'] = bwFileContents.toString().split('\n').length;

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -9,6 +9,7 @@ const whois = require('../../common/whoiswrapper'),
 
 const {
   ipcRenderer
+  , dialog
 } = require('electron');
 
 require('../../common/stringformat');
@@ -34,21 +35,35 @@ ipcRenderer.on('bwa:fileinput.confirmation', function(event, filePath = null, is
     if (isDragDrop === true) {
       $('#bwaEntry').addClass('is-hidden');
       $('#bwaFileinputloading').removeClass('is-hidden');
-      bwaFileStats = fs.statSync(filePath);
-      bwaFileStats['filename'] = filePath.replace(/^.*[\\\/]/, '');
-      bwaFileStats['humansize'] = conversions.byteToHumanFileSize(bwaFileStats['size'], settings['lookup.misc'].useStandardSize);
-      $('#bwaFileSpanInfo').text('Loading file contents...');
-      bwaFileContents = Papa.parse(fs.readFileSync(filePath).toString(), {
-        header: true
-      });
+      try {
+        bwaFileStats = fs.statSync(filePath);
+        bwaFileStats['filename'] = filePath.replace(/^.*[\\\/]/, '');
+        bwaFileStats['humansize'] = conversions.byteToHumanFileSize(bwaFileStats['size'], settings['lookup.misc'].useStandardSize);
+        $('#bwaFileSpanInfo').text('Loading file contents...');
+        bwaFileContents = Papa.parse(fs.readFileSync(filePath).toString(), {
+          header: true
+        });
+      } catch (err: any) {
+        dialog.showErrorBox('File Error', err.message);
+        $('#bwaFileinputloading').addClass('is-hidden');
+        $('#bwaEntry').removeClass('is-hidden');
+        return;
+      }
     } else {
-      bwaFileStats = fs.statSync(filePath[0]);
-      bwaFileStats['filename'] = filePath[0].replace(/^.*[\\\/]/, '');
-      bwaFileStats['humansize'] = conversions.byteToHumanFileSize(bwaFileStats['size'], settings['lookup.misc'].useStandardSize);
-      $('#bwaFileSpanInfo').text('Loading file contents...');
-      bwaFileContents = Papa.parse(fs.readFileSync(filePath[0]).toString(), {
-        header: true
-      });
+      try {
+        bwaFileStats = fs.statSync(filePath[0]);
+        bwaFileStats['filename'] = filePath[0].replace(/^.*[\\\/]/, '');
+        bwaFileStats['humansize'] = conversions.byteToHumanFileSize(bwaFileStats['size'], settings['lookup.misc'].useStandardSize);
+        $('#bwaFileSpanInfo').text('Loading file contents...');
+        bwaFileContents = Papa.parse(fs.readFileSync(filePath[0]).toString(), {
+          header: true
+        });
+      } catch (err: any) {
+        dialog.showErrorBox('File Error', err.message);
+        $('#bwaFileinputloading').addClass('is-hidden');
+        $('#bwaEntry').removeClass('is-hidden');
+        return;
+      }
     }
     //console.log(bwaFileContents.data[0]);
     $('#bwaFileSpanInfo').text('Getting line count...');

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -1,0 +1,21 @@
+jest.mock('electron', () => ({
+  app: undefined,
+  remote: { app: { getPath: jest.fn().mockReturnValue('/tmp') } },
+  dialog: { showErrorBox: jest.fn() }
+}));
+
+import fs from 'fs';
+import { saveSettings, settings } from '../app/ts/common/settings';
+
+describe('settings', () => {
+  test('saveSettings returns error when write fails', () => {
+    const spy = jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {
+      throw new Error('write failed');
+    });
+
+    const result = saveSettings(settings);
+    expect(result).toBeInstanceOf(Error);
+
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- handle errors on file read/write operations
- report errors to the user via dialogs
- test saveSettings failure case

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68588cfaaed48325915fbdfc8fb8920c