### PR TITLE
Fix runtime asset and remote issues

### DIFF
--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -2,7 +2,14 @@
 
 import * as fs from 'fs';
 import * as electron from 'electron';
-const { app, remote } = electron;
+let remote: typeof import('@electron/remote') | undefined;
+try {
+  // Dynamically require to avoid issues when Electron bindings are unavailable
+  remote = require('@electron/remote');
+} catch {
+  remote = (electron as any).remote;
+}
+const { app } = electron;
 import debugModule from 'debug';
 const debug = debugModule('common.settings');
 
@@ -52,9 +59,10 @@ const isMainProcess = ((): boolean => {
   }
 })();
 
-const filePath = isMainProcess
-  ? app.getPath('userData') + settings['custom.configuration']['filepath']
-  : remote.app.getPath('userData') + settings['custom.configuration']['filepath'];
+const userDataPath = isMainProcess
+  ? app.getPath('userData')
+  : remote?.app?.getPath('userData') ?? '';
+const filePath = userDataPath + settings['custom.configuration']['filepath'];
 
 /*
   load

--- a/postbuild.js
+++ b/postbuild.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const folders = ['html', 'css', 'fonts', 'icons'];
+const folders = ['html', 'css', 'fonts', 'icons', 'ts/common/fontawesome'];
 const appDir = path.join(__dirname, 'app');
 const distDir = path.join(__dirname, 'dist', 'app');
 


### PR DESCRIPTION
## Summary
- copy bundled fontawesome assets during postbuild
- safely load `@electron/remote` in settings helper
- compute user data path with optional remote

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68588d4aa4ac8325905f6ad696973d8e