### PR TITLE
Fix duplicate company parsing

### DIFF
--- a/app/ts/common/whoiswrapper.ts
+++ b/app/ts/common/whoiswrapper.ts
@@ -258,7 +258,6 @@ export function getDomainParameters(domain: string | null, status: string | null
   results.company =
     resultsJSON.registrantOrganization ||
     resultsJSON.registrant ||
-    resultsJSON.registrantOrganization ||
     resultsJSON.adminName ||
     resultsJSON.ownerName ||
     resultsJSON.contact ||


### PR DESCRIPTION
## Summary
- deduplicate `registrantOrganization` in `whoiswrapper`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68588dbd36c883258ce0c16e9175b119