### PR TITLE
Add domain availability tests

### DIFF
--- a/test/convertDomain.test.ts
+++ b/test/convertDomain.test.ts
@@ -10,4 +10,19 @@ describe('convertDomain', () => {
     const result = convertDomain('t\u00E4st.de', 'punycode');
     expect(result).toBe('xn--tst-qla.de');
   });
+
+  test('ascii mode strips non-ASCII characters', () => {
+    const result = convertDomain('t\u00E4st.de', 'ascii');
+    expect(result).toBe('tst.de');
+  });
+
+  test('defaults to uts46 conversion from settings', () => {
+    const result = convertDomain('t\u00E4st.de');
+    expect(result).toBe('xn--tst-qla.de');
+  });
+
+  test('unknown mode returns original domain', () => {
+    const domain = 'example.com';
+    expect(convertDomain(domain, 'unknown')).toBe(domain);
+  });
 });

--- a/test/isDomainAvailable.test.ts
+++ b/test/isDomainAvailable.test.ts
@@ -1,0 +1,27 @@
+jest.mock('electron', () => ({
+  app: undefined,
+  remote: { app: { getPath: jest.fn().mockReturnValue('') } }
+}));
+
+import { isDomainAvailable } from '../app/ts/common/whoiswrapper';
+
+describe('isDomainAvailable', () => {
+  test('detects available domains from no match message', () => {
+    const reply = 'No match for domain "example.com".';
+    expect(isDomainAvailable(reply)).toBe('available');
+  });
+
+  test('detects unavailable domains from whois data', () => {
+    const reply = 'Domain Status:ok\nExpiration Date: 2099-01-01';
+    expect(isDomainAvailable(reply)).toBe('unavailable');
+  });
+
+  test('handles rate limit messages', () => {
+    const reply = 'Your connection limit exceeded.';
+    expect(isDomainAvailable(reply)).toBe('error:ratelimiting');
+  });
+
+  test('returns error for empty replies', () => {
+    expect(isDomainAvailable('')).toBe('error:nocontent');
+  });
+});


### PR DESCRIPTION
## Summary
- expand convertDomain tests for more modes
- add isDomainAvailable test cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68588e5573cc832589113fdc5fbb989f