### PR TITLE
Use path.join for settings paths

### DIFF
--- a/app/ts/appsettings.ts
+++ b/app/ts/appsettings.ts
@@ -115,7 +115,7 @@ const appSettings = {
       'dnsFailureUnavailable': true // Assume a domain is unavailable if DNS request fails (default: true)
     },
     'custom.configuration': { // Application custom configurations
-      'filepath': '\\appconfig.js', // Custom configuration filename on app directory (default: appconfig.js) || Non functional
+      'filepath': 'appconfig.js', // Custom configuration filename on app directory (default: appconfig.js) || Non functional
       'load': true,  // Load custom configurations
       'save': true // Save custom configurations
     },

--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -1,6 +1,7 @@
 // jshint esversion: 8, -W069
 
 import * as fs from 'fs';
+import * as path from 'path';
 import * as electron from 'electron';
 let remote: typeof import('@electron/remote') | undefined;
 try {
@@ -62,7 +63,12 @@ const isMainProcess = ((): boolean => {
 const userDataPath = isMainProcess
   ? app.getPath('userData')
   : remote?.app?.getPath('userData') ?? '';
-const filePath = userDataPath + settings['custom.configuration']['filepath'];
+const filePath = isMainProcess
+  ? path.join(app.getPath('userData'), settings['custom.configuration'].filepath)
+  : path.join(
+      remote?.app?.getPath('userData') ?? '',
+      settings['custom.configuration'].filepath
+    );
 
 /*
   load

--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -11,6 +11,7 @@ import {
 import * as url from 'url';
 import debugModule from 'debug';
 import * as fs from 'fs';
+import * as path from 'path';
 import { loadSettings } from './common/settings';
 import type { Settings as BaseSettings } from './common/settings';
 import { initialize as initializeRemote, enable as enableRemote } from '@electron/remote/main';
@@ -89,10 +90,11 @@ app.on('ready', function() {
   } = settings;
 
   // Custom application settings startup
-  if (fs.existsSync(app.getPath('userData') + configuration.filepath)) {
+  const configPath = path.join(app.getPath('userData'), configuration.filepath);
+  if (fs.existsSync(configPath)) {
     debug("Reading persistent configurations");
     settings = JSON.parse(
-      fs.readFileSync(app.getPath('userData') + configuration.filepath, 'utf8')
+      fs.readFileSync(configPath, 'utf8')
     ) as MainSettings;
   } else {
     debug("Using default configurations");

--- a/app/ts/renderer.ts
+++ b/app/ts/renderer.ts
@@ -5,6 +5,7 @@ import { ipcRenderer, dialog } from 'electron';
 import * as remote from '@electron/remote';
 import type { IpcRendererEvent } from 'electron';
 import * as fs from 'fs';
+import * as path from 'path';
 import * as $ from 'jquery';
 
 import './renderer/index';
@@ -40,9 +41,15 @@ $(document).ready(function() {
   sendDebug('Document is ready');
 
   // Load custom configuration at startup
-  if (fs.existsSync(remote.app.getPath('userData') + configuration.filepath)) {
+  const configPath = path.join(
+    remote.app.getPath('userData'),
+    configuration.filepath
+  );
+  if (fs.existsSync(configPath)) {
     sendDebug('Reading persistent configurations');
-    settings = JSON.parse(fs.readFileSync(remote.app.getPath('userData') + configuration.filepath, 'utf8')) as Settings;
+    settings = JSON.parse(
+      fs.readFileSync(configPath, 'utf8')
+    ) as Settings;
   } else {
     sendDebug('Using default configurations');
   }

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -17,7 +17,7 @@ describe('settings load', () => {
     mockGetPath.mockReturnValue(tmpDir);
 
     const original = JSON.parse(JSON.stringify(settings));
-    const configName = '/bad.json';
+    const configName = 'bad.json';
     settings['custom.configuration'].filepath = configName;
     fs.writeFileSync(path.join(tmpDir, 'bad.json'), '{ invalid json');
 


### PR DESCRIPTION
## Summary
- calculate config file path via `path.join`
- update test for new path semantics
- adjust app defaults and usage

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68588f6335648325949e67d5a77f190d