### PR TITLE
Fix user data path initialization

### DIFF
--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -59,10 +59,12 @@ const isMainProcess = ((): boolean => {
   }
 })();
 
-const userDataPath = isMainProcess
-  ? app.getPath('userData')
-  : remote?.app?.getPath('userData') ?? '';
-const filePath = userDataPath + settings['custom.configuration']['filepath'];
+
+function getUserDataPath(): string {
+  return isMainProcess
+    ? app.getPath('userData')
+    : remote?.app?.getPath('userData') ?? '';
+}
 
 /*
   load
@@ -75,6 +77,8 @@ export function load(): Settings {
 
   if (configuration.load) {
     try {
+      const filePath =
+        getUserDataPath() + settings['custom.configuration']['filepath'];
       const raw = fs.readFileSync(filePath, 'utf8');
       try {
         settings = JSON.parse(raw) as Settings;
@@ -103,6 +107,8 @@ export function save(settings: Settings): string | Error | undefined {
 
   if (configuration.save) {
     try {
+      const filePath =
+        getUserDataPath() + settings['custom.configuration']['filepath'];
       fs.writeFileSync(filePath, JSON.stringify(settings));
       debug(`Saved custom configuration at ${filePath}`);
       return 'SAVED';


### PR DESCRIPTION
## Summary
- compute userData path lazily in load/save
- use new helper `getUserDataPath`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685890c1ee7c83258121d68f6f33c52c