### PR TITLE
Add resetObj test coverage

### DIFF
--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -71,6 +71,12 @@ const filePath = isMainProcess
       settings['custom.configuration'].filepath
     );
 
+function getUserDataPath(): string {
+  return isMainProcess
+    ? app.getPath('userData')
+    : remote?.app?.getPath('userData') ?? '';
+}
+
 /*
   load
     Loads custom configurations from file or defaults

--- a/test/resetObject.test.ts
+++ b/test/resetObject.test.ts
@@ -1,0 +1,19 @@
+import { resetObj } from '../app/ts/common/resetObject';
+
+describe('resetObj', () => {
+  test('modifying returned object does not mutate original', () => {
+    const original = { a: 1, b: { c: 2 } };
+    const copy = resetObj(original);
+    (copy.b as any).c = 3;
+    expect(original).toEqual({ a: 1, b: { c: 2 } });
+  });
+
+  test('default invocation returns a deep copy of {}', () => {
+    const first = resetObj();
+    expect(first).toEqual({});
+    (first as any).x = 1;
+    const second = resetObj();
+    expect(second).toEqual({});
+    expect(second).not.toBe(first);
+  });
+});


### PR DESCRIPTION
## Summary
- add test for resetObj deep copy behavior
- ensure missing helper in settings.ts to compute user data path

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68589253092483259830700cea5ca387