### PR TITLE
Add basic String.format tests

### DIFF
--- a/test/stringformat.test.ts
+++ b/test/stringformat.test.ts
@@ -1,0 +1,15 @@
+require('../app/ts/common/stringformat');
+
+describe('stringformat', () => {
+  test('replaces numbered placeholders', () => {
+    expect('Hello {0} {1}'.format('a', 'b')).toBe('Hello a b');
+  });
+
+  test('handles repeated placeholders', () => {
+    expect('Repeat {0} {0}'.format('x')).toBe('Repeat x x');
+  });
+
+  test('leaves unused placeholders unchanged', () => {
+    expect('Unused {2} {0}'.format('a')).toBe('Unused {2} a');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest test for String.prototype.format helper

## Testing
- `npm test` *(fails: TS2552 Cannot find name 'getUserDataPath' in settings.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6858925b245c83258410219f906c7ab9