### PR TITLE
Add convertDomain ascii and passthrough tests

### DIFF
--- a/test/convertDomain.test.ts
+++ b/test/convertDomain.test.ts
@@ -4,6 +4,7 @@ jest.mock('electron', () => ({
 }));
 
 import { convertDomain } from '../app/ts/common/whoiswrapper';
+import { settings } from '../app/ts/common/settings';
 
 describe('convertDomain', () => {
   test('punycode conversion handles unicode domains', () => {
@@ -16,6 +17,19 @@ describe('convertDomain', () => {
     expect(result).toBe('tst.de');
   });
 
+  test('ascii algorithm in settings strips characters by default', () => {
+    const original = settings['lookup.conversion'].algorithm;
+    settings['lookup.conversion'].algorithm = 'ascii';
+    const result = convertDomain('t\u00E4st.de');
+    expect(result).toBe('tst.de');
+    settings['lookup.conversion'].algorithm = original;
+  });
+
+  test('explicit uts46 conversion handles unicode domains', () => {
+    const result = convertDomain('t\u00E4st.de', 'uts46');
+    expect(result).toBe('xn--tst-qla.de');
+  });
+
   test('defaults to uts46 conversion from settings', () => {
     const result = convertDomain('t\u00E4st.de');
     expect(result).toBe('xn--tst-qla.de');
@@ -24,5 +38,14 @@ describe('convertDomain', () => {
   test('unknown mode returns original domain', () => {
     const domain = 'example.com';
     expect(convertDomain(domain, 'unknown')).toBe(domain);
+  });
+
+  test('passthrough when algorithm is unknown', () => {
+    const original = settings['lookup.conversion'].algorithm;
+    settings['lookup.conversion'].algorithm = 'unknown';
+    const domain = 'example.com';
+    const result = convertDomain(domain);
+    expect(result).toBe(domain);
+    settings['lookup.conversion'].algorithm = original;
   });
 });


### PR DESCRIPTION
## Summary
- expand test coverage for `convertDomain` with ascii algorithm
- check unknown algorithm passthrough
- verify explicit uts46 conversion

## Testing
- `npm test` *(fails: TS2552 getUserDataPath errors)*

------
https://chatgpt.com/codex/tasks/task_e_6858925f215c83258ecfff6247af8541