### PR TITLE
Add debug logging on nsLookup failure

### DIFF
--- a/app/ts/common/dnsLookup.ts
+++ b/app/ts/common/dnsLookup.ts
@@ -51,6 +51,7 @@ export async function nsLookup(host: string): Promise<string[] | 'error'> {
     result = await dnsResolvePromise(host, 'NS');
   } catch (e) {
     result = 'error';
+    debug(`Lookup failed with error ${e}`);
   }
 
   debug(`Looked up for ${host} with ${result}`);


### PR DESCRIPTION
## Summary
- reference the error in nsLookup catch block to avoid unused variable warnings

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685892b4a3508325b6d8360a86ae02fa