### PR TITLE
Fix HTML entity helper name

### DIFF
--- a/app/ts/common/parseRawData.ts
+++ b/app/ts/common/parseRawData.ts
@@ -4,12 +4,12 @@ import * as changeCase from 'change-case';
 import { XmlEntities } from 'html-entities';
 
 /*
-	stripHTMLEntitites
+       stripHTMLEntities
 		Strips HTML entities from a given string
 	parameters
 		rawData (string) - string to strip HTML entities from
  */
-function stripHTMLEntitites(rawData: string): string {
+function stripHTMLEntities(rawData: string): string {
         const entities = new XmlEntities();
         return entities.decode(rawData);
 }
@@ -34,7 +34,7 @@ export function parseRawData(rawData: string): Record<string, string> {
         const DELIMITER = ':';
         const result: Record<string, string> = {};
 
-	rawData = stripHTMLEntitites(rawData);
+       rawData = stripHTMLEntities(rawData);
 	rawData = filterColonChar(rawData);
         const lines = rawData.split('\n');
 

--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -64,6 +64,10 @@ const isMainProcess = ((): boolean => {
 const userDataPath = isMainProcess
   ? app.getPath('userData')
   : remote?.app?.getPath('userData') ?? '';
+
+function getUserDataPath(): string {
+  return userDataPath;
+}
 const filePath = isMainProcess
   ? path.join(app.getPath('userData'), settings['custom.configuration'].filepath)
   : path.join(


### PR DESCRIPTION
## Summary
- rename `stripHTMLEntitites` to `stripHTMLEntities`
- adjust references and restore missing `getUserDataPath` function

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685892d312388325a6c16071c243ae4c