### PR TITLE
Fix duplicate function definition

### DIFF
--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -75,10 +75,6 @@ const filePath = isMainProcess
       settings['custom.configuration'].filepath
     );
 
-function getUserDataPath(): string {
-  return userDataPath;
-}
-
 /*
   load
     Loads custom configurations from file or defaults


### PR DESCRIPTION
## Summary
- remove duplicate `getUserDataPath` definition from settings module

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685894d5e54483259d9c5518e4086566