### PR TITLE
Fix jQuery initialization to resolve renderer error

### DIFF
--- a/app/ts/renderer.ts
+++ b/app/ts/renderer.ts
@@ -6,7 +6,7 @@ import * as remote from '@electron/remote';
 import type { IpcRendererEvent } from 'electron';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as $ from 'jquery';
+import $ from 'jquery';
 
 import './renderer/index';
 import { loadSettings, Settings } from './common/settings';


### PR DESCRIPTION
## Summary
- fix jQuery import in renderer so `$` is a callable function

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685895d46a7083258f67152c3094e0a3