### PR TITLE
Fix line count substring

### DIFF
--- a/app/ts/common/lineHelper.ts
+++ b/app/ts/common/lineHelper.ts
@@ -10,7 +10,7 @@
 export function lineCount(text: string, newLineChar = '\n'): number { // '\n' unix; '\r' macos; '\r\n' windows
   let lines = 0;
   for (let char = 0; char <= text.length - newLineChar.length; char++) {
-    if (text.substr(char, newLineChar.length) === newLineChar) {
+    if (text.substring(char, char + newLineChar.length) === newLineChar) {
       lines++;
       char += newLineChar.length - 1;
     }


### PR DESCRIPTION
## Summary
- prevent using deprecated `substr` in line helper
- use `substring` for cross-node compatibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68589672a76c832586cd2b94919f3766