### PR TITLE
Refactor DNS lookup to use promises API

### DIFF
--- a/app/ts/common/dnsLookup.ts
+++ b/app/ts/common/dnsLookup.ts
@@ -1,6 +1,6 @@
 // jshint esversion: 8
 
-import dns from 'dns';
+import dns from 'dns/promises';
 import psl from 'psl';
 import debugModule from 'debug';
 import { convertDomain } from './whoiswrapper';
@@ -9,22 +9,6 @@ import { load, Settings } from './settings';
 const debug = debugModule('common.dnsLookup');
 let settings: Settings = load();
 
-/*
-  dnsResolvePromise
-    Promisified dns resolution with argument passthrough
-  .parameters
-    [parameter passthrough]
-  .returns
-    [rejects or resolves the promise]
- */
-const dnsResolvePromise = (host: string, rrtype: string): Promise<any> => {
-  return new Promise((resolve, reject) => {
-    dns.resolve(host, rrtype, (err, data) => {
-      if (err) return reject(err);
-      resolve(data);
-    });
-  });
-};
 
 /*
   nsLookup
@@ -48,7 +32,7 @@ export async function nsLookup(host: string): Promise<string[] | 'error'> {
   }
 
   try {
-    result = await dnsResolvePromise(host, 'NS');
+    result = await dns.resolve(host, 'NS');
   } catch (e) {
     result = 'error';
     debug(`Lookup failed with error ${e}`);
@@ -81,7 +65,7 @@ export async function hasNsServers(host: string): Promise<boolean> {
   }
 
   try {
-    result = await dnsResolvePromise(host, 'NS');
+    result = await dns.resolve(host, 'NS');
     result = Array.isArray(result) ? true : false;
   } catch (e) {
     result = settings['lookup.assumptions'].dnsFailureUnavailable ? true : false;

--- a/test/dnsLookup.test.ts
+++ b/test/dnsLookup.test.ts
@@ -3,16 +3,14 @@ jest.mock('electron', () => ({
   remote: { app: { getPath: jest.fn().mockReturnValue('') } }
 }));
 
-import dns from 'dns';
+import dns from 'dns/promises';
 import { nsLookup, hasNsServers, isDomainAvailable } from '../app/ts/common/dnsLookup';
 
 describe('dnsLookup', () => {
   let resolveMock: jest.SpyInstance;
 
   beforeAll(() => {
-    resolveMock = jest.spyOn(dns, 'resolve').mockImplementation((_: string, __: string, cb: Function) => {
-      cb(new Error('ENOTFOUND'));
-    });
+    resolveMock = jest.spyOn(dns, 'resolve').mockRejectedValue(new Error('ENOTFOUND'));
   });
 
   afterAll(() => {


### PR DESCRIPTION
## Summary
- simplify dns lookups using `dns/promises.resolve`
- adjust error handling
- update tests for new async API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68589660d7d483259cf564d6852c068b