### PR TITLE
Clarify invalid-domain handling

### DIFF
--- a/app/ts/common/whoiswrapper.ts
+++ b/app/ts/common/whoiswrapper.ts
@@ -162,7 +162,7 @@ export function isDomainAvailable(resultsText: string, resultsJSON?: any): strin
     case (resultsText.includes('Domain unknown')):
     case (resultsText.includes('No information available about domain name')):
     case (resultsText.includes('Error.') && resultsText.includes('SaudiNIC')):
-    case (resultsText.includes('is not valid!')): // ???
+    case (resultsText.includes('is not valid!')): // Whois server rejected the domain as syntactically invalid
       return 'available';
 
       /*

--- a/app/ts/common/whoiswrapper/patterns.ts
+++ b/app/ts/common/whoiswrapper/patterns.ts
@@ -141,7 +141,7 @@ var patterns = {
         type: 'includes',
         value: 'SaudiNIC'
       }],
-      20: 'is not valid!' // ???
+      20: 'is not valid!' // returned when the queried domain fails validation
     }
   },
 


### PR DESCRIPTION
## Summary
- explain the `is not valid!` pattern in whoiswrapper
- clarify corresponding comment in patterns list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685898cea7b08325bb48bd7beca9d5c6