### PR TITLE
Fix build errors

### DIFF
--- a/app/ts/main/bw/process.ts
+++ b/app/ts/main/bw/process.ts
@@ -84,7 +84,7 @@ ipcMain.on('bw:lookup', function(event, domains, tlds) {
 
   // Compile domains to process
   for (let tld in input.tlds) {
-    domainsPending = domainsPending.concat(input.domains.map(function(domain) {
+    domainsPending.push(...input.domains.map(function(domain) {
       return domain + tldSeparator + input.tlds[tld];
     }));
   }
@@ -190,7 +190,7 @@ ipcMain.on('bw:lookup.continue', function(event) {
 
   // Compile domains to process
   for (let tld in input.tlds) {
-    domainsPending = domainsPending.concat(input.domains.map(function(domain) {
+    domainsPending.push(...input.domains.map(function(domain) {
       return domain + tldSeparator + input.tlds[tld];
     }));
   }


### PR DESCRIPTION
## Summary
- avoid reassigning `domainsPending` constant when generating lists of pending domains

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685899513c908325b09b37899ee3c5ce