### PR TITLE
Add dark mode

### DIFF
--- a/app/css/dark.css
+++ b/app/css/dark.css
@@ -1,0 +1,43 @@
+html, body {
+  background-color: #121212;
+  color: #e0e0e0;
+}
+
+.has-background-white,
+.has-background-white-bis,
+.has-background-white-ter {
+  background-color: #1e1e1e !important;
+}
+
+.navbar,
+.tabs,
+.box,
+.notification,
+.modal-content,
+.table,
+.hero {
+  background-color: #1e1e1e !important;
+  color: #e0e0e0 !important;
+}
+
+.input,
+.textarea,
+.select select {
+  background-color: #222;
+  color: #e0e0e0;
+  border-color: #444;
+}
+
+.button {
+  background-color: #333;
+  color: #e0e0e0;
+  border-color: #444;
+}
+
+a {
+  color: #81c6ff;
+}
+
+a:hover {
+  color: #a3d3ff;
+}

--- a/app/html/mainPanel.html
+++ b/app/html/mainPanel.html
@@ -18,6 +18,7 @@
   <link href="../css/bulma.min.css" rel="stylesheet">
   <link href="../css/cousine.css" rel="stylesheet">
   <link href="../css/style.css" rel="stylesheet">
+  <link id="dark-theme" href="../css/dark.css" rel="stylesheet" disabled>
   <link href="../css/tables.css" rel="stylesheet">
   <!--<link href="../css/fontawesome/all.min.css" rel="stylesheet">-->
   <script defer src="../ts/common/fontawesome/all.min.js"></script>

--- a/app/html/tabs/op/opEntry.html
+++ b/app/html/tabs/op/opEntry.html
@@ -40,6 +40,12 @@
     </td>
   </tr>
   <tr>
+    <th>dark mode <span class="content is-small">(enable dark theme)</span></th>
+    <td class="is-expanded">
+      <input id="theme.darkMode" type="checkbox">
+    </td>
+  </tr>
+  <tr>
     <th colspan=2>
       <h4 class="title is-5">url</h4>
     </th>

--- a/app/ts/renderer/darkmode.ts
+++ b/app/ts/renderer/darkmode.ts
@@ -1,0 +1,20 @@
+import $ from 'jquery';
+
+function applyDarkMode(enabled: boolean): void {
+  const link = document.getElementById('dark-theme') as HTMLLinkElement | null;
+  if (link) link.disabled = !enabled;
+}
+
+$(document).ready(() => {
+  const checkbox = $('#theme\\.darkMode');
+  const stored = localStorage.getItem('darkMode') === 'true';
+  applyDarkMode(stored);
+  if (checkbox.length) {
+    checkbox.prop('checked', stored);
+    checkbox.on('change', function () {
+      const state = $(this).is(':checked');
+      localStorage.setItem('darkMode', String(state));
+      applyDarkMode(state);
+    });
+  }
+});

--- a/app/ts/renderer/index.ts
+++ b/app/ts/renderer/index.ts
@@ -3,3 +3,4 @@
 require('./sw');
 require('./bw');
 require('./bwa');
+require('./darkmode');


### PR DESCRIPTION
## Summary
- create a dark theme stylesheet
- add dark mode link and toggle in Options
- implement dark mode logic in renderer

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68589ac6ba048325bc65f89f355a4656