### PR TITLE
Fix wordlist settings reference

### DIFF
--- a/app/ts/renderer/bw/wordlistinput.ts
+++ b/app/ts/renderer/bw/wordlistinput.ts
@@ -2,6 +2,7 @@
 
 /** global: settings */
 const conversions = require('../../common/conversions');
+const { settings } = require('../../common/settings');
 
 const {
   ipcRenderer


### PR DESCRIPTION
## Summary
- import settings in wordlist input handler so the renderer has access to user settings

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: many '$' is not defined errors)*

------
https://chatgpt.com/codex/tasks/task_e_68589b4b499483259ff67ef004468ee8