### PR TITLE
Fix setTimeout sender.send calls

### DIFF
--- a/app/ts/main/bw/process.ts
+++ b/app/ts/main/bw/process.ts
@@ -302,10 +302,10 @@ function processDomain(domainSetup, event) {
 
     let data: any;
     stats.domains.sent++; // Add to requests sent
-    await sender.send('bw:status.update', 'domains.sent', stats.domains.sent); // Requests sent, update stats
+    sender.send('bw:status.update', 'domains.sent', stats.domains.sent); // Requests sent, update stats
 
     stats.domains.waiting++; // Waiting in queue
-    await sender.send('bw:status.update', 'domains.waiting', stats.domains.waiting); // Waiting in queue, update stats
+    sender.send('bw:status.update', 'domains.waiting', stats.domains.waiting); // Waiting in queue, update stats
 
     reqtime[domainSetup.index] = await performance.now();
 


### PR DESCRIPTION
## Summary
- remove `await` before `sender.send` in the bulk Whois timeout handler

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68589d7342c083258bc155d0a3c00c19