### PR TITLE
Refactor file loading to async

### DIFF
--- a/app/ts/renderer/bw/fileinput.ts
+++ b/app/ts/renderer/bw/fileinput.ts
@@ -24,7 +24,7 @@ var bwFileContents;
     filePath
     isDragDrop
  */
-ipcRenderer.on('bw:fileinput.confirmation', function(event, filePath = null, isDragDrop = false) {
+ipcRenderer.on('bw:fileinput.confirmation', async function(event, filePath = null, isDragDrop = false) {
   var bwFileStats; // File stats, size, last changed, etc
   const misc = settings['lookup.misc'];
   const lookup = {
@@ -43,17 +43,17 @@ ipcRenderer.on('bw:fileinput.confirmation', function(event, filePath = null, isD
     if (isDragDrop === true) {
       $('#bwEntry').addClass('is-hidden');
       $('#bwFileinputloading').removeClass('is-hidden');
-      bwFileStats = fs.statSync(filePath);
+      bwFileStats = await fs.promises.stat(filePath);
       bwFileStats['filename'] = filePath.replace(/^.*[\\\/]/, '');
       bwFileStats['humansize'] = conversions.byteToHumanFileSize(bwFileStats['size'], misc.useStandardSize);
       $('#bwFileSpanInfo').text('Loading file contents...');
-      bwFileContents = fs.readFileSync(filePath);
+      bwFileContents = await fs.promises.readFile(filePath);
     } else {
-      bwFileStats = fs.statSync(filePath[0]);
+      bwFileStats = await fs.promises.stat(filePath[0]);
       bwFileStats['filename'] = filePath[0].replace(/^.*[\\\/]/, '');
       bwFileStats['humansize'] = conversions.byteToHumanFileSize(bwFileStats['size'], misc.useStandardSize);
       $('#bwFileSpanInfo').text('Loading file contents...');
-      bwFileContents = fs.readFileSync(filePath[0]);
+      bwFileContents = await fs.promises.readFile(filePath[0]);
     }
     $('#bwFileSpanInfo').text('Getting line count...');
     bwFileStats['linecount'] = bwFileContents.toString().split('\n').length;


### PR DESCRIPTION
## Summary
- replace synchronous fs calls with async fs.promises API
- adjust event handler to async/await style

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68589db7d7788325a9b6e30b6e4408cb