### PR TITLE
Fix config path join

### DIFF
--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -87,7 +87,10 @@ export function load(): Settings {
   if (configuration.load) {
     try {
       const filePath =
-        getUserDataPath() + settings['custom.configuration']['filepath'];
+        path.join(
+          getUserDataPath(),
+          settings['custom.configuration'].filepath
+        );
       const raw = fs.readFileSync(filePath, 'utf8');
       try {
         settings = JSON.parse(raw) as Settings;
@@ -117,7 +120,10 @@ export function save(settings: Settings): string | Error | undefined {
   if (configuration.save) {
     try {
       const filePath =
-        getUserDataPath() + settings['custom.configuration']['filepath'];
+        path.join(
+          getUserDataPath(),
+          settings['custom.configuration'].filepath
+        );
       fs.writeFileSync(filePath, JSON.stringify(settings));
       debug(`Saved custom configuration at ${filePath}`);
       return 'SAVED';


### PR DESCRIPTION
## Summary
- use `path.join` when forming custom config file paths in settings.ts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68589df874d08325bb58a9487c4375f7