### PR TITLE
Add dark mode toggle with persistence

### DIFF
--- a/app/html/tabs/op/opEntry.html
+++ b/app/html/tabs/op/opEntry.html
@@ -42,7 +42,10 @@
   <tr>
     <th>dark mode <span class="content is-small">(enable dark theme)</span></th>
     <td class="is-expanded">
-      <input id="theme.darkMode" type="checkbox">
+      <label class="switch">
+        <input id="theme.darkMode" type="checkbox">
+        <span class="check"></span>
+      </label>
     </td>
   </tr>
   <tr>

--- a/app/ts/appsettings.ts
+++ b/app/ts/appsettings.ts
@@ -39,6 +39,9 @@ const appSettings = {
     'startup': { // Application startup
       'developerTools': false, // Enable/Show developer tools at startup (default: false)
     },
+    'theme': { // Application theme settings
+      'darkMode': false // Enable dark mode theme (default: false)
+    },
     'app.window.url': { // Window URL
       'pathname': path.join(__dirname, '../html/mainPanel.html'), // Main html file location
       'protocol': 'file:', // Path protocol (default: file:)

--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -34,6 +34,7 @@ export interface Settings {
   'lookup.randomize.timeBetween': { randomize: boolean; minimum: number; maximum: number };
   'lookup.assumptions': { uniregistry: boolean; ratelimit: boolean; unparsable: boolean; dnsFailureUnavailable: boolean };
   'custom.configuration': { filepath: string; load: boolean; save: boolean };
+  theme: { darkMode: boolean };
   [key: string]: any;
 }
 

--- a/app/ts/renderer/darkmode.ts
+++ b/app/ts/renderer/darkmode.ts
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import { settings, saveSettings } from '../common/settings';
 
 function applyDarkMode(enabled: boolean): void {
   const link = document.getElementById('dark-theme') as HTMLLinkElement | null;
@@ -7,13 +8,15 @@ function applyDarkMode(enabled: boolean): void {
 
 $(document).ready(() => {
   const checkbox = $('#theme\\.darkMode');
-  const stored = localStorage.getItem('darkMode') === 'true';
+  const stored = settings.theme?.darkMode ?? false;
   applyDarkMode(stored);
   if (checkbox.length) {
     checkbox.prop('checked', stored);
     checkbox.on('change', function () {
       const state = $(this).is(':checked');
-      localStorage.setItem('darkMode', String(state));
+      settings.theme = settings.theme || { darkMode: false };
+      settings.theme.darkMode = state;
+      saveSettings(settings);
       applyDarkMode(state);
     });
   }


### PR DESCRIPTION
## Summary
- toggle control for dark mode option
- remember dark mode setting via app config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68589d693a44832585c95fc08acac8be