### PR TITLE
Fix fontawesome module loading

### DIFF
--- a/app/html/mainPanel.html
+++ b/app/html/mainPanel.html
@@ -21,7 +21,9 @@
   <link id="dark-theme" href="../css/dark.css" rel="stylesheet" disabled>
   <link href="../css/tables.css" rel="stylesheet">
   <!--<link href="../css/fontawesome/all.min.css" rel="stylesheet">-->
-  <script defer src="../ts/common/fontawesome.js"></script>
+  <script>
+    require('../ts/common/fontawesome.js');
+  </script>
 
   <script>
     window.$ = window.jQuery = require('jquery');


### PR DESCRIPTION
## Summary
- load `fontawesome.js` via `require` so it runs in Electron

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6858a33d2ef88325ab79cc19462f35a6