### PR TITLE
Fix settings reference in BWA file input

### DIFF
--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -6,6 +6,7 @@ const whois = require('../../common/whoiswrapper'),
   fs = require('fs'),
   Papa = require('papaparse'),
   dt = require('datatables')();
+const { settings } = require('../../common/settings');
 
 const {
   ipcRenderer


### PR DESCRIPTION
## Summary
- import settings in the BWA fileinput renderer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858a6911f408325bdaa2583f4045968