### PR TITLE
Add typed IPC interfaces

### DIFF
--- a/app/ts/main/bw/export.ts
+++ b/app/ts/main/bw/export.ts
@@ -17,6 +17,7 @@ const {
 } = electron;
 
 const settings = require('../../common/settings').load();
+import type { IpcMainEvent } from 'electron';
 
 /*
   ipcMain.on('bw:export', function(...) {...});
@@ -26,7 +27,7 @@ const settings = require('../../common/settings').load();
     results (object) - bulk whois results object
     options (object) - bulk whois export options object
  */
-ipcMain.on('bw:export', function(event, results, options) {
+ipcMain.on('bw:export', function(event: IpcMainEvent, results, options) {
   const {
     'lookup.export': resExports
   } = settings;

--- a/app/ts/main/bw/fileinput.ts
+++ b/app/ts/main/bw/fileinput.ts
@@ -12,6 +12,7 @@ const {
 } = electron;
 
 const settings = require('../../common/settings').load();
+import type { IpcMainEvent } from 'electron';
 
 /*
   ipcMain.on('bw:input.file', function(...) {...});
@@ -19,7 +20,7 @@ const settings = require('../../common/settings').load();
   parameters
     event (object) - renderer object
  */
-ipcMain.on('bw:input.file', function(event) {
+ipcMain.on('bw:input.file', function(event: IpcMainEvent) {
   debug("Waiting for file selection");
   const filePath = dialog.showOpenDialogSync({
     title: "Select wordlist file",
@@ -42,7 +43,7 @@ ipcMain.on('bw:input.file', function(event) {
     event (object) - renderer object
     filePath (string) - dropped file path
  */
-ipcMain.on('ondragstart', function(event, filePath) {
+ipcMain.on('ondragstart', function(event: IpcMainEvent, filePath) {
   const {
     'app.window': appWindow
   } = settings;

--- a/app/ts/main/bw/process.ts
+++ b/app/ts/main/bw/process.ts
@@ -26,6 +26,7 @@ const {
   dialog,
   remote
 } = electron;
+import type { IpcMainEvent } from 'electron';
 
 const defaultValue = null; // Changing this implies changing all dependant comparisons
 let bulkWhois; // BulkWhois object
@@ -39,7 +40,8 @@ let reqtime: any[] = [];
     domains (array) - domains to request whois for
     tlds (array) - tlds to look for
  */
-ipcMain.on('bw:lookup', function(event, domains, tlds) {
+ipcMain.on('bw:lookup', function(event: IpcMainEvent, message: BwLookupEvent) {
+  const { domains, tlds } = message;
   resetUiCounters(event); // Reset UI counters, pass window param
   bulkWhois = resetObject(defaultBulkWhois); // Resets the bulkWhois object to default
   reqtime = [];
@@ -128,7 +130,7 @@ ipcMain.on('bw:lookup', function(event, domains, tlds) {
   parameters
     event (object) - renderer event
  */
-ipcMain.on('bw:lookup.pause', function(event) {
+ipcMain.on('bw:lookup.pause', function(event: IpcMainEvent) {
 
   // bulkWhois section
   const {
@@ -159,7 +161,7 @@ ipcMain.on('bw:lookup.pause', function(event) {
   parameters
     event (object) - renderer object
  */
-ipcMain.on('bw:lookup.continue', function(event) {
+ipcMain.on('bw:lookup.continue', function(event: IpcMainEvent) {
   debug('Continuing bulk whois requests');
 
   // Go through the remaining domains and queue them again using setTimeouts
@@ -242,7 +244,7 @@ ipcMain.on('bw:lookup.continue', function(event) {
   parameters
     event (object) - Current renderer object
  */
-ipcMain.on('bw:lookup.stop', function(event) {
+ipcMain.on('bw:lookup.stop', function(event: IpcMainEvent) {
   const {
     results,
     stats

--- a/app/ts/main/bw/wordlistinput.ts
+++ b/app/ts/main/bw/wordlistinput.ts
@@ -11,6 +11,7 @@ const {
   dialog,
   remote
 } = electron;
+import type { IpcMainEvent } from 'electron';
 
 /*
   ipcMain.on('bw:input.wordlist', function(...) {...});
@@ -18,7 +19,7 @@ const {
   parameters
     event (object) - renderer object
  */
-ipcMain.on('bw:input.wordlist', function(event) {
+ipcMain.on('bw:input.wordlist', function(event: IpcMainEvent) {
   const {
     sender
   } = event;

--- a/app/ts/main/bwa/analyser.ts
+++ b/app/ts/main/bwa/analyser.ts
@@ -10,6 +10,7 @@ const {
   ipcMain,
   dialog
 } = electron;
+import type { IpcMainEvent } from 'electron';
 
 /*
   ipcMain.on('bwa:analyser.start', function(...) {...});
@@ -18,7 +19,7 @@ const {
     event (object) - renderer object
     contents (object) - bulk whois lookup results object
  */
-ipcMain.on('bwa:analyser.start', function(event, contents) {
+ipcMain.on('bwa:analyser.start', function(event: IpcMainEvent, contents) {
   const {
     sender
   } = event;

--- a/app/ts/main/bwa/fileinput.ts
+++ b/app/ts/main/bwa/fileinput.ts
@@ -10,6 +10,7 @@ const {
   ipcMain,
   dialog
 } = electron;
+import type { IpcMainEvent } from 'electron';
 
 /*
   ipcMain.on('bwa:input.file', function(...) {...});
@@ -17,7 +18,7 @@ const {
   parameters
     event
  */
-ipcMain.on('bwa:input.file', function(event) {
+ipcMain.on('bwa:input.file', function(event: IpcMainEvent) {
   const {
     sender
   } = event;
@@ -34,7 +35,7 @@ ipcMain.on('bwa:input.file', function(event) {
 
 /*
 // On drag and drop file
-ipcMain.on('ondragstart', function(event, filePath) {
+ipcMain.on('ondragstart', function(event: IpcMainEvent, filePath) {
   event.sender.startDrag({
     file: filePath,
     icon: appSettings.window.icon

--- a/app/ts/renderer/bw/export.ts
+++ b/app/ts/renderer/bw/export.ts
@@ -13,6 +13,7 @@ const {
   setExportOptions,
   setExportOptionsEx
 } = require('./auxiliary');
+import type { IpcRendererEvent } from 'electron';
 
 require('../../common/stringformat');
 
@@ -25,7 +26,7 @@ var results, options;
     event
     rcvResults
  */
-ipcRenderer.on('bw:result.receive', function(event, rcvResults) {
+ipcRenderer.on('bw:result.receive', function(event: IpcRendererEvent, rcvResults) {
   ipcRenderer.send('app:debug', "Results are ready for export {0}".format(rcvResults));
 
   results = rcvResults;

--- a/app/ts/renderer/bw/fileinput.ts
+++ b/app/ts/renderer/bw/fileinput.ts
@@ -11,6 +11,7 @@ const {
 } = require('electron'), {
   tableReset
 } = require('./auxiliary');
+import type { IpcRendererEvent } from 'electron';
 
 require('../../common/stringformat');
 
@@ -24,7 +25,7 @@ var bwFileContents;
     filePath
     isDragDrop
  */
-ipcRenderer.on('bw:fileinput.confirmation', async function(event, filePath = null, isDragDrop = false) {
+ipcRenderer.on('bw:fileinput.confirmation', async function(event: IpcRendererEvent, filePath = null, isDragDrop = false) {
   var bwFileStats; // File stats, size, last changed, etc
   const misc = settings['lookup.misc'];
   const lookup = {
@@ -137,7 +138,7 @@ $(document).on('click', '#bwFileButtonConfirm', function() {
   debug(bwDomainArray);
   debug(bwTldsArray);
 
-  ipcRenderer.send("bw:lookup", bwDomainArray, bwTldsArray);
+  ipcRenderer.send("bw:lookup", { domains: bwDomainArray, tlds: bwTldsArray });
 });
 
 /*

--- a/app/ts/renderer/bw/process.ts
+++ b/app/ts/renderer/bw/process.ts
@@ -7,6 +7,7 @@ const whois = require('../../common/whoiswrapper'),
 const {
   ipcRenderer
 } = require('electron');
+import type { IpcRendererEvent } from 'electron';
 
 require('../../common/stringformat');
 
@@ -49,7 +50,7 @@ ipcRenderer.on('bulkwhois:resultreceive', function(event, results) {
     stat
     value
  */
-ipcRenderer.on('bw:status.update', function(event, stat, value) {
+ipcRenderer.on('bw:status.update', function(event: IpcRendererEvent, stat, value) {
   ipcRenderer.send('app:debug', "{0}, value update to {1}".format(stat, value)); // status update
   var percent;
   switch (stat) {

--- a/app/ts/renderer/bw/wordlistinput.ts
+++ b/app/ts/renderer/bw/wordlistinput.ts
@@ -9,6 +9,7 @@ const {
 } = require('electron'), {
   tableReset
 } = require('./auxiliary');
+import type { IpcRendererEvent } from 'electron';
 
 require('../../common/stringformat');
 
@@ -120,7 +121,7 @@ $(document).on('click', '#bwWordlistconfirmButtonStart', function() {
   $('#bwWordlistconfirm').addClass('is-hidden');
   $('#bwProcessing').removeClass('is-hidden');
 
-  ipcRenderer.send("bw:lookup", bwDomainArray, bwTldsArray);
+  ipcRenderer.send("bw:lookup", { domains: bwDomainArray, tlds: bwTldsArray });
 
   return;
 });

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -113,7 +113,12 @@ declare module '@electron/remote' {
   export function getCurrentWebContents(): any;
 }
 
-declare module '@electron/remote/main' {
-  export function initialize(): void;
-  export function enable(webContents: any): void;
+  declare module '@electron/remote/main' {
+    export function initialize(): void;
+    export function enable(webContents: any): void;
+  }
+
+interface BwLookupEvent {
+  domains: string[];
+  tlds: string[];
 }


### PR DESCRIPTION
## Summary
- define `BwLookupEvent` in custom types
- use `BwLookupEvent` and `Ipc*Event` types for IPC handlers
- pass a single lookup payload to `bw:lookup`

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858aab324b48325a59a3703c976a18d