### PR TITLE
Switch to ES module syntax

### DIFF
--- a/app/ts/common/fontawesome.ts
+++ b/app/ts/common/fontawesome.ts
@@ -1,9 +1,7 @@
 // Font Awesome setup for Electron renderer
 // Import the full Font Awesome library so icons render in HTML
 // but guard against missing dependencies when packaging
-try {
-  require('@fortawesome/fontawesome-free/js/all.js');
-} catch (err) {
+import('@fortawesome/fontawesome-free/js/all.js').catch((err) => {
   // eslint-disable-next-line no-console
   console.error('Failed to load Font Awesome:', err);
-}
+});

--- a/app/ts/common/lineHelper.ts
+++ b/app/ts/common/lineHelper.ts
@@ -1,4 +1,6 @@
 // jshint esversion: 8
+import * as readline from 'readline';
+import * as fs from 'fs';
 
 /*
   lineCount
@@ -31,8 +33,6 @@ export function fileReadLines(filePath: string, lines = 2, startLine = 0): Promi
   return new Promise((resolve, reject) => {
     let lineCounter = 0;
     const linesRead: string[] = [];
-    const readline = require('readline');
-    const fs = require('fs');
     const lineReader = readline.createInterface({
       input: fs.createReadStream(filePath),
     });

--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -3,14 +3,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as electron from 'electron';
-let remote: typeof import('@electron/remote') | undefined;
-try {
-  // Dynamically require to avoid issues when Electron bindings are unavailable
-  remote = require('@electron/remote');
-} catch {
-  remote = (electron as any).remote;
-}
 const { app } = electron;
+const remote = (electron as any).remote;
 import debugModule from 'debug';
 const debug = debugModule('common.settings');
 
@@ -38,13 +32,9 @@ export interface Settings {
   [key: string]: any;
 }
 
-const rawModule = fs.existsSync('./appsettings')
-  ? require('./appsettings')
-  : require('../appsettings');
-const settingsModule: { settings: Settings } = rawModule.settings
-  ? rawModule
-  : rawModule.default;
-let { settings } = settingsModule;
+import defaultAppSettings from '../appsettings';
+
+let settings = (defaultAppSettings as any).settings as Settings;
 export { settings };
 export default settings;
 

--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -71,7 +71,7 @@ interface MainSettings extends BaseSettings {
   [key: string]: any;
 }
 
-require('./main/index');
+import './main/index';
 
 let settings: MainSettings = loadSettings() as MainSettings;
 let mainWindow: BrowserWindow;

--- a/app/ts/main/bw.ts
+++ b/app/ts/main/bw.ts
@@ -1,20 +1,19 @@
 // jshint esversion: 8
 
-const electron = require('electron'),
-  debug = require('debug')('main.bw');
-
-const {
+import {
   app,
   BrowserWindow,
   Menu,
   ipcMain,
   dialog,
-  remote
-} = electron;
+  remote,
+} from 'electron';
+import debugModule from 'debug';
 
+import './bw/fileinput'; // File input
+import './bw/wordlistinput'; // Wordlist input
+import './bw/process'; // Process stage
+import './bw/export'; // Export stage
+import '../common/stringformat'; // String format
 
-require('./bw/fileinput'); // File input
-require('./bw/wordlistinput'); // Wordlist input
-require('./bw/process'); // Process stage
-require('./bw/export'); // Export stage
-require('../common/stringformat'); // String format
+const debug = debugModule('main.bw');

--- a/app/ts/main/bw/auxiliary.ts
+++ b/app/ts/main/bw/auxiliary.ts
@@ -45,7 +45,7 @@ function resetUiCounters(event) {
 }
 
 
-module.exports = {
-  resetUiCounters: resetUiCounters,
-  rstUiCntrs: resetUiCounters
+export {
+  resetUiCounters,
+  resetUiCounters as rstUiCntrs,
 };

--- a/app/ts/main/bw/export.ts
+++ b/app/ts/main/bw/export.ts
@@ -1,22 +1,23 @@
 // jshint esversion: 8
 
-const electron = require('electron'),
-  fs = require('fs'),
-  path = require('path'),
-  conversions = require('../../common/conversions'),
-  debug = require('debug')('main.bw.export'),
-  JSZip = require('jszip');
-
-const {
+import {
   app,
   BrowserWindow,
   Menu,
   ipcMain,
   dialog,
-  remote
-} = electron;
+  remote,
+} from 'electron';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as conversions from '../../common/conversions';
+import debugModule from 'debug';
+import JSZip from 'jszip';
+import { load as loadSettings } from '../../common/settings';
 
-const settings = require('../../common/settings').load();
+const debug = debugModule('main.bw.export');
+
+const settings = loadSettings();
 
 /*
   ipcMain.on('bw:export', function(...) {...});
@@ -72,10 +73,10 @@ ipcMain.on('bw:export', function(event, results, options) {
   }
 
   const filePath = dialog.showSaveDialogSync({
-    title: "Save export file",
-    buttonLabel: "Save",
-    properties: ['openFile', 'showHiddenFiles'],
-    filters: filters
+    title: 'Save export file',
+    buttonLabel: 'Save',
+    properties: ['showHiddenFiles'],
+    filters: filters,
   });
 
   if (filePath === undefined || filePath == '' || filePath === null) {

--- a/app/ts/main/bw/fileinput.ts
+++ b/app/ts/main/bw/fileinput.ts
@@ -1,17 +1,18 @@
 // jshint esversion: 8
 
-const electron = require('electron'),
-  debug = require('debug')('main.bw.fileinput');
-
-const {
+import {
   app,
   BrowserWindow,
   Menu,
   ipcMain,
-  dialog
-} = electron;
+  dialog,
+} from 'electron';
+import debugModule from 'debug';
+import { load as loadSettings } from '../../common/settings';
 
-const settings = require('../../common/settings').load();
+const debug = debugModule('main.bw.fileinput');
+
+const settings = loadSettings();
 
 /*
   ipcMain.on('bw:input.file', function(...) {...});

--- a/app/ts/main/bw/process.defaults.ts
+++ b/app/ts/main/bw/process.defaults.ts
@@ -78,5 +78,5 @@ const defaultBulkWhois: BulkWhoisDefaults = {
   }
 };
 
-export = defaultBulkWhois;
+export default defaultBulkWhois;
 

--- a/app/ts/main/bw/process.ts
+++ b/app/ts/main/bw/process.ts
@@ -1,31 +1,26 @@
 //jshint esversion: 8, -W030, -W083
 
-const electron = require('electron'),
-  whois = require('../../common/whoiswrapper'),
-  debug = require('debug')('main.bw.process'),
-  defaultBulkWhois = require('./process.defaults'),
-  dns = require('../../common/dnsLookup');
-
-const {
-  msToHumanTime
-} = require('../../common/conversions'), {
-  resetObject
-} = require('../../common/resetObject'), {
-  resetUiCounters
-} = require('./auxiliary'), {
-  performance
-} = require('perf_hooks');
-
-const settings = require('../../common/settings').load();
-
-const {
+import {
   app,
   BrowserWindow,
   Menu,
   ipcMain,
   dialog,
-  remote
-} = electron;
+  remote,
+} from 'electron';
+import * as whois from '../../common/whoiswrapper';
+import debugModule from 'debug';
+import defaultBulkWhois from './process.defaults';
+import dnsLookup from '../../common/dnsLookup';
+import { msToHumanTime } from '../../common/conversions';
+import { resetObject } from '../../common/resetObject';
+import { resetUiCounters } from './auxiliary';
+import { performance } from 'perf_hooks';
+import { load as loadSettings } from '../../common/settings';
+
+const debug = debugModule('main.bw.process');
+
+const settings: any = loadSettings();
 
 const defaultValue = null; // Changing this implies changing all dependant comparisons
 let bulkWhois; // BulkWhois object
@@ -316,7 +311,7 @@ function processDomain(domainSetup, event) {
         await whois.lookup(domainSetup.domain, {
           'follow': domainSetup.follow,
           'timeout': domainSetup.timeout
-        }) : await dns.hasNsServers(domainSetup.domain);
+        }) : await dnsLookup.hasNsServers(domainSetup.domain);
       processData(event, domainSetup.domain, domainSetup.index, data, false);
     } catch (e) {
       console.log(e);
@@ -403,7 +398,7 @@ function processData(event, domain, index, data = null, isError = false) {
     stats.laststatus.error = domain;
     sender.send('bw:status.update', 'laststatus.error', stats.laststatus.error);
   })() : (function() {
-    domainAvailable = (settings['lookup.general'].type == 'whois') ? whois.isDomainAvailable(data) : dns.isDomainAvailable(data);
+    domainAvailable = (settings['lookup.general'].type == 'whois') ? whois.isDomainAvailable(data) : dnsLookup.isDomainAvailable(data);
     switch (domainAvailable) {
       case 'available':
         status.available++;
@@ -440,7 +435,7 @@ function processData(event, domain, index, data = null, isError = false) {
   stats.domains.waiting--; // Waiting in queue
   sender.send('bw:status.update', 'domains.waiting', stats.domains.waiting); // Waiting in queue, update stats
 
-  let resultFilter = {
+  let resultFilter: any = {
     domain: '',
     status: '',
     registrar: '',

--- a/app/ts/main/bw/wordlistinput.ts
+++ b/app/ts/main/bw/wordlistinput.ts
@@ -1,16 +1,16 @@
 // jshint esversion: 8
 
-const electron = require('electron'),
-  debug = require('debug')('main.bw.wordlistinput');
-
-const {
+import {
   app,
   BrowserWindow,
   Menu,
   ipcMain,
   dialog,
-  remote
-} = electron;
+  remote,
+} from 'electron';
+import debugModule from 'debug';
+
+const debug = debugModule('main.bw.wordlistinput');
 
 /*
   ipcMain.on('bw:input.wordlist', function(...) {...});

--- a/app/ts/main/bwa.ts
+++ b/app/ts/main/bwa.ts
@@ -1,4 +1,4 @@
 // jshint esversion: 8
 
-require('./bwa/fileinput'); // File input
-require('./bwa/analyser');
+import './bwa/fileinput'; // File input
+import './bwa/analyser';

--- a/app/ts/main/bwa/analyser.ts
+++ b/app/ts/main/bwa/analyser.ts
@@ -1,15 +1,15 @@
 // jshint esversion: 8
 
-const electron = require('electron'),
-  debug = require('debug')('main.bwa.analyser');
-
-const {
+import {
   app,
   BrowserWindow,
   Menu,
   ipcMain,
-  dialog
-} = electron;
+  dialog,
+} from 'electron';
+import debugModule from 'debug';
+
+const debug = debugModule('main.bwa.analyser');
 
 /*
   ipcMain.on('bwa:analyser.start', function(...) {...});

--- a/app/ts/main/bwa/fileinput.ts
+++ b/app/ts/main/bwa/fileinput.ts
@@ -1,15 +1,15 @@
 // jshint esversion: 8
 
-const electron = require('electron'),
-  debug = require('debug')('main.bwa.fileinput');
-
-const {
+import {
   app,
   BrowserWindow,
   Menu,
   ipcMain,
-  dialog
-} = electron;
+  dialog,
+} from 'electron';
+import debugModule from 'debug';
+
+const debug = debugModule('main.bwa.fileinput');
 
 /*
   ipcMain.on('bwa:input.file', function(...) {...});

--- a/app/ts/main/index.ts
+++ b/app/ts/main/index.ts
@@ -1,5 +1,5 @@
 // jshint esversion: 8
 
-require('./sw');
-require('./bw');
-require('./bwa');
+import './sw';
+import './bw';
+import './bwa';

--- a/app/ts/main/sw.ts
+++ b/app/ts/main/sw.ts
@@ -1,22 +1,23 @@
 // jshint esversion: 8, -W030
 
-const electron = require('electron'),
-  path = require('path'),
-  url = require('url'),
-  whois = require('../common/whoiswrapper'),
-  debug = require('debug')('main.sw');
-
-const {
+import {
   app,
   BrowserWindow,
   Menu,
   ipcMain,
   dialog,
   remote,
-  clipboard
-} = electron;
+  clipboard,
+} from 'electron';
+import * as path from 'path';
+import * as url from 'url';
+import * as whois from '../common/whoiswrapper';
+import debugModule from 'debug';
+import { load as loadSettings } from '../common/settings';
 
-const settings = require('../common/settings').load();
+const debug = debugModule('main.sw');
+
+const settings = loadSettings();
 
 /*
   ipcMain.on('sw:lookup', function(...) {...});

--- a/app/ts/renderer.ts
+++ b/app/ts/renderer.ts
@@ -56,7 +56,7 @@ $(document).ready(function() {
   }
 
   startup();
-  require('./renderer/navigation');
+  import('./renderer/navigation');
   
   return;
 });

--- a/app/ts/renderer/bw.ts
+++ b/app/ts/renderer/bw.ts
@@ -1,7 +1,7 @@
 // jshint esversion: 8
 
 /* Bulk whois handling */
-require('./bw/wordlistinput'); // Bulk whois by wordlist input
-require('./bw/fileinput'); // Bulk whois by file input
-require('./bw/process'); // Bulk whois requests processing
-require('./bw/export'); // Export processing
+import './bw/wordlistinput'; // Bulk whois by wordlist input
+import './bw/fileinput'; // Bulk whois by file input
+import './bw/process'; // Bulk whois requests processing
+import './bw/export'; // Export processing

--- a/app/ts/renderer/bw/auxiliary.ts
+++ b/app/ts/renderer/bw/auxiliary.ts
@@ -1,8 +1,6 @@
 // jshint esversion: 8
 
-const {
-  resetObject
-} = require('../../common/resetObject');
+import { resetObject } from '../../common/resetObject';
 
 /*
   tableReset
@@ -140,12 +138,12 @@ function unlockFields(isTxt = false) {
   return;
 }
 
-module.exports = {
-  tableReset: tableReset,
-  tblReset: tableReset,
-  getExportOptions: getExportOptions,
-  getExprtOptns: getExportOptions,
-  setExportOptions: setExportOptions,
-  setExprtOptns: setExportOptions,
-  setExportOptionsEx: setExportOptionsEx
+export {
+  tableReset,
+  tableReset as tblReset,
+  getExportOptions,
+  getExportOptions as getExprtOptns,
+  setExportOptions,
+  setExportOptions as setExprtOptns,
+  setExportOptionsEx,
 };

--- a/app/ts/renderer/bw/export.defaults.ts
+++ b/app/ts/renderer/bw/export.defaults.ts
@@ -1,8 +1,10 @@
 // Default export options values
-module.exports = {
-  'filetype': 'csv', // Filetype to export
-  'domains': 'available', // Export only available domains
-  'errors': 'no', // Do not export lookup errors
-  'information': 'domain', // Export only domain name
-  'whoisreply': 'no' // Do not include whois replies in export
+const defaultExportOptions = {
+  filetype: 'csv', // Filetype to export
+  domains: 'available', // Export only available domains
+  errors: 'no', // Do not export lookup errors
+  information: 'domain', // Export only domain name
+  whoisreply: 'no', // Do not include whois replies in export
 };
+
+export default defaultExportOptions;

--- a/app/ts/renderer/bw/export.ts
+++ b/app/ts/renderer/bw/export.ts
@@ -1,20 +1,18 @@
 // jshint esversion: 8
 
-const whois = require('../../common/whoiswrapper'),
-  conversions = require('../../common/conversions'),
-  defaultExportOptions = require('./export.defaults');
+import * as whois from '../../common/whoiswrapper';
+import * as conversions from '../../common/conversions';
+import defaultExportOptions from './export.defaults';
 
-const {
-  ipcRenderer
-} = require('electron'), {
-  resetObject
-} = require('../../common/resetObject'), {
+import { ipcRenderer } from 'electron';
+import { resetObject } from '../../common/resetObject';
+import {
   getExportOptions,
   setExportOptions,
-  setExportOptionsEx
-} = require('./auxiliary');
+  setExportOptionsEx,
+} from './auxiliary';
 
-require('../../common/stringformat');
+import '../../common/stringformat';
 
 var results, options;
 

--- a/app/ts/renderer/bw/fileinput.ts
+++ b/app/ts/renderer/bw/fileinput.ts
@@ -1,18 +1,17 @@
 // jshint esversion: 8, -W069
 /** global: appSettings */
 
-const whois = require('../../common/whoiswrapper'),
-  conversions = require('../../common/conversions'),
-  fs = require('fs'),
-  debug = require('debug')('renderer.bw.fileinput');
+import * as whois from '../../common/whoiswrapper';
+import * as conversions from '../../common/conversions';
+import * as fs from 'fs';
+import debugModule from 'debug';
 
-const {
-  ipcRenderer
-} = require('electron'), {
-  tableReset
-} = require('./auxiliary');
+import { ipcRenderer } from 'electron';
+import { tableReset } from './auxiliary';
 
-require('../../common/stringformat');
+import '../../common/stringformat';
+
+const debug = debugModule('renderer.bw.fileinput');
 
 var bwFileContents;
 

--- a/app/ts/renderer/bw/process.ts
+++ b/app/ts/renderer/bw/process.ts
@@ -1,14 +1,12 @@
 // jshint esversion: 8, -W030
 
-const whois = require('../../common/whoiswrapper'),
-  conversions = require('../../common/conversions'),
-  base = 10;
+import * as whois from '../../common/whoiswrapper';
+import * as conversions from '../../common/conversions';
+const base = 10;
 
-const {
-  ipcRenderer
-} = require('electron');
+import { ipcRenderer } from 'electron';
 
-require('../../common/stringformat');
+import '../../common/stringformat';
 
 /*
 // Receive whois lookup reply

--- a/app/ts/renderer/bw/wordlistinput.ts
+++ b/app/ts/renderer/bw/wordlistinput.ts
@@ -1,16 +1,13 @@
 // jshint esversion: 8, -W069
 
 /** global: settings */
-const conversions = require('../../common/conversions');
-const { settings } = require('../../common/settings');
+import * as conversions from '../../common/conversions';
+import { settings } from '../../common/settings';
 
-const {
-  ipcRenderer
-} = require('electron'), {
-  tableReset
-} = require('./auxiliary');
+import { ipcRenderer } from 'electron';
+import { tableReset } from './auxiliary';
 
-require('../../common/stringformat');
+import '../../common/stringformat';
 
 var bwWordlistContents; // Global wordlist input contents
 

--- a/app/ts/renderer/bwa.ts
+++ b/app/ts/renderer/bwa.ts
@@ -1,5 +1,5 @@
 // jshint esversion: 8
 
 /* Bulk whois analyser handling */
-require('./bwa/fileinput');
-require('./bwa/analyser');
+import './bwa/fileinput';
+import './bwa/analyser';

--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -1,15 +1,14 @@
 // jshint esversion: 8, -W030
 
 /** global: appSettings */
-const whois = require('../../common/whoiswrapper'),
-  conversions = require('../../common/conversions'),
-  fs = require('fs'),
-  Papa = require('papaparse'),
-  dt = require('datatables')();
+import * as whois from '../../common/whoiswrapper';
+import * as conversions from '../../common/conversions';
+import * as fs from 'fs';
+import Papa from 'papaparse';
+import datatables from 'datatables';
+import { ipcRenderer } from 'electron';
 
-const {
-  ipcRenderer
-} = require('electron');
+const dt = datatables();
 
 var bwaFileContents;
 

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -1,18 +1,18 @@
 // jshint esversion: 8, -W069
 
 /** global: settings */
-const whois = require('../../common/whoiswrapper'),
-  conversions = require('../../common/conversions'),
-  fs = require('fs'),
-  Papa = require('papaparse'),
-  dt = require('datatables')();
-const { settings } = require('../../common/settings');
+import * as whois from '../../common/whoiswrapper';
+import * as conversions from '../../common/conversions';
+import * as fs from 'fs';
+import Papa from 'papaparse';
+import datatables from 'datatables';
+import { settings } from '../../common/settings';
 
-const {
-  ipcRenderer
-} = require('electron');
+import { ipcRenderer } from 'electron';
 
-require('../../common/stringformat');
+import '../../common/stringformat';
+
+const dt = datatables();
 
 var bwaFileContents;
 

--- a/app/ts/renderer/index.ts
+++ b/app/ts/renderer/index.ts
@@ -1,6 +1,6 @@
 // jshint esversion: 8
 
-require('./sw');
-require('./bw');
-require('./bwa');
-require('./darkmode');
+import './sw';
+import './bw';
+import './bwa';
+import './darkmode';

--- a/app/ts/renderer/sw.ts
+++ b/app/ts/renderer/sw.ts
@@ -1,13 +1,9 @@
 // jshint esversion: 8, -W069
 
-const whois = require('../common/whoiswrapper'),
-  parseRawData = require('../common/parseRawData');
-
-const {
-  getDate
-} = require('../common/conversions'), {
-  ipcRenderer
-} = require('electron');
+import * as whois from '../common/whoiswrapper';
+import parseRawData from '../common/parseRawData';
+import { getDate } from '../common/conversions';
+import { ipcRenderer } from 'electron';
 
 const {
   isDomainAvailable,
@@ -16,7 +12,8 @@ const {
   toJSON
 } = whois;
 
-(window as any).$ = (window as any).jQuery = require('jquery');
+import jQuery from 'jquery';
+(window as any).$ = (window as any).jQuery = jQuery;
 
 var singleWhois = {
   'input': {


### PR DESCRIPTION
## Summary
- refactor TypeScript sources under `app/ts` to use `import`/`export`
- keep dynamic loading for optional modules
- ensure `esModuleInterop` stays enabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858aa9bbe948325ac92cf65b31606fe