### PR TITLE
Refactor string formatting helper

### DIFF
--- a/app/ts/common/index.ts
+++ b/app/ts/common/index.ts
@@ -2,7 +2,7 @@
 
 import * as Conversions from './conversions';
 import LineHelper from './lineHelper';
-import * as StringFormat from './stringformat';
+import { formatString } from './stringformat';
 import { parseRawData as ParseRawData } from './parseRawData';
 import { lookup as WhoisLookup } from './whoiswrapper';
 import DnsLookup from './dnsLookup';
@@ -10,7 +10,7 @@ import DnsLookup from './dnsLookup';
 export {
   Conversions,
   LineHelper,
-  StringFormat,
+  formatString,
   ParseRawData,
   WhoisLookup,
   DnsLookup

--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -14,7 +14,6 @@ const { app } = electron;
 import debugModule from 'debug';
 const debug = debugModule('common.settings');
 
-import './stringformat';
 
 export interface Settings {
   'lookup.conversion': { enabled: boolean; algorithm: string };

--- a/app/ts/common/stringformat.ts
+++ b/app/ts/common/stringformat.ts
@@ -1,23 +1,18 @@
 // jshint esversion: 8
 
 /*
-  .format String Prototype
+  formatString Helper
     formats a given string with input parameters
   parameters
-    string + x (string) - String to include in string
- */
-declare global {
-  interface String {
-    format(...args: any[]): string;
+    str (string) - String with placeholders
+    ...args (unknown[]) - values to insert
+*/
+
+export function formatString(str: string, ...args: unknown[]): string {
+  let result = str;
+  for (const k in args) {
+    result = result.replace(new RegExp(`\\{${k}\\}`, 'g'), String(args[k]));
   }
+  return result;
 }
 
-String.prototype.format = function (...args: any[]): string {
-  let a = this as string;
-  for (const k in args) {
-    a = a.replace(new RegExp(`\\{${k}\\}`, 'g'), args[k]);
-  }
-  return a;
-};
-
-export {};

--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -14,6 +14,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { loadSettings } from './common/settings';
 import type { Settings as BaseSettings } from './common/settings';
+import { formatString } from './common/stringformat';
 import { initialize as initializeRemote, enable as enableRemote } from '@electron/remote/main';
 import type { IpcMainEvent } from 'electron';
 
@@ -102,9 +103,9 @@ app.on('ready', function() {
 
   // Some application start debugging messages
   debug("App is starting");
-  debug("'appWindow.frame': {0}".format(appWindow.frame));
-  debug("'appWindow.height': {0}".format(appWindow.height));
-  debug("'appWindow.width': {0}".format(appWindow.width));
+  debug(formatString("'appWindow.frame': {0}", appWindow.frame));
+  debug(formatString("'appWindow.height': {0}", appWindow.height));
+  debug(formatString("'appWindow.width': {0}", appWindow.width));
 
   // mainWindow, Main application window initialization
   mainWindow = new BrowserWindow({
@@ -147,8 +148,8 @@ app.on('ready', function() {
   }));
 
   // Some more debugging messages
-  debug("'settings.url.protocol': {0}".format(appUrl.protocol));
-  debug("'settings.url.pathname': {0}".format(appUrl.pathname));
+  debug(formatString("'settings.url.protocol': {0}", appUrl.protocol));
+  debug(formatString("'settings.url.pathname': {0}", appUrl.pathname));
   debug("'mainWindow' object: %o", mainWindow);
 
   /*
@@ -193,7 +194,7 @@ function startup() {
   } = settings;
 
   debug('Doing startup checks');
-  debug("'settings.startup.developerTools': {0}".format(startup.developerTools));
+  debug(formatString("'settings.startup.developerTools': {0}", startup.developerTools));
   if (startup.developerTools) mainWindow.webContents.toggleDevTools();
 
   return;

--- a/app/ts/main/bw.ts
+++ b/app/ts/main/bw.ts
@@ -17,4 +17,3 @@ require('./bw/fileinput'); // File input
 require('./bw/wordlistinput'); // Wordlist input
 require('./bw/process'); // Process stage
 require('./bw/export'); // Export stage
-require('../common/stringformat'); // String format

--- a/app/ts/main/bw/fileinput.ts
+++ b/app/ts/main/bw/fileinput.ts
@@ -10,6 +10,7 @@ const {
   ipcMain,
   dialog
 } = electron;
+const { formatString } = require('../../common/stringformat');
 
 const settings = require('../../common/settings').load();
 
@@ -31,7 +32,7 @@ ipcMain.on('bw:input.file', function(event) {
     sender
   } = event;
 
-  debug("Using selected file at {0}".format(filePath));
+  debug(formatString('Using selected file at {0}', filePath));
   sender.send('bw:fileinput.confirmation', filePath);
 });
 
@@ -56,6 +57,6 @@ ipcMain.on('ondragstart', function(event, filePath) {
     icon: appWindow.icon
   });
   
-  debug('File drag filepath: {0}'.format(filePath));
+  debug(formatString('File drag filepath: {0}', filePath));
   sender.send('bw:fileinput.confirmation', filePath, true);
 });

--- a/app/ts/main/bw/process.ts
+++ b/app/ts/main/bw/process.ts
@@ -26,6 +26,7 @@ const {
   dialog,
   remote
 } = electron;
+const { formatString } = require('../../common/stringformat');
 
 const defaultValue = null; // Changing this implies changing all dependant comparisons
 let bulkWhois; // BulkWhois object
@@ -101,7 +102,7 @@ ipcMain.on('bw:lookup', function(event, domains, tlds) {
     domainSetup.domain = domainsPending[domain];
     domainSetup.index = domain;
 
-    debug("Using timebetween, {0}, follow, {1}, timeout, {2}".format(domainSetup.timebetween, domainSetup.follow, domainSetup.timeout));
+    debug(formatString('Using timebetween, {0}, follow, {1}, timeout, {2}', domainSetup.timebetween, domainSetup.follow, domainSetup.timeout));
 
     processDomain(domainSetup, event);
 
@@ -148,7 +149,7 @@ ipcMain.on('bw:lookup.pause', function(event) {
 
   // Go through all queued domain lookups and delete setTimeouts for remaining domains
   for (let j = stats.domains.sent; j < stats.domains.processed; j++) {
-    debug('Stopping whois request {0} with id {1}'.format(j, processingIDs[j]));
+    debug(formatString('Stopping whois request {0} with id {1}', j, processingIDs[j]));
     clearTimeout(processingIDs[j]);
   }
 });
@@ -270,7 +271,7 @@ ipcMain.on('bw:lookup.stop', function(event) {
     event (object) - renderer object
  */
 function processDomain(domainSetup, event) {
-  debug("Domain: {0}, id/index: {1}, timebetween: {2}".format(domainSetup.domain, domainSetup.index, domainSetup.timebetween));
+  debug(formatString('Domain: {0}, id/index: {1}, timebetween: {2}', domainSetup.domain, domainSetup.index, domainSetup.timebetween));
 
   // bulkWhois section
   const {
@@ -309,7 +310,7 @@ function processDomain(domainSetup, event) {
 
     reqtime[domainSetup.index] = await performance.now();
 
-    debug('Looking up domain: {0}'.format(domainSetup.domain));
+    debug(formatString('Looking up domain: {0}', domainSetup.domain));
 
     try {
       data = (settings['lookup.general'].type == 'whois') ?
@@ -325,7 +326,7 @@ function processDomain(domainSetup, event) {
 
   }, domainSetup.timebetween * (Number(domainSetup.index - stats.domains.sent) + 1)); // End processing domains
 
-  debug("Timebetween: {0}".format((domainSetup.timebetween * (Number(domainSetup.index - stats.domains.sent) + 1))));
+  debug(formatString('Timebetween: {0}', (domainSetup.timebetween * (Number(domainSetup.index - stats.domains.sent) + 1))));
 
 
   // Self executing function hack to do whois lookup PROBLEM HERE
@@ -433,7 +434,7 @@ function processData(event, domain, index, data = null, isError = false) {
     }
   })();
 
-  debug('Average request time {0}ms'.format(reqtimes.average));
+  debug(formatString('Average request time {0}ms', reqtimes.average));
 
   sender.send('bw:status.update', 'reqtimes.average', reqtimes.average);
   //sender.send('bulkwhois:results', domain, data);
@@ -544,9 +545,9 @@ function getDomainSetup(isRandom) {
   }
   */
 
-  debug("Time between requests, 'israndom': {0}, 'timebetweenmax': {1}, 'timebetweenmin': {2}, 'timebetween': {3}".format(isRandom, settings['lookup.randomize.timeBetween'].maximum, settings['lookup.randomize.timeBetween'].minimum, settings['lookup.general'].timeBetween));
-  debug("Follow depth, 'israndom': {0}, 'followmax': {1}, 'followmin': {2}, 'follow': {3}".format(isRandom, settings['lookup.randomize.follow'].maximum, settings['lookup.randomize.follow'].minimum, settings['lookup.general'].follow));
-  debug("Request timeout, 'israndom': {0}, 'timeoutmax': {1}, 'timeoutmin': {2}, 'timeout': {3}".format(isRandom, settings['lookup.randomize.timeout'].maximum, settings['lookup.randomize.timeout'].minimum, settings['lookup.general'].timeout));
+  debug(formatString("Time between requests, 'israndom': {0}, 'timebetweenmax': {1}, 'timebetweenmin': {2}, 'timebetween': {3}", isRandom, settings['lookup.randomize.timeBetween'].maximum, settings['lookup.randomize.timeBetween'].minimum, settings['lookup.general'].timeBetween));
+  debug(formatString("Follow depth, 'israndom': {0}, 'followmax': {1}, 'followmin': {2}, 'follow': {3}", isRandom, settings['lookup.randomize.follow'].maximum, settings['lookup.randomize.follow'].minimum, settings['lookup.general'].follow));
+  debug(formatString("Request timeout, 'israndom': {0}, 'timeoutmax': {1}, 'timeoutmin': {2}, 'timeout': {3}", isRandom, settings['lookup.randomize.timeout'].maximum, settings['lookup.randomize.timeout'].minimum, settings['lookup.general'].timeout));
 
   return {
     timebetween: (isRandom.timeBetween ? (Math.floor((Math.random() * settings['lookup.randomize.timeBetween'].maximum) + settings['lookup.randomize.timeBetween'].minimum)) : settings['lookup.general'].timeBetween),
@@ -574,7 +575,7 @@ function getTimeBetween(isRandom = false) {
     timebetweenmin
   } = randomize;
 
-  debug("Time between requests, 'israndom': {0}, 'timebetweenmax': {1}, 'timebetweenmin': {2}, 'timebetween': {3}".format(isRandom, timebetweenmax, timebetweenmin, timebetween));
+  debug(formatString("Time between requests, 'israndom': {0}, 'timebetweenmax': {1}, 'timebetweenmin': {2}, 'timebetween': {3}", isRandom, timebetweenmax, timebetweenmin, timebetween));
   return (isRandom ? (Math.floor((Math.random() * timebetweenmax) + timebetweenmin)) : timebetween);
 }
 
@@ -598,7 +599,7 @@ function getFollowDepth(isRandom = false) {
     followmin
   } = randomize;
 
-  debug("Follow depth, 'israndom': {0}, 'followmax': {1}, 'followmin': {2}, 'follow': {3}".format(isRandom, followmax, followmin, follow));
+  debug(formatString("Follow depth, 'israndom': {0}, 'followmax': {1}, 'followmin': {2}, 'follow': {3}", isRandom, followmax, followmin, follow));
   return (isRandom ? (Math.floor((Math.random() * followmax) + followmin)) : follow);
 }
 
@@ -621,6 +622,6 @@ function getTimeout(isRandom = false) {
     timeoutmin
   } = randomize;
 
-  debug("Request timeout, 'israndom': {0}, 'timeoutmax': {1}, 'timeoutmin': {2}, 'timeout': {3}".format(isRandom, timeoutmax, timeoutmin, timeout));
+  debug(formatString("Request timeout, 'israndom': {0}, 'timeoutmax': {1}, 'timeoutmin': {2}, 'timeout': {3}", isRandom, timeoutmax, timeoutmin, timeout));
   return (isRandom ? (Math.floor((Math.random() * timeoutmax) + timeoutmin)) : timeout);
 }

--- a/app/ts/main/bwa/fileinput.ts
+++ b/app/ts/main/bwa/fileinput.ts
@@ -10,6 +10,7 @@ const {
   ipcMain,
   dialog
 } = electron;
+const { formatString } = require('../../common/stringformat');
 
 /*
   ipcMain.on('bwa:input.file', function(...) {...});
@@ -28,7 +29,7 @@ ipcMain.on('bwa:input.file', function(event) {
     buttonLabel: "Open",
     properties: ['openFile', 'showHiddenFiles']
   });
-  debug("Using selected file at {0}".format(filePath));
+  debug(formatString('Using selected file at {0}', filePath));
   sender.send('bwa:fileinput.confirmation', filePath);
 });
 
@@ -39,7 +40,7 @@ ipcMain.on('ondragstart', function(event, filePath) {
     file: filePath,
     icon: appSettings.window.icon
   });
-  debug('File drag filepath: {0}'.format(filePath));
+  debug(formatString('File drag filepath: {0}', filePath));
   event.sender.send('bwa:fileinput.confirmation', filePath, true);
 });
 */

--- a/app/ts/main/sw.ts
+++ b/app/ts/main/sw.ts
@@ -15,6 +15,7 @@ const {
   remote,
   clipboard
 } = electron;
+const { formatString } = require('../common/stringformat');
 
 const settings = require('../common/settings').load();
 
@@ -65,7 +66,7 @@ function copyToClipboard(event, domain) {
     sender
   } = event;
 
-  debug('Copied {0} to clipboard'.format(domain));
+  debug(formatString('Copied {0} to clipboard', domain));
   clipboard.writeText(domain);
   sender.send('sw:copied');
 
@@ -84,7 +85,7 @@ function openUrl(event, domain) {
     'app.window': appWindow,
   } = settings;
 
-  debug('Opening {0} on a new window'.format(domain));
+  debug(formatString('Opening {0} on a new window', domain));
 
   let hwnd: any = new BrowserWindow({
     frame: true,

--- a/app/ts/renderer.ts
+++ b/app/ts/renderer.ts
@@ -10,6 +10,7 @@ import $ from 'jquery';
 
 import './renderer/index';
 import { loadSettings, Settings } from './common/settings';
+import { formatString } from './common/stringformat';
 
 (window as any).$ = $;
 (window as any).jQuery = $;
@@ -70,16 +71,16 @@ function startup() {
     'app.window.navigation': navigation
   } = settings;
 
-  sendDebug("'navigation.developerTools': {0}".format(String(navigation.developerTools)));
+  sendDebug(formatString("'navigation.developerTools': {0}", String(navigation.developerTools)));
   if (navigation.developerTools) $('#navTabDevtools').removeClass('is-force-hidden');
 
-  sendDebug("'navigation.extendedcollapsed': {0}".format(String(navigation.extendedCollapsed)));
+  sendDebug(formatString("'navigation.extendedcollapsed': {0}", String(navigation.extendedCollapsed)));
   if (navigation.extendedCollapsed) {
     $('#navButtonExpandedmenu').toggleClass('is-active');
     $('.is-specialmenu').toggleClass('is-hidden');
   }
 
-  sendDebug("'navigation.extendedmenu': {0}".format(String(navigation.enableExtendedMenu)));
+  sendDebug(formatString("'navigation.extendedmenu': {0}", String(navigation.enableExtendedMenu)));
   if (navigation.enableExtendedMenu) $('#navButtonExpandedmenu').addClass('is-force-hidden');
 
   return;

--- a/app/ts/renderer/bw/export.ts
+++ b/app/ts/renderer/bw/export.ts
@@ -14,7 +14,7 @@ const {
   setExportOptionsEx
 } = require('./auxiliary');
 
-require('../../common/stringformat');
+const { formatString } = require('../../common/stringformat');
 
 var results, options;
 
@@ -26,7 +26,7 @@ var results, options;
     rcvResults
  */
 ipcRenderer.on('bw:result.receive', function(event, rcvResults) {
-  ipcRenderer.send('app:debug', "Results are ready for export {0}".format(rcvResults));
+  ipcRenderer.send('app:debug', formatString('Results are ready for export {0}', rcvResults));
 
   results = rcvResults;
   //console.log("%o", results);

--- a/app/ts/renderer/bw/fileinput.ts
+++ b/app/ts/renderer/bw/fileinput.ts
@@ -12,7 +12,7 @@ const {
   tableReset
 } = require('./auxiliary');
 
-require('../../common/stringformat');
+const { formatString } = require('../../common/stringformat');
 
 var bwFileContents;
 
@@ -62,9 +62,9 @@ ipcRenderer.on('bw:fileinput.confirmation', async function(event, filePath = nul
       bwFileStats['minestimate'] = conversions.msToHumanTime(bwFileStats['linecount'] * lookup.randomize.timeBetween.minimum);
       bwFileStats['maxestimate'] = conversions.msToHumanTime(bwFileStats['linecount'] * lookup.randomize.timeBetween.maximum);
 
-      $('#bwFileSpanTimebetweenmin').text('{0}ms '.format(lookup.randomize.timeBetween.minimum));
-      $('#bwFileSpanTimebetweenmax').text('/ {0}ms'.format(lookup.randomize.timeBetween.maximum));
-      $('#bwFileTdEstimate').text('{0} to {1}'.format(bwFileStats['minestimate'], bwFileStats['maxestimate']));
+      $('#bwFileSpanTimebetweenmin').text(formatString('{0}ms ', lookup.randomize.timeBetween.minimum));
+      $('#bwFileSpanTimebetweenmax').text(formatString('/ {0}ms', lookup.randomize.timeBetween.maximum));
+      $('#bwFileTdEstimate').text(formatString('{0} to {1}', bwFileStats['minestimate'], bwFileStats['maxestimate']));
     } else {
       bwFileStats['minestimate'] = conversions.msToHumanTime(
         bwFileStats['linecount'] * settings['lookup.general'].timeBetween
@@ -73,7 +73,7 @@ ipcRenderer.on('bw:fileinput.confirmation', async function(event, filePath = nul
       $('#bwFileSpanTimebetweenmin').text(
         settings['lookup.general'].timeBetween + 'ms'
       );
-      $('#bwFileTdEstimate').text('> {0}'.format(bwFileStats['minestimate']));
+      $('#bwFileTdEstimate').text(formatString('> {0}', bwFileStats['minestimate']));
     }
 
 
@@ -87,7 +87,7 @@ ipcRenderer.on('bw:fileinput.confirmation', async function(event, filePath = nul
     $('#bwFileTdName').text(bwFileStats['filename']);
     $('#bwFileTdLastmodified').text(conversions.getDate(bwFileStats['mtime']));
     $('#bwFileTdLastaccess').text(conversions.getDate(bwFileStats['atime']));
-    $('#bwFileTdFilesize').text(bwFileStats['humansize'] + ' ({0} line(s))'.format(bwFileStats['linecount']));
+    $('#bwFileTdFilesize').text(bwFileStats['humansize'] + formatString(' ({0} line(s))', bwFileStats['linecount']));
     $('#bwFileTdFilepreview').text(bwFileStats['filepreview'] + '...');
     //$('#bwTableMaxEstimate').text(bwFileStats['maxestimate']);
     debug('cont:' + bwFileContents);

--- a/app/ts/renderer/bw/process.ts
+++ b/app/ts/renderer/bw/process.ts
@@ -8,7 +8,7 @@ const {
   ipcRenderer
 } = require('electron');
 
-require('../../common/stringformat');
+const { formatString } = require('../../common/stringformat');
 
 /*
 // Receive whois lookup reply
@@ -50,7 +50,7 @@ ipcRenderer.on('bulkwhois:resultreceive', function(event, results) {
     value
  */
 ipcRenderer.on('bw:status.update', function(event, stat, value) {
-  ipcRenderer.send('app:debug', "{0}, value update to {1}".format(stat, value)); // status update
+  ipcRenderer.send('app:debug', formatString('{0}, value update to {1}', stat, value)); // status update
   var percent;
   switch (stat) {
     case 'start':
@@ -62,57 +62,57 @@ ipcRenderer.on('bw:status.update', function(event, stat, value) {
       break;
     case 'domains.processed': // processed domains
       percent = parseFloat((value / parseInt($('#bwProcessingSpanTotal').text(), base) * 100).toFixed(1)) || 0;
-      $('#bwProcessingSpanProcessed').text('{0} ({1}%)'.format(value, percent));
+      $('#bwProcessingSpanProcessed').text(formatString('{0} ({1}%)', value, percent));
       break;
     case 'domains.waiting': // whois requests waiting reply
       percent = parseFloat((value / parseInt($('#bwProcessingSpanSent').text(), base) * 100).toFixed(1)) || 0;
-      $('#bwProcessingSpanWaiting').text('{0} ({1}%)'.format(value, percent));
+      $('#bwProcessingSpanWaiting').text(formatString('{0} ({1}%)', value, percent));
       break;
     case 'domains.sent': // sent whois requests
       percent = parseFloat((value / parseInt($('#bwProcessingSpanTotal').text(), base) * 100).toFixed(1)) || 0;
-      $('#bwProcessingSpanSent').text('{0} ({1}%)'.format(value, percent));
+      $('#bwProcessingSpanSent').text(formatString('{0} ({1}%)', value, percent));
       break;
     case 'domains.total': // total domains
       $('#bwProcessingSpanTotal').text(value);
       break;
     case 'time.current': // current time
-      $('#bwProcessingSpanTimecurrent').text('{0}'.format(value));
+      $('#bwProcessingSpanTimecurrent').text(formatString('{0}', value));
       break;
     case 'time.remaining': // remaining time
-      $('#bwProcessingSpanTimeremaining').text('{0}'.format(value));
+      $('#bwProcessingSpanTimeremaining').text(formatString('{0}', value));
       break;
     case 'reqtimes.maximum': // maximum request reply time
-      $('#bwProcessingSpanReqtimemax').text('{0}ms'.format(value));
+      $('#bwProcessingSpanReqtimemax').text(formatString('{0}ms', value));
       break;
     case 'reqtimes.minimum': // minimum request reply time
-      $('#bwProcessingSpanReqtimemin').text('{0}ms'.format(value));
+      $('#bwProcessingSpanReqtimemin').text(formatString('{0}ms', value));
       break;
     case 'reqtimes.last': // last request reply time
-      $('#bwProcessingSpanReqtimelast').text('{0}ms'.format(value));
+      $('#bwProcessingSpanReqtimelast').text(formatString('{0}ms', value));
       break;
     case 'reqtimes.average': // Average request reply time
-      $('#bwProcessingSpanReqtimeavg').text('{0}ms'.format(value));
+      $('#bwProcessingSpanReqtimeavg').text(formatString('{0}ms', value));
       break;
     case 'status.available': // Domains available
       percent = parseFloat((value / parseInt($('#bwProcessingSpanTotal').text(), base) * 100).toFixed(1)) || 0;
-      $('#bwProcessingSpanStatusavailable').text('{0} ({1}%)'.format(value, percent));
+      $('#bwProcessingSpanStatusavailable').text(formatString('{0} ({1}%)', value, percent));
       break;
     case 'status.unavailable': // Domains unavailable
       percent = parseFloat((value / parseInt($('#bwProcessingSpanTotal').text(), base) * 100).toFixed(1)) || 0;
-      $('#bwProcessingSpanStatusunavailable').text('{0} ({1}%)'.format(value, percent));
+      $('#bwProcessingSpanStatusunavailable').text(formatString('{0} ({1}%)', value, percent));
       break;
     case 'status.error': // Domains error
       percent = parseFloat((value / parseInt($('#bwProcessingSpanTotal').text(), base) * 100).toFixed(1)) || 0;
-      $('#bwProcessingSpanStatuserror').text('{0} ({1}%)'.format(value, percent));
+      $('#bwProcessingSpanStatuserror').text(formatString('{0} ({1}%)', value, percent));
       break;
     case 'laststatus.available': // Last available domain
-      $('#bwProcessingSpanLaststatusavailable').text('{0}'.format(value));
+      $('#bwProcessingSpanLaststatusavailable').text(formatString('{0}', value));
       break;
     case 'laststatus.unavailable': // Last unavailable domain
-      $('#bwProcessingSpanLaststatusunavailable').text('{0}'.format(value));
+      $('#bwProcessingSpanLaststatusunavailable').text(formatString('{0}', value));
       break;
     case 'laststatus.error': // Last error domain
-      $('#bwProcessingSpanLaststatuserror').text('{0}'.format(value));
+      $('#bwProcessingSpanLaststatuserror').text(formatString('{0}', value));
       break;
     case 'finished': // Finished
       $('#bwProcessingButtonPause').addClass('is-hidden');

--- a/app/ts/renderer/bw/wordlistinput.ts
+++ b/app/ts/renderer/bw/wordlistinput.ts
@@ -10,7 +10,7 @@ const {
   tableReset
 } = require('./auxiliary');
 
-require('../../common/stringformat');
+const { formatString } = require('../../common/stringformat');
 
 var bwWordlistContents; // Global wordlist input contents
 
@@ -33,14 +33,14 @@ ipcRenderer.on('bw:wordlistinput.confirmation', function() {
     if (settings['lookup.randomize.timeBetween'].randomize === true) {
       bwFileStats['minestimate'] = conversions.msToHumanTime(bwFileStats['linecount'] * settings['lookup.randomize.timeBetween'].minimum);
       bwFileStats['maxestimate'] = conversions.msToHumanTime(bwFileStats['linecount'] * settings['lookup.randomize.timeBetween'].maximum);
-      $('#bwWordlistSpanTimebetweenmin').text('{0}ms '.format(settings['lookup.randomize.timeBetween'].minimum));
-      $('#bwWordlistSpanTimebetweenmax').text('/ {0}ms'.format(settings['lookup.randomize.timeBetween'].maximum));
-      $('#bwWordlistTdEstimate').text('{0} to {1}'.format(bwFileStats['minestimate'], bwFileStats['maxestimate']));
+      $('#bwWordlistSpanTimebetweenmin').text(formatString('{0}ms ', settings['lookup.randomize.timeBetween'].minimum));
+      $('#bwWordlistSpanTimebetweenmax').text(formatString('/ {0}ms', settings['lookup.randomize.timeBetween'].maximum));
+      $('#bwWordlistTdEstimate').text(formatString('{0} to {1}', bwFileStats['minestimate'], bwFileStats['maxestimate']));
     } else {
       bwFileStats['minestimate'] = conversions.msToHumanTime(bwFileStats['linecount'] * settings['lookup.general'].timeBetween);
       $('#bwWordlistSpanTimebetweenminmax').addClass('is-hidden');
       $('#bwWordlistSpanTimebetweenmin').text(settings['lookup.general'].timeBetween + 'ms');
-      $('#bwWordlistTdEstimate').text('> {0}'.format(bwFileStats['minestimate']));
+      $('#bwWordlistTdEstimate').text(formatString('> {0}', bwFileStats['minestimate']));
     }
 
     bwFileStats['filepreview'] = bwWordlistContents.toString().substring(0, 50);
@@ -52,7 +52,7 @@ ipcRenderer.on('bw:wordlistinput.confirmation', function() {
     $('#bwWordlistconfirm').removeClass('is-hidden');
 
     // stats
-    $('#bwWordlistTdDomains').text('{0} line(s)'.format(bwFileStats['linecount']));
+    $('#bwWordlistTdDomains').text(formatString('{0} line(s)', bwFileStats['linecount']));
     $('#bwWordlistTdFilepreview').text(bwFileStats['filepreview'] + '...');
   }
 

--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -11,6 +11,8 @@ const {
   ipcRenderer
 } = require('electron');
 
+const { formatString } = require('../../common/stringformat');
+
 var bwaFileContents;
 
 /*
@@ -73,7 +75,7 @@ function showTable() {
   // Generate header column content
   header.content = '<tr>\n';
   for (var column in header.columns) {
-    header.content += '\t<th><abbr title="{0}">{1}</abbr></th>\n'.format(header.columns[column], getInitials(header.columns[column]));
+    header.content += formatString('\t<th><abbr title="{0}">{1}</abbr></th>\n', header.columns[column], getInitials(header.columns[column]));
   }
   header.content += '</tr>';
 
@@ -85,7 +87,7 @@ function showTable() {
     body.content += '<tr>\n';
 
     for (var field in body.records[record]) {
-      body.content += '\t<td>{0}</td>\n'.format(body.records[record][field]);
+      body.content += formatString('\t<td>{0}</td>\n', body.records[record][field]);
     }
     body.content += '</tr>\n';
   }

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -12,7 +12,7 @@ const {
   ipcRenderer
 } = require('electron');
 
-require('../../common/stringformat');
+const { formatString } = require('../../common/stringformat');
 
 var bwaFileContents;
 
@@ -73,7 +73,7 @@ ipcRenderer.on('bwa:fileinput.confirmation', function(event, filePath = null, is
     $('#bwaFileTdFilename').text(bwaFileStats['filename']);
     $('#bwaFileTdLastmodified').text(conversions.getDate(bwaFileStats['mtime']));
     $('#bwaFileTdLastaccessed').text(conversions.getDate(bwaFileStats['atime']));
-    $('#bwaFileTdFilesize').text(bwaFileStats['humansize'] + ' ({0} record(s))'.format(bwaFileStats['linecount']));
+    $('#bwaFileTdFilesize').text(bwaFileStats['humansize'] + formatString(' ({0} record(s))', bwaFileStats['linecount']));
     $('#bwaFileTdFilepreview').text(bwaFileStats['filepreview'] + '...');
     $('#bwaFileTextareaErrors').text(bwaFileStats['errors'] || "No errors");
     //$('#bwTableMaxEstimate').text(bwFileStats['maxestimate']);

--- a/app/ts/renderer/navigation.ts
+++ b/app/ts/renderer/navigation.ts
@@ -1,4 +1,5 @@
 // jshint esversion: 8
+const { formatString } = require('../common/stringformat');
 
 /*
   $(document).on('drop', function(...) {...});
@@ -50,7 +51,7 @@ $(document).on('click', 'section.tabs ul li', function() {
     $(this).addClass('is-active');
     $("#" + tabName).addClass('current');
   }
-  ipcRenderer.send('app:debug', "#section.tabs switched to data tab, {0}".format(tabName));
+  ipcRenderer.send('app:debug', formatString('#section.tabs switched to data tab, {0}', tabName));
 
   return;
 });
@@ -74,7 +75,7 @@ $(document).on('click', '.delete', function() {
  */
 $(document).keyup(function(event) {
   if (event.keyCode === 27) {
-    ipcRenderer.send('app:debug', "Hotkey, Used [ESC] key, {0}".format(event.keyCode));
+    ipcRenderer.send('app:debug', formatString('Hotkey, Used [ESC] key, {0}', event.keyCode));
     switch (true) {
 
       // Single whois tab is active

--- a/app/ts/renderer/sw.ts
+++ b/app/ts/renderer/sw.ts
@@ -8,6 +8,7 @@ const {
 } = require('../common/conversions'), {
   ipcRenderer
 } = require('electron');
+const { formatString } = require('../common/stringformat');
 
 const {
   isDomainAvailable,
@@ -83,10 +84,10 @@ ipcRenderer.on('sw:results', function(event, domainResults) {
     default:
       if (domainStatus.includes('error')) {
         errorReason = domainStatus.split(':')[1]; // Get Error reason
-        $('#swMessageWhoisResults').text("Whois error due to {0}:\n{1}".format(errorReason, domainResults));
+        $('#swMessageWhoisResults').text(formatString('Whois error due to {0}:\n{1}', errorReason, domainResults));
         $('#swMessageError').removeClass('is-hidden');
       } else {
-        $('#swMessageWhoisResults').text("Whois default error\n{0}".format(domainResults));
+        $('#swMessageWhoisResults').text(formatString('Whois default error\n{0}', domainResults));
         $('#swMessageError').removeClass('is-hidden');
       }
       break;
@@ -149,7 +150,7 @@ $(document).on('click', '#swSearchButtonSearch', function() {
 
   domain = $('#swSearchInputDomain').val();
 
-  ipcRenderer.send('app:debug', "Looking up for {0}".format(domain));
+ipcRenderer.send('app:debug', formatString('Looking up for {0}', domain));
 
   $('#swSearchButtonSearch').addClass('is-loading');
   $('#swSearchInputDomain').attr('readonly', '');

--- a/test/stringformat.test.ts
+++ b/test/stringformat.test.ts
@@ -1,15 +1,15 @@
-require('../app/ts/common/stringformat');
+const { formatString } = require('../app/ts/common/stringformat');
 
 describe('stringformat', () => {
   test('replaces numbered placeholders', () => {
-    expect('Hello {0} {1}'.format('a', 'b')).toBe('Hello a b');
+    expect(formatString('Hello {0} {1}', 'a', 'b')).toBe('Hello a b');
   });
 
   test('handles repeated placeholders', () => {
-    expect('Repeat {0} {0}'.format('x')).toBe('Repeat x x');
+    expect(formatString('Repeat {0} {0}', 'x')).toBe('Repeat x x');
   });
 
   test('leaves unused placeholders unchanged', () => {
-    expect('Unused {2} {0}'.format('a')).toBe('Unused {2} a');
+    expect(formatString('Unused {2} {0}', 'a')).toBe('Unused {2} a');
   });
 });

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -89,9 +89,6 @@ declare module 'html-entities' {
   }
 }
 
-interface String {
-  format(...args: any[]): string;
-}
 
 declare const $: any;
 declare const ipcRenderer: any;


### PR DESCRIPTION
## Summary
- create `formatString` util and export it
- remove `String.prototype` augmentation and update typings
- switch all `.format` usage to the helper
- adjust tests for the new helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858ac5b3cdc83259adb3c7d01297fd7