### PR TITLE
Improve prebuild dependency check

### DIFF
--- a/prebuild.js
+++ b/prebuild.js
@@ -1,9 +1,19 @@
 const fs = require('fs');
 const path = require('path');
+const { spawnSync } = require('child_process');
 
 const modulesPath = path.join(__dirname, 'node_modules');
+
 if (!fs.existsSync(modulesPath)) {
-  console.error('Dependencies not installed. Run "npm install" before building.');
-  process.exit(1);
+  console.log('node_modules not found. Running "npm install" to install dependencies...');
+  const result = spawnSync('npm', ['install'], { stdio: 'inherit', shell: true });
+
+  if (result.error || result.status !== 0) {
+    console.error('\nFailed to automatically install dependencies.');
+    console.error('Please run "npm install" manually before building.');
+    process.exit(result.status || 1);
+  }
+
+  console.log('\nDependencies installed successfully. Continuing build...');
 }
 


### PR DESCRIPTION
## Summary
- automatically run `npm install` in `prebuild.js` if `node_modules` is missing
- provide more helpful console output when dependencies are missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858ac9f04d08325a78475e9100c2978