### PR TITLE
Centralize electron mocks for tests

### DIFF
--- a/test/convertDomain.test.ts
+++ b/test/convertDomain.test.ts
@@ -1,7 +1,4 @@
-jest.mock('electron', () => ({
-  app: undefined,
-  remote: { app: { getPath: jest.fn().mockReturnValue('') } }
-}));
+import '../test/electronMock';
 
 import { convertDomain } from '../app/ts/common/whoiswrapper';
 import { settings } from '../app/ts/common/settings';

--- a/test/dnsLookup.test.ts
+++ b/test/dnsLookup.test.ts
@@ -1,7 +1,4 @@
-jest.mock('electron', () => ({
-  app: undefined,
-  remote: { app: { getPath: jest.fn().mockReturnValue('') } }
-}));
+import '../test/electronMock';
 
 import dns from 'dns/promises';
 import { nsLookup, hasNsServers, isDomainAvailable } from '../app/ts/common/dnsLookup';

--- a/test/electronMock.ts
+++ b/test/electronMock.ts
@@ -1,0 +1,9 @@
+export const mockGetPath = jest.fn().mockReturnValue('');
+export const mockIpcSend = jest.fn();
+
+jest.mock('electron', () => ({
+  ipcRenderer: { send: mockIpcSend },
+  dialog: {},
+  app: undefined,
+  remote: { app: { getPath: mockGetPath } }
+}));

--- a/test/isDomainAvailable.test.ts
+++ b/test/isDomainAvailable.test.ts
@@ -1,7 +1,4 @@
-jest.mock('electron', () => ({
-  app: undefined,
-  remote: { app: { getPath: jest.fn().mockReturnValue('') } }
-}));
+import '../test/electronMock';
 
 import { isDomainAvailable } from '../app/ts/common/whoiswrapper';
 

--- a/test/jqueryAvailability.test.ts
+++ b/test/jqueryAvailability.test.ts
@@ -1,9 +1,6 @@
 /** @jest-environment jsdom */
 
-jest.mock('electron', () => ({
-  ipcRenderer: { send: jest.fn() },
-  dialog: {}
-}));
+import '../test/electronMock';
 
 jest.mock('@electron/remote', () => ({
   app: { getPath: jest.fn(() => '') }

--- a/test/patterns.test.ts
+++ b/test/patterns.test.ts
@@ -1,7 +1,4 @@
-jest.mock('electron', () => ({
-  app: undefined,
-  remote: { app: { getPath: jest.fn().mockReturnValue('') } }
-}));
+import '../test/electronMock';
 
 import { buildPatterns, checkPatterns } from '../app/ts/common/whoiswrapper/patterns';
 import { builtPatterns } from '../app/ts/common/whoiswrapper/patterns';

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -1,12 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-
-const mockGetPath = jest.fn();
-
-jest.mock('electron', () => ({
-  app: undefined,
-  remote: { app: { getPath: mockGetPath } }
-}));
+import { mockGetPath } from '../test/electronMock';
 
 import { loadSettings, settings } from '../app/ts/common/settings';
 

--- a/test/whoiswrapper.test.ts
+++ b/test/whoiswrapper.test.ts
@@ -1,7 +1,4 @@
-jest.mock('electron', () => ({
-  app: undefined,
-  remote: { app: { getPath: jest.fn().mockReturnValue('') } }
-}));
+import '../test/electronMock';
 
 import whois from 'whois';
 import { lookup, toJSON } from '../app/ts/common/whoiswrapper';


### PR DESCRIPTION
## Summary
- create a single mock helper for electron APIs
- import the helper in tests instead of repeating jest.mock blocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858ad07695083259b7ebea3f9721aa0