### PR TITLE
Refactor remote access

### DIFF
--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -3,13 +3,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as electron from 'electron';
-let remote: typeof import('@electron/remote') | undefined;
-try {
-  // Dynamically require to avoid issues when Electron bindings are unavailable
-  remote = require('@electron/remote');
-} catch {
-  remote = (electron as any).remote;
-}
+import * as remote from '@electron/remote';
 const { app } = electron;
 import debugModule from 'debug';
 const debug = debugModule('common.settings');
@@ -64,7 +58,7 @@ const isMainProcess = ((): boolean => {
 
 const userDataPath = isMainProcess
   ? app.getPath('userData')
-  : remote?.app?.getPath('userData') ?? '';
+  : remote && remote.app ? remote.app.getPath('userData') || '' : '';
 
 function getUserDataPath(): string {
   return userDataPath;
@@ -72,7 +66,7 @@ function getUserDataPath(): string {
 const filePath = isMainProcess
   ? path.join(app.getPath('userData'), settings['custom.configuration'].filepath)
   : path.join(
-      remote?.app?.getPath('userData') ?? '',
+      remote && remote.app ? remote.app.getPath('userData') || '' : '',
       settings['custom.configuration'].filepath
     );
 

--- a/app/ts/renderer.ts
+++ b/app/ts/renderer.ts
@@ -43,7 +43,7 @@ $(document).ready(function() {
   // Load custom configuration at startup
 
   const configPath = path.join(
-    remote.app.getPath('userData'),
+    remote && remote.app ? remote.app.getPath('userData') : '',
     configuration.filepath
   );
   if (fs.existsSync(configPath)) {

--- a/test/convertDomain.test.ts
+++ b/test/convertDomain.test.ts
@@ -2,6 +2,9 @@ jest.mock('electron', () => ({
   app: undefined,
   remote: { app: { getPath: jest.fn().mockReturnValue('') } }
 }));
+jest.mock('@electron/remote', () => ({
+  app: { getPath: jest.fn().mockReturnValue('') }
+}));
 
 import { convertDomain } from '../app/ts/common/whoiswrapper';
 import { settings } from '../app/ts/common/settings';

--- a/test/dnsLookup.test.ts
+++ b/test/dnsLookup.test.ts
@@ -2,6 +2,9 @@ jest.mock('electron', () => ({
   app: undefined,
   remote: { app: { getPath: jest.fn().mockReturnValue('') } }
 }));
+jest.mock('@electron/remote', () => ({
+  app: { getPath: jest.fn().mockReturnValue('') }
+}));
 
 import dns from 'dns/promises';
 import { nsLookup, hasNsServers, isDomainAvailable } from '../app/ts/common/dnsLookup';

--- a/test/isDomainAvailable.test.ts
+++ b/test/isDomainAvailable.test.ts
@@ -2,6 +2,9 @@ jest.mock('electron', () => ({
   app: undefined,
   remote: { app: { getPath: jest.fn().mockReturnValue('') } }
 }));
+jest.mock('@electron/remote', () => ({
+  app: { getPath: jest.fn().mockReturnValue('') }
+}));
 
 import { isDomainAvailable } from '../app/ts/common/whoiswrapper';
 

--- a/test/patterns.test.ts
+++ b/test/patterns.test.ts
@@ -2,6 +2,9 @@ jest.mock('electron', () => ({
   app: undefined,
   remote: { app: { getPath: jest.fn().mockReturnValue('') } }
 }));
+jest.mock('@electron/remote', () => ({
+  app: { getPath: jest.fn().mockReturnValue('') }
+}));
 
 import { buildPatterns, checkPatterns } from '../app/ts/common/whoiswrapper/patterns';
 import { builtPatterns } from '../app/ts/common/whoiswrapper/patterns';

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -7,6 +7,9 @@ jest.mock('electron', () => ({
   app: undefined,
   remote: { app: { getPath: mockGetPath } }
 }));
+jest.mock('@electron/remote', () => ({
+  app: { getPath: mockGetPath }
+}));
 
 import { loadSettings, settings } from '../app/ts/common/settings';
 

--- a/test/whoiswrapper.test.ts
+++ b/test/whoiswrapper.test.ts
@@ -2,6 +2,9 @@ jest.mock('electron', () => ({
   app: undefined,
   remote: { app: { getPath: jest.fn().mockReturnValue('') } }
 }));
+jest.mock('@electron/remote', () => ({
+  app: { getPath: jest.fn().mockReturnValue('') }
+}));
 
 import whois from 'whois';
 import { lookup, toJSON } from '../app/ts/common/whoiswrapper';


### PR DESCRIPTION
## Summary
- switch settings to static import of `@electron/remote`
- guard use of Electron remote features
- adapt renderer to guard remote usage
- update unit tests for new import

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6858ac6986dc83259fc4a297c49ce9d1