### PR TITLE
Add asset watcher for dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build": "tsc",
     "postbuild": "node postbuild.js",
     "watch": "tsc -w",
-    "dev": "concurrently \"npm:watch\" \"electronmon .\"",
+    "watch-assets": "node watch-assets.js",
+    "dev": "concurrently \"npm:watch\" \"npm:watch-assets\" \"electronmon .\"",
     "lint": "eslint \"app/**/*.ts\" \"test/**/*.ts\"",
     "test": "jest",
     "prebuild": "node prebuild.js"

--- a/readme.md
+++ b/readme.md
@@ -158,7 +158,7 @@ Errors during bulk lookups are pretty common due to sheer request volume, this m
 
 Run `npm install` to download all runtime and development dependencies.
 Development packages such as `@types/node` and `@types/jest` are required for TypeScript compilation and running tests. A `prebuild` script in `package.json` checks for `node_modules` and aborts if dependencies are missing.
-Use `npm run dev` to watch source files and automatically reload the application during development.
+Use `npm run dev` to watch source files and automatically reload the application during development. Static assets such as stylesheets are synced to `dist` while this command runs, so CSS changes are picked up without rebuilding.
 
 
 ## Settings

--- a/watch-assets.js
+++ b/watch-assets.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const path = require('path');
+const watchboy = require('watchboy');
+
+const folders = ['html', 'css', 'fonts', 'icons'];
+const appDir = path.join(__dirname, 'app');
+const distDir = path.join(__dirname, 'dist', 'app');
+
+function copyRecursiveSync(src, dest) {
+  const stat = fs.statSync(src);
+  if (stat.isDirectory()) {
+    fs.mkdirSync(dest, { recursive: true });
+    for (const entry of fs.readdirSync(src)) {
+      const srcPath = path.join(src, entry);
+      const destPath = path.join(dest, entry);
+      copyRecursiveSync(srcPath, destPath);
+    }
+  } else {
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(src, dest);
+  }
+}
+
+function copyFile(src) {
+  const rel = path.relative(appDir, src);
+  if (rel.startsWith('..')) return; // ignore changes outside app dir
+  const dest = path.join(distDir, rel);
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.copyFileSync(src, dest);
+  console.log(`[watch-assets] copied ${rel}`);
+}
+
+for (const folder of folders) {
+  const src = path.join(appDir, folder);
+  const dest = path.join(distDir, folder);
+  copyRecursiveSync(src, dest);
+}
+
+const patterns = folders.map(f => `app/${f}/**/*`);
+const watcher = watchboy(patterns, { cwd: __dirname });
+
+watcher.on('add', ({ path: p }) => copyFile(p));
+watcher.on('change', ({ path: p }) => copyFile(p));
+
+watcher.on('ready', () => console.log('[watch-assets] watching assets...'));


### PR DESCRIPTION
## Summary
- keep CSS and other static files in sync while running `npm run dev`
- document asset sync behaviour in readme

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859746f98b48325b5a4b583dc85e8a8