### PR TITLE
Refactor copy helper

### DIFF
--- a/postbuild.js
+++ b/postbuild.js
@@ -1,23 +1,10 @@
 const fs = require('fs');
 const path = require('path');
+const { copyRecursiveSync } = require('./scripts/copyRecursive');
 
 const folders = ['html', 'css', 'fonts', 'icons'];
 const appDir = path.join(__dirname, 'app');
 const distDir = path.join(__dirname, 'dist', 'app');
-
-function copyRecursiveSync(src, dest) {
-  const stat = fs.statSync(src);
-  if (stat.isDirectory()) {
-    fs.mkdirSync(dest, { recursive: true });
-    for (const entry of fs.readdirSync(src)) {
-      const srcPath = path.join(src, entry);
-      const destPath = path.join(dest, entry);
-      copyRecursiveSync(srcPath, destPath);
-    }
-  } else {
-    fs.copyFileSync(src, dest);
-  }
-}
 
 for (const folder of folders) {
   const src = path.join(appDir, folder);

--- a/scripts/copyRecursive.js
+++ b/scripts/copyRecursive.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+
+function copyRecursiveSync(src, dest) {
+  const stat = fs.statSync(src);
+  if (stat.isDirectory()) {
+    fs.mkdirSync(dest, { recursive: true });
+    for (const entry of fs.readdirSync(src)) {
+      const srcPath = path.join(src, entry);
+      const destPath = path.join(dest, entry);
+      copyRecursiveSync(srcPath, destPath);
+    }
+  } else {
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(src, dest);
+  }
+}
+
+module.exports = { copyRecursiveSync };

--- a/watch-assets.js
+++ b/watch-assets.js
@@ -1,25 +1,11 @@
 const fs = require('fs');
 const path = require('path');
 const watchboy = require('watchboy');
+const { copyRecursiveSync } = require('./scripts/copyRecursive');
 
 const folders = ['html', 'css', 'fonts', 'icons'];
 const appDir = path.join(__dirname, 'app');
 const distDir = path.join(__dirname, 'dist', 'app');
-
-function copyRecursiveSync(src, dest) {
-  const stat = fs.statSync(src);
-  if (stat.isDirectory()) {
-    fs.mkdirSync(dest, { recursive: true });
-    for (const entry of fs.readdirSync(src)) {
-      const srcPath = path.join(src, entry);
-      const destPath = path.join(dest, entry);
-      copyRecursiveSync(srcPath, destPath);
-    }
-  } else {
-    fs.mkdirSync(path.dirname(dest), { recursive: true });
-    fs.copyFileSync(src, dest);
-  }
-}
 
 function copyFile(src) {
   const rel = path.relative(appDir, src);


### PR DESCRIPTION
## Summary
- centralize `copyRecursiveSync` in `scripts/copyRecursive.js`
- reuse the helper in build scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685983d290a88325a4f361749d6a3140