### PR TITLE
Enhance CI workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,13 +5,14 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [18.x, 20.x, 22.x, 23.x, 24.x]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -20,21 +21,54 @@ jobs:
           cache: 'npm'
       - run: npm install
       - run: npm run lint
+
+  type-check:
+    runs-on: ubuntu-latest
+    needs: lint
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x, 23.x, 24.x]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - run: npm install
+      - run: npx tsc --noEmit
+
+  build:
+    runs-on: ubuntu-latest
+    needs: type-check
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x, 23.x, 24.x]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - run: npm install
       - run: npm test
 
   package:
     needs: build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x, 23.x, 24.x]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - run: npm install
       - run: npm run package-linux
+      - run: mv release_builds release_builds-${{ matrix.node-version }}
       - uses: actions/upload-artifact@v4
         with:
-          name: linux-package
-          path: release_builds
+          name: linux-package-${{ matrix.node-version }}
+          path: release_builds-${{ matrix.node-version }}
 


### PR DESCRIPTION
## Summary
- allow manual execution with workflow_dispatch
- test, lint, and build on Node 18.x, 20.x, 22.x, 23.x, and 24.x
- add separate lint and type-check jobs
- cache node modules
- publish version-specific packages

## Testing
- `npm run lint`
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_685983b9476483258fb4c15d21ddf5dd