### PR TITLE
Improve newline handling in parseRawData

### DIFF
--- a/app/ts/common/parseRawData.ts
+++ b/app/ts/common/parseRawData.ts
@@ -34,8 +34,9 @@ export function parseRawData(rawData: string): Record<string, string> {
         const result: Record<string, string> = {};
 
        rawData = stripHTMLEntities(rawData);
-	rawData = filterColonChar(rawData);
-        const lines = rawData.split('\n');
+        rawData = filterColonChar(rawData);
+        rawData = rawData.replace(/\r\n?/g, '\n');
+        const lines = rawData.split(/\r?\n/);
 
         for (let i = 0; i < lines.length; ++i) {
                 let line = lines[i].trim();

--- a/test/parseRawData.test.ts
+++ b/test/parseRawData.test.ts
@@ -1,8 +1,20 @@
 import parseRawData from '../app/ts/common/parseRawData';
 
 describe('parseRawData', () => {
-  test('parses key value pairs', () => {
+  test('parses key value pairs with LF newlines', () => {
     const raw = 'Domain Name: example.com\nRegistrar: Example';
+    const result = parseRawData(raw);
+    expect(result).toEqual({ domainName: 'example.com', registrar: 'Example' });
+  });
+
+  test('parses key value pairs with CRLF newlines', () => {
+    const raw = 'Domain Name: example.com\r\nRegistrar: Example';
+    const result = parseRawData(raw);
+    expect(result).toEqual({ domainName: 'example.com', registrar: 'Example' });
+  });
+
+  test('parses key value pairs with CR newlines', () => {
+    const raw = 'Domain Name: example.com\rRegistrar: Example';
     const result = parseRawData(raw);
     expect(result).toEqual({ domainName: 'example.com', registrar: 'Example' });
   });


### PR DESCRIPTION
## Summary
- make `parseRawData` normalize CR/LF sequences and split using `/\r?\n/`
- test parsing on LF, CRLF and CR-separated data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859844b8ba8832595d7d6f05dc5cfe2