### PR TITLE
Add export error messaging

### DIFF
--- a/app/html/tabs/bw/bwEntry.html
+++ b/app/html/tabs/bw/bwEntry.html
@@ -14,5 +14,9 @@
         <i class="fas fa-edit"></i>
       </span>
     </a>
-  </div>
+</div>
+</div>
+<div id="bwExportMessageError" class="notification is-danger box-shadow-5 is-hidden">
+  <button data-notif="bwExportMessageError" class="delete"></button>
+  Export failed: <span id="bwExportErrorText"></span>
 </div>

--- a/app/ts/main/bw/export.ts
+++ b/app/ts/main/bw/export.ts
@@ -168,6 +168,7 @@ ipcMain.on('bw:export', async function(event, results, options) {
         debug(formatString('File was saved, {0}', filePath));
       } catch (err) {
         debug(err);
+        sender.send('bw:export.error', (err as Error).message);
       }
     }
 
@@ -182,6 +183,7 @@ ipcMain.on('bw:export', async function(event, results, options) {
           debug(formatString('Zip saved, {0}', filePath + zip));
         } catch (err) {
           debug(formatString('Error, {0}', err));
+          sender.send('bw:export.error', (err as Error).message);
         }
         break;
     }

--- a/app/ts/renderer/bw/export.ts
+++ b/app/ts/renderer/bw/export.ts
@@ -43,6 +43,17 @@ ipcRenderer.on('bw:export.cancel', function() {
 });
 
 /*
+  ipcRenderer.on('bw:export.error', function(...) {...});
+    Bulk whois export error
+ */
+ipcRenderer.on('bw:export.error', function(event, message) {
+  $('#bwExportErrorText').text(message);
+  $('#bwExportMessageError').removeClass('is-hidden');
+
+  return;
+});
+
+/*
   $('#bwExportButtonExport').click(function() {...});
     Bulk whois export confirm
  */

--- a/test/electronMainMock.ts
+++ b/test/electronMainMock.ts
@@ -1,0 +1,24 @@
+import { EventEmitter } from 'events';
+
+export const mockShowSaveDialogSync = jest.fn();
+export const ipcMainHandlers: Record<string, (...args: any[]) => any> = {};
+
+export const ipcMain = {
+  on: jest.fn((channel: string, listener: (...args: any[]) => void) => {
+    ipcMainHandlers[channel] = listener;
+  })
+};
+
+export const app = undefined as any;
+export const BrowserWindow = class {};
+export const Menu = {} as any;
+export const remote = {} as any;
+
+jest.mock('electron', () => ({
+  app,
+  BrowserWindow,
+  Menu,
+  ipcMain,
+  dialog: { showSaveDialogSync: mockShowSaveDialogSync },
+  remote,
+}));

--- a/test/exportError.test.ts
+++ b/test/exportError.test.ts
@@ -1,0 +1,64 @@
+import './electronMainMock';
+import fs from 'fs';
+import { ipcMainHandlers, mockShowSaveDialogSync } from './electronMainMock';
+jest.mock('jszip', () => {
+  const generateAsync = jest.fn().mockResolvedValue('zip');
+  const JSZipMock: any = jest.fn().mockImplementation(() => ({
+    file: jest.fn(),
+    generateAsync,
+  }));
+  JSZipMock.support = { uint8array: false };
+  return { __esModule: true, default: JSZipMock };
+});
+
+import '../app/ts/main/bw/export';
+
+describe('bw export error handling', () => {
+  const results = {
+    id: [1],
+    domain: ['example.com'],
+    status: ['available'],
+    registrar: ['reg'],
+    company: ['comp'],
+    creationdate: ['c'],
+    updatedate: ['u'],
+    expirydate: ['e'],
+    whoisreply: ['reply'],
+    whoisjson: ['json'],
+    requesttime: [1],
+  };
+
+  test('sends error when csv write fails', async () => {
+    const handler = ipcMainHandlers['bw:export'];
+    mockShowSaveDialogSync.mockReturnValue('/tmp/out.csv');
+    jest.spyOn(fs.promises, 'writeFile').mockRejectedValueOnce(new Error('fail'));
+
+    const send = jest.fn();
+    await handler({ sender: { send } } as any, results, {
+      filetype: 'csv',
+      domains: 'available',
+      errors: 'no',
+      information: 'domain',
+      whoisreply: 'no',
+    });
+
+    expect(send).toHaveBeenCalledWith('bw:export.error', 'fail');
+  });
+
+  test('sends error when zip write fails', async () => {
+    const handler = ipcMainHandlers['bw:export'];
+    mockShowSaveDialogSync.mockReturnValue('/tmp/out');
+    jest.spyOn(fs.promises, 'writeFile').mockRejectedValueOnce(new Error('zip fail'));
+
+    const send = jest.fn();
+    await handler({ sender: { send } } as any, results, {
+      filetype: 'txt',
+      domains: 'available',
+      errors: 'no',
+      information: 'domain',
+      whoisreply: 'yes+block',
+    });
+
+    expect(send).toHaveBeenCalledWith('bw:export.error', 'zip fail');
+  });
+});

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -54,6 +54,7 @@ declare module 'electron' {
     'bw:fileinput.confirmation': [string | string[] | null, boolean?];
     'bw:result.receive': [any];
     'bw:export.cancel': [];
+    'bw:export.error': [string];
     'sw:results': [any];
     'sw:copied': [];
   }


### PR DESCRIPTION
## Summary
- notify renderer when export write fails
- show an error notification in the bulk whois UI
- type and test new IPC channel for export errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68598afcac4c8325804dd607f621395c