### PR TITLE
Handle readline errors

### DIFF
--- a/app/ts/common/lineHelper.ts
+++ b/app/ts/common/lineHelper.ts
@@ -52,7 +52,10 @@ export function fileReadLines(filePath: string, lines = 2, startLine = 0): Promi
       resolve(linesRead);
     });
 
-    lineReader.on('error', (err: Error) => reject(err));
+    lineReader.on('error', (err: Error) => {
+      lineReader.close();
+      reject(err);
+    });
   });
 }
 

--- a/test/lineHelper.test.ts
+++ b/test/lineHelper.test.ts
@@ -1,5 +1,7 @@
 import fs from 'fs';
 import path from 'path';
+import readline from 'readline';
+import { EventEmitter } from 'events';
 import { lineCount, fileReadLines } from '../app/ts/common/lineHelper';
 
 describe('lineHelper', () => {
@@ -14,5 +16,25 @@ describe('lineHelper', () => {
     const result = await fileReadLines(tmpPath, 2, 1);
     expect(result).toEqual(['second', 'third']);
     fs.unlinkSync(tmpPath);
+  });
+
+  test('fileReadLines closes reader on error', async () => {
+    const lineEmitter = new EventEmitter() as any;
+    lineEmitter.close = jest.fn();
+    const fsStream = new EventEmitter() as any;
+
+    const fsSpy = jest.spyOn(fs, 'createReadStream').mockReturnValue(fsStream);
+    const rlSpy = jest
+      .spyOn(readline, 'createInterface')
+      .mockReturnValue(lineEmitter);
+
+    const promise = fileReadLines('dummy');
+    lineEmitter.emit('error', new Error('fail'));
+
+    await expect(promise).rejects.toThrow('fail');
+    expect(lineEmitter.close).toHaveBeenCalled();
+
+    fsSpy.mockRestore();
+    rlSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- ensure `fileReadLines` closes the readline interface when an error occurs
- add a test that mocks `readline` and `fs` to cover the error path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685995c727cc8325aa294cb9eb072767