### PR TITLE
Reload settings dynamically

### DIFF
--- a/app/ts/common/dnsLookup.ts
+++ b/app/ts/common/dnsLookup.ts
@@ -3,11 +3,14 @@ import dns from 'dns/promises';
 import psl from 'psl';
 import debugModule from 'debug';
 import { convertDomain } from './lookup';
-import { load, Settings } from './settings';
+import { loadSettings, Settings } from './settings';
 import { DnsLookupError, Result } from './errors';
 
 const debug = debugModule('common.dnsLookup');
-let settings: Settings = load();
+
+function getSettings(): Settings {
+  return loadSettings();
+}
 
 
 /*
@@ -24,7 +27,7 @@ export async function nsLookup(host: string): Promise<string[]> {
   const {
     'lookup.conversion': conversion,
     'lookup.general': general
-  } = settings;
+  } = getSettings();
 
   host = conversion.enabled ? convertDomain(host) : host;
   if (general.psl) {
@@ -59,7 +62,7 @@ export async function hasNsServers(host: string): Promise<Result<boolean, DnsLoo
   const {
     'lookup.conversion': conversion,
     'lookup.general': general
-  } = settings;
+  } = getSettings();
 
   host = conversion.enabled ? convertDomain(host) : host;
   if (general.psl) {

--- a/app/ts/common/lookup.ts
+++ b/app/ts/common/lookup.ts
@@ -3,10 +3,13 @@ import puny from 'punycode';
 import uts46 from 'idna-uts46';
 import whois from 'whois';
 import debugModule from 'debug';
-import { load, Settings } from './settings';
+import { loadSettings, Settings } from './settings';
 
 const debug = debugModule('common.whoisWrapper');
-let settings: Settings = load();
+
+function getSettings(): Settings {
+  return loadSettings();
+}
 
 const lookupPromise = (...args: unknown[]): Promise<string> => {
   return new Promise((resolve, reject) => {
@@ -22,7 +25,7 @@ export async function lookup(domain: string, options = getWhoisOptions()): Promi
   const {
     'lookup.conversion': conversion,
     'lookup.general': general,
-  } = settings;
+  } = getSettings();
   let domainResults: string;
 
   try {
@@ -44,7 +47,7 @@ export async function lookup(domain: string, options = getWhoisOptions()): Promi
 export function convertDomain(domain: string, mode?: string): string {
   const {
     'lookup.conversion': conversion,
-  } = settings;
+  } = getSettings();
 
   mode = mode || conversion.algorithm;
 
@@ -67,7 +70,7 @@ export function convertDomain(domain: string, mode?: string): string {
 export function getWhoisOptions(): Record<string, unknown> {
   const {
     'lookup.general': general,
-  } = settings;
+  } = getSettings();
 
   const options: Record<string, unknown> = {},
     follow = 'follow',
@@ -87,7 +90,7 @@ function getWhoisParameters(parameter: string): number | undefined {
     'lookup.randomize.timeout': timeout,
     'lookup.randomize.timeBetween': timeBetween,
     'lookup.general': general,
-  } = settings;
+  } = getSettings();
 
   switch (parameter) {
     case 'follow':

--- a/test/settingsReload.test.ts
+++ b/test/settingsReload.test.ts
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import path from 'path';
+import '../test/electronMock';
+import dns from 'dns/promises';
+import { mockGetPath } from '../test/electronMock';
+
+import { convertDomain } from '../app/ts/common/lookup';
+import { nsLookup } from '../app/ts/common/dnsLookup';
+import { loadSettings, saveSettings, settings } from '../app/ts/common/settings';
+
+describe('settings reload', () => {
+  test('convertDomain reflects saved settings', () => {
+    const tmpDir = fs.mkdtempSync(path.join(__dirname, 'config'));
+    mockGetPath.mockReturnValue(tmpDir);
+    const originalAlg = settings['lookup.conversion'].algorithm;
+    const configName = 'reload.json';
+    settings['custom.configuration'].filepath = configName;
+
+    const cfg = loadSettings();
+    cfg['lookup.conversion'].algorithm = 'ascii';
+    saveSettings(cfg);
+
+    const result = convertDomain('t\u00E4st.de');
+    expect(result).toBe('tst.de');
+
+    settings['lookup.conversion'].algorithm = originalAlg;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('nsLookup uses updated settings from file', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(__dirname, 'config'));
+    mockGetPath.mockReturnValue(tmpDir);
+    const originalPsl = settings['lookup.general'].psl;
+    const originalPath = settings['custom.configuration'].filepath;
+    const configName = 'dns.json';
+    settings['custom.configuration'].filepath = configName;
+
+    const cfg = loadSettings();
+    cfg['lookup.general'].psl = false;
+    saveSettings(cfg);
+
+    const resolveMock = jest.spyOn(dns, 'resolve').mockResolvedValue([]);
+    await nsLookup('sub.example.com');
+    expect(resolveMock).toHaveBeenCalledWith('sub.example.com', 'NS');
+    resolveMock.mockRestore();
+
+    settings['lookup.general'].psl = originalPsl;
+    settings['custom.configuration'].filepath = originalPath;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- ensure dnsLookup and lookup fetch latest settings
- add regression tests for saving settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685995f473d083258b851161d1149f01