### PR TITLE
Use typed FileStats in renderer

### DIFF
--- a/app/ts/common/fileStats.ts
+++ b/app/ts/common/fileStats.ts
@@ -1,0 +1,11 @@
+import fs from 'fs';
+
+export interface FileStats extends fs.Stats {
+  filename?: string;
+  humansize?: string;
+  linecount?: number;
+  minestimate?: string;
+  maxestimate?: string;
+  filepreview?: string;
+  errors?: string;
+}


### PR DESCRIPTION
## Summary
- add FileStats interface extending `fs.Stats`
- use FileStats in bw/bwa file input modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685995df2b4c8325afd58bc4e0ff57e5