### PR TITLE
Add URL validation for openUrl

### DIFF
--- a/app/ts/main/sw.ts
+++ b/app/ts/main/sw.ts
@@ -87,6 +87,17 @@ function openUrl(event: IpcMainEvent, domain: string): void {
     'app.window': appWindow,
   } = settings;
 
+  let target: URL;
+  try {
+    target = new URL(domain);
+    if (target.protocol !== 'http:' && target.protocol !== 'https:') {
+      throw new Error('invalid protocol');
+    }
+  } catch {
+    console.warn(`Invalid URL: ${domain}`);
+    return;
+  }
+
   debug(formatString('Opening {0} on a new window', domain));
 
   let hwnd: any = new BrowserWindow({

--- a/test/openUrl.test.ts
+++ b/test/openUrl.test.ts
@@ -1,0 +1,52 @@
+const ipcMainHandlers: Record<string, (...args: any[]) => any> = {};
+const loadURLMock = jest.fn();
+const BrowserWindowMock = jest.fn().mockImplementation(() => ({
+  setSkipTaskbar: jest.fn(),
+  setMenu: jest.fn(),
+  loadURL: loadURLMock,
+  on: jest.fn(),
+}));
+
+jest.mock('electron', () => ({
+  ipcMain: {
+    on: (channel: string, listener: (...args: any[]) => void) => {
+      ipcMainHandlers[channel] = listener;
+    },
+  },
+  BrowserWindow: BrowserWindowMock,
+  app: undefined,
+  Menu: {},
+  dialog: { showSaveDialogSync: jest.fn() },
+  remote: {},
+  clipboard: { writeText: jest.fn() },
+}));
+
+import { settings } from '../app/ts/common/settings';
+import '../app/ts/main/sw';
+
+describe('openUrl', () => {
+  beforeEach(() => {
+    BrowserWindowMock.mockClear();
+    loadURLMock.mockClear();
+  });
+
+  test('opens new window for valid http url', () => {
+    settings['lookup.misc'].onlyCopy = false;
+    const handler = ipcMainHandlers['sw:openlink'];
+    handler({ sender: { send: jest.fn() } } as any, 'https://example.com');
+
+    expect(BrowserWindowMock).toHaveBeenCalled();
+    expect(loadURLMock).toHaveBeenCalledWith('https://example.com');
+  });
+
+  test('rejects invalid url', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    settings['lookup.misc'].onlyCopy = false;
+    const handler = ipcMainHandlers['sw:openlink'];
+    handler({ sender: { send: jest.fn() } } as any, 'ftp://example.com');
+
+    expect(BrowserWindowMock).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- validate URLs in `openUrl`
- warn on invalid URLs
- test openUrl with valid and invalid inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859a820e6e48325aa8fd551f3a8ab04