### PR TITLE
fix: propagate bulk export failures

### DIFF
--- a/app/ts/main/bw/export.ts
+++ b/app/ts/main/bw/export.ts
@@ -28,7 +28,7 @@ const settings = loadSettings();
     results (object) - bulk whois results object
     options (object) - bulk whois export options object
  */
-ipcMain.on('bw:export', async function(event, results, options) {
+  ipcMain.handle('bw:export', async function(event, results, options) {
   const {
     'lookup.export': resExports
   } = settings;
@@ -168,7 +168,7 @@ ipcMain.on('bw:export', async function(event, results, options) {
         debug(formatString('File was saved, {0}', filePath));
       } catch (err) {
         debug(err);
-        sender.send('bw:export.error', (err as Error).message);
+        throw err;
       }
     }
 
@@ -183,7 +183,7 @@ ipcMain.on('bw:export', async function(event, results, options) {
           debug(formatString('Zip saved, {0}', filePath + zip));
         } catch (err) {
           debug(formatString('Error, {0}', err));
-          sender.send('bw:export.error', (err as Error).message);
+          throw err;
         }
         break;
     }

--- a/app/ts/renderer/bw/export.ts
+++ b/app/ts/renderer/bw/export.ts
@@ -42,26 +42,21 @@ ipcRenderer.on('bw:export.cancel', function() {
   return;
 });
 
-/*
-  ipcRenderer.on('bw:export.error', function(...) {...});
-    Bulk whois export error
- */
-ipcRenderer.on('bw:export.error', function(event, message) {
-  $('#bwExportErrorText').text(message);
-  $('#bwExportMessageError').removeClass('is-hidden');
-
-  return;
-});
 
 /*
   $('#bwExportButtonExport').click(function() {...});
     Bulk whois export confirm
  */
-$(document).on('click', '#bwExportButtonExport', function() {
+$(document).on('click', '#bwExportButtonExport', async function() {
   $('#bwExport').addClass('is-hidden');
   options = getExportOptions();
-  $.when($('#bwExportloading').removeClass('is-hidden').delay(10)).done(function() {
-    ipcRenderer.send("bw:export", results, options);
+  $.when($('#bwExportloading').removeClass('is-hidden').delay(10)).done(async function() {
+    try {
+      await ipcRenderer.invoke('bw:export', results, options);
+    } catch (err) {
+      $('#bwExportErrorText').text((err as Error).message);
+      $('#bwExportMessageError').removeClass('is-hidden');
+    }
   });
 
   return;

--- a/test/electronMainMock.ts
+++ b/test/electronMainMock.ts
@@ -6,6 +6,9 @@ export const ipcMainHandlers: Record<string, (...args: any[]) => any> = {};
 export const ipcMain = {
   on: jest.fn((channel: string, listener: (...args: any[]) => void) => {
     ipcMainHandlers[channel] = listener;
+  }),
+  handle: jest.fn((channel: string, listener: (...args: any[]) => any) => {
+    ipcMainHandlers[channel] = listener;
   })
 };
 

--- a/test/exportError.test.ts
+++ b/test/exportError.test.ts
@@ -28,37 +28,35 @@ describe('bw export error handling', () => {
     requesttime: [1],
   };
 
-  test('sends error when csv write fails', async () => {
+  test('rejects when csv write fails', async () => {
     const handler = ipcMainHandlers['bw:export'];
     mockShowSaveDialogSync.mockReturnValue('/tmp/out.csv');
     jest.spyOn(fs.promises, 'writeFile').mockRejectedValueOnce(new Error('fail'));
 
-    const send = jest.fn();
-    await handler({ sender: { send } } as any, results, {
-      filetype: 'csv',
-      domains: 'available',
-      errors: 'no',
-      information: 'domain',
-      whoisreply: 'no',
-    });
-
-    expect(send).toHaveBeenCalledWith('bw:export.error', 'fail');
+    await expect(
+      handler({ sender: { send: jest.fn() } } as any, results, {
+        filetype: 'csv',
+        domains: 'available',
+        errors: 'no',
+        information: 'domain',
+        whoisreply: 'no',
+      })
+    ).rejects.toThrow('fail');
   });
 
-  test('sends error when zip write fails', async () => {
+  test('rejects when zip write fails', async () => {
     const handler = ipcMainHandlers['bw:export'];
     mockShowSaveDialogSync.mockReturnValue('/tmp/out');
     jest.spyOn(fs.promises, 'writeFile').mockRejectedValueOnce(new Error('zip fail'));
 
-    const send = jest.fn();
-    await handler({ sender: { send } } as any, results, {
-      filetype: 'txt',
-      domains: 'available',
-      errors: 'no',
-      information: 'domain',
-      whoisreply: 'yes+block',
-    });
-
-    expect(send).toHaveBeenCalledWith('bw:export.error', 'zip fail');
+    await expect(
+      handler({ sender: { send: jest.fn() } } as any, results, {
+        filetype: 'txt',
+        domains: 'available',
+        errors: 'no',
+        information: 'domain',
+        whoisreply: 'yes+block',
+      })
+    ).rejects.toThrow('zip fail');
   });
 });

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -32,6 +32,7 @@ declare module 'electron' {
   }
   export const Menu: any;
   export interface IpcMainEvent {}
+  export interface IpcMainInvokeEvent {}
   export interface IpcRendererEvent {}
 
   interface RendererToMainIpc {
@@ -64,6 +65,13 @@ declare module 'electron' {
       channel: C,
       listener: (event: IpcMainEvent, ...args: RendererToMainIpc[C]) => void
     ): void;
+    handle<C extends keyof RendererToMainIpc>(
+      channel: C,
+      listener: (
+        event: IpcMainInvokeEvent,
+        ...args: RendererToMainIpc[C]
+      ) => any
+    ): void;
   }
 
   export interface IpcRenderer {
@@ -75,6 +83,10 @@ declare module 'electron' {
       channel: C,
       listener: (event: IpcRendererEvent, ...args: MainToRendererIpc[C]) => void
     ): void;
+    invoke<C extends keyof RendererToMainIpc>(
+      channel: C,
+      ...args: RendererToMainIpc[C]
+    ): Promise<any>;
   }
 
   export const ipcMain: IpcMain;


### PR DESCRIPTION
## Summary
- propagate bulk export failures via Promise rejection
- use `ipcRenderer.invoke` in the renderer to receive rejection
- adjust mocks and tests for new IPC handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859a84f82d48325b78648d813d58e12