### PR TITLE
Simplify newline counting

### DIFF
--- a/app/ts/common/lineHelper.ts
+++ b/app/ts/common/lineHelper.ts
@@ -10,15 +10,10 @@ import * as fs from 'fs';
     newLineChar (string) - new line character
  */
 export function lineCount(text: string, newLineChar = '\n'): number { // '\n' unix; '\r' macos; '\r\n' windows
-  let lines = 0;
-  for (let char = 0; char <= text.length - newLineChar.length; char++) {
-    if (text.substring(char, char + newLineChar.length) === newLineChar) {
-      lines++;
-      char += newLineChar.length - 1;
-    }
+  if (newLineChar === '') {
+    return 0;
   }
-
-  return lines;
+  return text.split(newLineChar).length - 1;
 }
 
 /*


### PR DESCRIPTION
## Summary
- simplify newline counting by using `text.split()`
- keep custom newline delimiter support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859a909ed4c8325a057f884c2271224