### PR TITLE
Refactor bulk whois logic

### DIFF
--- a/app/ts/main/bw/process.defaults.ts
+++ b/app/ts/main/bw/process.defaults.ts
@@ -1,3 +1,4 @@
+import type { BulkWhois } from './types';
 
 const defaultFirstValue = null, // Default that is equivalent or similar to null value: null, undefined, false..
   defaultSecondValue = 0, // Default numeric starting value
@@ -5,18 +6,10 @@ const defaultFirstValue = null, // Default that is equivalent or similar to null
   defaultForthValue = '.',
   defaultFifthValue = 99999;
 
-interface BulkWhoisDefaults {
-  input: Record<string, any>;
-  stats: Record<string, any>;
-  results: Record<string, any>;
-  processingIDs: any[];
-  domains: any[];
-  default: Record<string, any>;
-}
 
 
 // Default BulkWhois values
-const defaultBulkWhois: BulkWhoisDefaults = {
+const defaultBulkWhois: BulkWhois = {
   'input': {
     'domains': [],
     'domainsPending': [],

--- a/app/ts/main/bw/queue.ts
+++ b/app/ts/main/bw/queue.ts
@@ -1,0 +1,70 @@
+import debugModule from 'debug';
+import { formatString } from '../../common/stringformat';
+import { loadSettings } from '../../common/settings';
+import type { DomainSetup } from './types';
+
+const debug = debugModule('main.bw.queue');
+const settings = loadSettings();
+
+export function compileQueue(domains: string[], tlds: string[], separator: string): string[] {
+  const queue: string[] = [];
+  for (const tld of tlds) {
+    queue.push(...domains.map((d) => d + separator + tld));
+  }
+  return queue;
+}
+
+export function getDomainSetup(isRandom: {
+  timeBetween: boolean;
+  followDepth: boolean;
+  timeout: boolean;
+}): DomainSetup {
+  debug(
+    formatString(
+      "Time between requests, 'israndom': {0}, 'timebetweenmax': {1}, 'timebetweenmin': {2}, 'timebetween': {3}",
+      isRandom,
+      settings['lookup.randomize.timeBetween'].maximum,
+      settings['lookup.randomize.timeBetween'].minimum,
+      settings['lookup.general'].timeBetween,
+    ),
+  );
+  debug(
+    formatString(
+      "Follow depth, 'israndom': {0}, 'followmax': {1}, 'followmin': {2}, 'follow': {3}",
+      isRandom,
+      settings['lookup.randomize.follow'].maximumDepth,
+      settings['lookup.randomize.follow'].minimumDepth,
+      settings['lookup.general'].follow,
+    ),
+  );
+  debug(
+    formatString(
+      "Request timeout, 'israndom': {0}, 'timeoutmax': {1}, 'timeoutmin': {2}, 'timeout': {3}",
+      isRandom,
+      settings['lookup.randomize.timeout'].maximum,
+      settings['lookup.randomize.timeout'].minimum,
+      settings['lookup.general'].timeout,
+    ),
+  );
+
+  return {
+    timebetween: isRandom.timeBetween
+      ? Math.floor(
+          Math.random() * settings['lookup.randomize.timeBetween'].maximum +
+            settings['lookup.randomize.timeBetween'].minimum,
+        )
+      : settings['lookup.general'].timeBetween,
+    follow: isRandom.followDepth
+      ? Math.floor(
+          Math.random() * settings['lookup.randomize.follow'].maximumDepth +
+            settings['lookup.randomize.follow'].minimumDepth,
+        )
+      : settings['lookup.general'].follow,
+    timeout: isRandom.timeout
+      ? Math.floor(
+          Math.random() * settings['lookup.randomize.timeout'].maximum +
+            settings['lookup.randomize.timeout'].minimum,
+        )
+      : settings['lookup.general'].timeout,
+  };
+}

--- a/app/ts/main/bw/resultHandler.ts
+++ b/app/ts/main/bw/resultHandler.ts
@@ -1,0 +1,141 @@
+import debugModule from 'debug';
+import { isDomainAvailable, getDomainParameters } from '../../common/availability';
+import { toJSON } from '../../common/parser';
+import { performance } from 'perf_hooks';
+import { loadSettings } from "../../common/settings";
+import { formatString } from '../../common/stringformat';
+import type { BulkWhois } from './types';
+import * as dns from '../../common/dnsLookup';
+import { Result, DnsLookupError } from '../../common/errors';
+import type { IpcMainEvent } from 'electron';
+
+const debug = debugModule('main.bw.resultHandler');
+const settings = loadSettings();
+
+export function processData(
+  bulkWhois: BulkWhois,
+  reqtime: any[],
+  event: IpcMainEvent,
+  domain: string,
+  index: number,
+  data: string | Result<boolean, DnsLookupError> | null = null,
+  isError = false,
+): void {
+  let lastweight: number;
+  const { sender } = event;
+  const { results, stats } = bulkWhois;
+  const { reqtimes, status } = stats;
+  let domainAvailable: string;
+  let lastStatus: string | undefined;
+  let resultsJSON: any;
+
+  reqtime[index] = Number(performance.now() - reqtime[index]).toFixed(2);
+
+  if (Number(reqtimes.minimum) > Number(reqtime[index])) {
+    reqtimes.minimum = reqtime[index];
+    sender.send('bw:status.update', 'reqtimes.minimum', reqtimes.minimum);
+  }
+  if (Number(reqtimes.maximum) < Number(reqtime[index])) {
+    reqtimes.maximum = reqtime[index];
+    sender.send('bw:status.update', 'reqtimes.maximum', reqtimes.maximum);
+  }
+
+  reqtimes.last = reqtime[index];
+  sender.send('bw:status.update', 'reqtimes.last', reqtimes.last);
+
+  if (settings['lookup.misc'].asfOverride) {
+    lastweight = Number(((stats.domains.sent - stats.domains.waiting) / stats.domains.processed).toFixed(2));
+    reqtimes.average = (
+      Number(reqtimes.average) * lastweight +
+      (1 - lastweight) * Number(reqtime[index])
+    ).toFixed(2);
+  } else {
+    reqtimes.average = reqtimes.average || reqtime[index];
+    reqtimes.average = (
+      Number(reqtime[index]) * settings['lookup.misc'].averageSmoothingFactor +
+      (1 - settings['lookup.misc'].averageSmoothingFactor) * Number(reqtimes.average)
+    ).toFixed(2);
+  }
+
+  if (isError) {
+    status.error++;
+    sender.send('bw:status.update', 'status.error', status.error);
+    stats.laststatus.error = domain;
+    sender.send('bw:status.update', 'laststatus.error', stats.laststatus.error);
+  } else {
+    domainAvailable =
+      settings['lookup.general'].type == 'whois'
+        ? isDomainAvailable(data as string)
+        : dns.isDomainAvailable(data as Result<boolean, DnsLookupError>);
+    switch (domainAvailable) {
+      case 'available':
+        status.available++;
+        sender.send('bw:status.update', 'status.available', status.available);
+        stats.laststatus.available = domain;
+        sender.send('bw:status.update', 'laststatus.available', stats.laststatus.available);
+        lastStatus = 'available';
+        break;
+      case 'unavailable':
+        status.unavailable++;
+        sender.send('bw:status.update', 'status.unavailable', status.unavailable);
+        stats.laststatus.unavailable = domain;
+        sender.send('bw:status.update', 'laststatus.unavailable', stats.laststatus.unavailable);
+        lastStatus = 'unavailable';
+        break;
+      default:
+        if (domainAvailable.includes('error')) {
+          status.error++;
+          sender.send('bw:status.update', 'status.error', status.error);
+          stats.laststatus.error = domain;
+          sender.send('bw:status.update', 'laststatus.error', stats.laststatus.error);
+          lastStatus = 'error';
+        }
+        break;
+    }
+  }
+
+  debug(formatString('Average request time {0}ms', reqtimes.average));
+  sender.send('bw:status.update', 'reqtimes.average', reqtimes.average);
+
+  stats.domains.waiting--;
+  sender.send('bw:status.update', 'domains.waiting', stats.domains.waiting);
+
+  let resultFilter: any = {
+    domain: '',
+    status: '',
+    registrar: '',
+    company: '',
+    creationdate: '',
+    updatedate: '',
+    expirydate: '',
+    whoisreply: '',
+    whoisjson: '',
+  };
+
+  if (settings['lookup.general'].type == 'whois') {
+    resultsJSON = toJSON(data as string);
+    resultFilter = getDomainParameters(domain, lastStatus ?? null, data as string, resultsJSON);
+  } else {
+    resultFilter.domain = domain;
+    resultFilter.status = lastStatus ?? null;
+    resultFilter.registrar = null;
+    resultFilter.company = null;
+    resultFilter.creationdate = null;
+    resultFilter.updatedate = null;
+    resultFilter.expirydate = null;
+    resultFilter.whoisreply = null;
+    resultFilter.whoisjson = null;
+  }
+
+  results.id[index] = Number(index + 1);
+  results.domain[index] = resultFilter.domain;
+  results.status[index] = resultFilter.status;
+  results.registrar[index] = resultFilter.registrar;
+  results.company[index] = resultFilter.company;
+  results.creationdate[index] = resultFilter.creationdate;
+  results.updatedate[index] = resultFilter.updatedate;
+  results.expirydate[index] = resultFilter.expirydate;
+  results.whoisreply[index] = resultFilter.whoisreply;
+  results.whoisjson[index] = resultFilter.whoisjson;
+  results.requesttime[index] = reqtime[index];
+}

--- a/app/ts/main/bw/scheduler.ts
+++ b/app/ts/main/bw/scheduler.ts
@@ -1,0 +1,101 @@
+import debugModule from 'debug';
+import { performance } from 'perf_hooks';
+import { lookup as whoisLookup } from '../../common/lookup';
+import * as dns from '../../common/dnsLookup';
+import { Result, DnsLookupError } from '../../common/errors';
+import { formatString } from '../../common/stringformat';
+import { msToHumanTime } from '../../common/conversions';
+import { loadSettings } from "../../common/settings";
+import type { BulkWhois, DomainSetup } from './types';
+import { processData } from './resultHandler';
+import type { IpcMainEvent } from 'electron';
+
+const debug = debugModule('main.bw.scheduler');
+const settings = loadSettings();
+
+export function processDomain(
+  bulkWhois: BulkWhois,
+  reqtime: any[],
+  domainSetup: DomainSetup,
+  event: IpcMainEvent,
+): void {
+  debug(
+    formatString(
+      'Domain: {0}, id/index: {1}, timebetween: {2}',
+      domainSetup.domain,
+      domainSetup.index,
+      domainSetup.timebetween,
+    ),
+  );
+
+  const { stats, processingIDs } = bulkWhois;
+  const { sender } = event;
+
+  processingIDs[domainSetup.index!] = setTimeout(async () => {
+    let data: any;
+    stats.domains.sent++;
+    sender.send('bw:status.update', 'domains.sent', stats.domains.sent);
+    stats.domains.waiting++;
+    sender.send('bw:status.update', 'domains.waiting', stats.domains.waiting);
+
+    reqtime[domainSetup.index!] = await performance.now();
+
+    debug(formatString('Looking up domain: {0}', domainSetup.domain));
+
+    try {
+      data =
+        settings['lookup.general'].type == 'whois'
+          ? await whoisLookup(domainSetup.domain!, {
+              follow: domainSetup.follow,
+              timeout: domainSetup.timeout,
+            })
+          : await dns.hasNsServers(domainSetup.domain!);
+      processData(bulkWhois, reqtime, event, domainSetup.domain!, domainSetup.index!, data, false);
+    } catch (e) {
+      console.log(e);
+      console.trace();
+    }
+  }, domainSetup.timebetween * (domainSetup.index! - stats.domains.sent + 1));
+
+  debug(
+    formatString(
+      'Timebetween: {0}',
+      domainSetup.timebetween * (domainSetup.index! - stats.domains.sent + 1),
+    ),
+  );
+}
+
+export function counter(
+  bulkWhois: BulkWhois,
+  event: IpcMainEvent,
+  start = true,
+): void {
+  const { results, stats } = bulkWhois;
+  const { sender } = event;
+
+  if (start) {
+    stats.time.counter = setInterval(() => {
+      stats.time.currentcounter += 1000;
+      stats.time.remainingcounter -= 1000;
+      if (stats.time.remainingcounter <= 0) {
+        stats.time.remainingcounter = 0;
+        bulkWhois.stats.time.remaining = '-';
+      } else {
+        stats.time.remaining = msToHumanTime(stats.time.remainingcounter);
+      }
+      stats.time.current = msToHumanTime(stats.time.currentcounter);
+      sender.send('bw:status.update', 'time.current', stats.time.current);
+      sender.send('bw:status.update', 'time.remaining', stats.time.remaining);
+      if (
+        stats.domains.total == stats.domains.sent &&
+        stats.domains.waiting === 0
+      ) {
+        clearTimeout(stats.time.counter!);
+        sender.send('bw:result.receive', results);
+        sender.send('bw:status.update', 'finished');
+      }
+    }, 1000);
+  } else {
+    clearTimeout(stats.time.counter!);
+  }
+}

--- a/app/ts/main/bw/types.ts
+++ b/app/ts/main/bw/types.ts
@@ -1,0 +1,75 @@
+export interface BulkWhoisInput {
+  domains: string[];
+  domainsPending: string[];
+  tlds: string[];
+  tldSeparator: string;
+}
+
+export interface BulkWhoisStats {
+  domains: {
+    processed: number;
+    sent: number;
+    waiting: number;
+    total: number;
+  };
+  time: {
+    current: string | null;
+    remaining: string | null;
+    counter: NodeJS.Timeout | null;
+    currentcounter: number;
+    remainingcounter: number;
+  };
+  reqtimes: {
+    minimum: number;
+    average: string | null;
+    maximum: string | null;
+    last: string | null;
+  };
+  status: {
+    available: number;
+    unavailable: number;
+    error: number;
+    percentavailable: string | null;
+    percentunavailable: string | null;
+    percenterror: string | null;
+  };
+  laststatus: {
+    available: string | null;
+    unavailable: string | null;
+    error: string | null;
+  };
+}
+
+export interface BulkWhoisResults {
+  id: number[];
+  domain: (string | null)[];
+  status: (string | null)[];
+  registrar: (string | null)[];
+  company: (string | null)[];
+  updatedate: (string | null)[];
+  creationdate: (string | null)[];
+  expirydate: (string | null)[];
+  whoisreply: (string | null)[];
+  whoisjson: (string | null)[];
+  requesttime: (string | number | null)[];
+}
+
+export interface BulkWhois {
+  input: BulkWhoisInput;
+  stats: BulkWhoisStats;
+  results: BulkWhoisResults;
+  processingIDs: any[];
+  domains: string[];
+  default: {
+    numericstart: number | null;
+    others: string;
+  };
+}
+
+export interface DomainSetup {
+  domain?: string;
+  index?: number;
+  timebetween: number;
+  follow: number;
+  timeout: number;
+}


### PR DESCRIPTION
## Summary
- break bulk whois code into smaller modules
- define interfaces for the bulk whois object
- adjust default object typing
- wire up new queue and scheduler helpers

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859a6fef8648325bd44c84378aab697