### PR TITLE
Add msToHumanTime zero and negative tests

### DIFF
--- a/test/conversions.test.ts
+++ b/test/conversions.test.ts
@@ -9,6 +9,14 @@ describe('conversions', () => {
     expect(msToHumanTime(62000)).toBe('1 m 2 s');
   });
 
+  test("msToHumanTime returns '-' for zero duration", () => {
+    expect(msToHumanTime(0)).toBe('-');
+  });
+
+  test("msToHumanTime returns '-' for negative duration", () => {
+    expect(msToHumanTime(-1000)).toBe('-');
+  });
+
   test('getDate parses valid dates', () => {
     const date = new Date('2020-01-01T00:00:00Z');
     expect(getDate(date)).toBe(date.toUTCString());


### PR DESCRIPTION
## Summary
- extend conversions tests to cover zero and negative durations for `msToHumanTime`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859ac3c2b688325a807c92f2e4f232f