### PR TITLE
Fix extended menu toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 release_builds/
 node_modules/
 dist/
+
+dns.json
+reload.json

--- a/app/ts/renderer.ts
+++ b/app/ts/renderer.ts
@@ -80,7 +80,11 @@ function startup() {
   }
 
   sendDebug(formatString("'navigation.extendedmenu': {0}", String(navigation.enableExtendedMenu)));
-  if (navigation.enableExtendedMenu) $('#navButtonExpandedmenu').addClass('is-force-hidden');
+  if (!navigation.enableExtendedMenu) {
+    $('#navButtonExpandedmenu').addClass('is-force-hidden');
+  } else {
+    $('#navButtonExpandedmenu').removeClass('is-force-hidden');
+  }
 
   return;
 }


### PR DESCRIPTION
## Summary
- hide nav button only when extended menus are disabled
- ignore temporary settings files produced by tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859ad66f7d483258919bdf2aa9a147d