### PR TITLE
Switch settings IO to async

### DIFF
--- a/app/ts/common/availability.ts
+++ b/app/ts/common/availability.ts
@@ -1,10 +1,10 @@
 import debugModule from 'debug';
 import { getDate } from './conversions';
 import { toJSON } from './parser';
-import { load, Settings } from './settings';
+import { settings as appSettings, Settings } from './settings';
 
 const debug = debugModule('common.whoisWrapper');
-let settings: Settings = load();
+let settings: Settings = appSettings;
 
 export interface WhoisResult {
   domain?: string;

--- a/app/ts/common/dnsLookup.ts
+++ b/app/ts/common/dnsLookup.ts
@@ -3,13 +3,13 @@ import dns from 'dns/promises';
 import psl from 'psl';
 import debugModule from 'debug';
 import { convertDomain } from './lookup';
-import { loadSettings, Settings } from './settings';
+import { settings, Settings } from './settings';
 import { DnsLookupError, Result } from './errors';
 
 const debug = debugModule('common.dnsLookup');
 
 function getSettings(): Settings {
-  return loadSettings();
+  return settings;
 }
 
 

--- a/app/ts/common/lookup.ts
+++ b/app/ts/common/lookup.ts
@@ -3,12 +3,12 @@ import puny from 'punycode';
 import uts46 from 'idna-uts46';
 import whois from 'whois';
 import debugModule from 'debug';
-import { loadSettings, Settings } from './settings';
+import { settings, Settings } from './settings';
 
 const debug = debugModule('common.whoisWrapper');
 
 function getSettings(): Settings {
-  return loadSettings();
+  return settings;
 }
 
 const lookupPromise = (...args: unknown[]): Promise<string> => {

--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -84,7 +84,7 @@ const filePath = isMainProcess
   load
     Loads custom configurations from file or defaults
  */
-export function load(): Settings {
+export async function load(): Promise<Settings> {
   const {
     'custom.configuration': configuration
   } = settings;
@@ -96,7 +96,7 @@ export function load(): Settings {
           getUserDataPath(),
           settings['custom.configuration'].filepath
         );
-      const raw = fs.readFileSync(filePath, 'utf8');
+      const raw = await fs.promises.readFile(filePath, 'utf8');
       try {
         settings = JSON.parse(raw) as Settings;
         debug(`Loaded custom configuration at ${filePath}`);
@@ -117,7 +117,7 @@ export function load(): Settings {
   parameters
     settings (object) - Current custom configurations to be saved
  */
-export function save(settings: Settings): string | Error | undefined {
+export async function save(settings: Settings): Promise<string | Error | undefined> {
   const {
     'custom.configuration': configuration
   } = settings;
@@ -129,7 +129,7 @@ export function save(settings: Settings): string | Error | undefined {
           getUserDataPath(),
           settings['custom.configuration'].filepath
         );
-      fs.writeFileSync(filePath, JSON.stringify(settings));
+      await fs.promises.writeFile(filePath, JSON.stringify(settings));
       debug(`Saved custom configuration at ${filePath}`);
       return 'SAVED';
     } catch (e) {

--- a/app/ts/common/whoiswrapper/patterns.ts
+++ b/app/ts/common/whoiswrapper/patterns.ts
@@ -1,10 +1,9 @@
 
-import { load, Settings } from '../settings';
+import { settings as appSettings, Settings } from '../settings';
 import { toJSON } from '../parser';
 import { getDomainParameters, WhoisResult } from '../availability';
 import { getDate } from '../conversions';
 
-const settings: Settings = load();
 
 export interface PatternFunction {
   (context: PatternContext): boolean;
@@ -42,7 +41,7 @@ const patterns = {
   special: {
     1: {
       includes: ['Uniregistry', 'Query limit exceeded'],
-      result: settings['lookup.assumptions']['uniregistry'] ?
+      result: appSettings['lookup.assumptions']['uniregistry'] ?
         'unavailable' : 'error:ratelimiting'
     }
   },
@@ -97,7 +96,7 @@ const patterns = {
       1: [{
         type: 'minuslessthan',
         parameters: ['domainParams.expiryDate', 'controlDate', 0],
-        result: settings['lookup.assumptions']['expired'] ? 'expired' : 'available'
+        result: appSettings['lookup.assumptions']['expired'] ? 'expired' : 'available'
       }],
       2: 'This domain name has not been registered',
       3: 'The domain has not been registered',
@@ -365,7 +364,7 @@ export function checkPatterns(
   for (const p of builtPatterns.unavailable) if (p.fn(ctx)) return p.result;
   for (const p of builtPatterns.error) if (p.fn(ctx)) return p.result;
 
-  return settings['lookup.assumptions'].unparsable ? 'available' : 'error:unparsable';
+  return appSettings['lookup.assumptions'].unparsable ? 'available' : 'error:unparsable';
 }
 
 const exported = {

--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -73,15 +73,16 @@ interface MainSettings extends BaseSettings {
 
 import './main/index';
 
-let settings: MainSettings = loadSettings() as MainSettings;
+let settings: MainSettings;
 let mainWindow: BrowserWindow;
 
 /*
   app.on('ready', function() {...}
     When application is ready
  */
-app.on('ready', function() {
+app.on('ready', async function() {
   initializeRemote();
+  settings = (await loadSettings()) as MainSettings;
   const {
     'custom.configuration': configuration,
     'app.window': appWindow,
@@ -94,7 +95,7 @@ app.on('ready', function() {
   if (fs.existsSync(configPath)) {
     debug("Reading persistent configurations");
     settings = JSON.parse(
-      fs.readFileSync(configPath, 'utf8')
+      await fs.promises.readFile(configPath, 'utf8')
     ) as MainSettings;
   } else {
     debug("Using default configurations");

--- a/app/ts/main/bw/export.ts
+++ b/app/ts/main/bw/export.ts
@@ -18,7 +18,6 @@ const {
 } = electron;
 
 import { loadSettings } from '../../common/settings';
-const settings = loadSettings();
 
 /*
   ipcMain.on('bw:export', function(...) {...});
@@ -29,6 +28,7 @@ const settings = loadSettings();
     options (object) - bulk whois export options object
  */
   ipcMain.handle('bw:export', async function(event, results, options) {
+  const settings = await loadSettings();
   const {
     'lookup.export': resExports
   } = settings;

--- a/app/ts/main/bw/fileinput.ts
+++ b/app/ts/main/bw/fileinput.ts
@@ -13,7 +13,6 @@ const {
 import { formatString } from '../../common/stringformat';
 
 import { loadSettings } from '../../common/settings';
-const settings = loadSettings();
 
 /*
   ipcMain.on('bw:input.file', function(...) {...});
@@ -44,7 +43,8 @@ ipcMain.on('bw:input.file', function(event) {
     event (object) - renderer object
     filePath (string) - dropped file path
  */
-ipcMain.on('ondragstart', function(event, filePath) {
+ipcMain.on('ondragstart', async function(event, filePath) {
+  const settings = await loadSettings();
   const {
     'app.window': appWindow
   } = settings;

--- a/app/ts/main/bw/process.ts
+++ b/app/ts/main/bw/process.ts
@@ -12,7 +12,6 @@ import { resetObject } from '../../common/resetObject';
 import { resetUiCounters } from './auxiliary';
 
 import { loadSettings } from '../../common/settings';
-const settings = loadSettings();
 
 const {
   app,
@@ -36,7 +35,8 @@ let reqtime: number[] = [];
     domains (array) - domains to request whois for
     tlds (array) - tlds to look for
  */
-ipcMain.on('bw:lookup', function(event: IpcMainEvent, domains: string[], tlds: string[]) {
+ipcMain.on('bw:lookup', async function(event: IpcMainEvent, domains: string[], tlds: string[]) {
+  const settings = await loadSettings();
   resetUiCounters(event); // Reset UI counters, pass window param
   bulkWhois = resetObject(defaultBulkWhois); // Resets the bulkWhois object to default
   reqtime = [];
@@ -85,7 +85,7 @@ ipcMain.on('bw:lookup', function(event: IpcMainEvent, domains: string[], tlds: s
   // Process compiled domains into future requests
   for (let domain in domainsPending) {
 
-    domainSetup = getDomainSetup({
+    domainSetup = getDomainSetup(settings, {
       timeBetween: settings['lookup.randomize.timeBetween'].randomize,
       followDepth: settings['lookup.randomize.follow'].randomize,
       timeout: settings['lookup.randomize.timeout'].randomize
@@ -152,7 +152,8 @@ ipcMain.on('bw:lookup.pause', function(event: IpcMainEvent) {
   parameters
     event (object) - renderer object
  */
-ipcMain.on('bw:lookup.continue', function(event: IpcMainEvent) {
+ipcMain.on('bw:lookup.continue', async function(event: IpcMainEvent) {
+  const settings = await loadSettings();
   debug('Continuing bulk whois requests');
 
   // Go through the remaining domains and queue them again using setTimeouts
@@ -187,7 +188,7 @@ ipcMain.on('bw:lookup.continue', function(event: IpcMainEvent) {
   // Do domain setup
   for (let domain = stats.domains.sent; domain < domainsPending.length; domain++) {
 
-    domainSetup = getDomainSetup({
+    domainSetup = getDomainSetup(settings, {
       timeBetween: settings['lookup.randomize.timeBetween'].randomize,
       followDepth: settings['lookup.randomize.follow'].randomize,
       timeout: settings['lookup.randomize.timeout'].randomize

--- a/app/ts/main/bw/queue.ts
+++ b/app/ts/main/bw/queue.ts
@@ -1,10 +1,9 @@
 import debugModule from 'debug';
 import { formatString } from '../../common/stringformat';
-import { loadSettings } from '../../common/settings';
+import type { Settings } from '../../common/settings';
 import type { DomainSetup } from './types';
 
 const debug = debugModule('main.bw.queue');
-const settings = loadSettings();
 
 export function compileQueue(domains: string[], tlds: string[], separator: string): string[] {
   const queue: string[] = [];
@@ -14,7 +13,7 @@ export function compileQueue(domains: string[], tlds: string[], separator: strin
   return queue;
 }
 
-export function getDomainSetup(isRandom: {
+export function getDomainSetup(settings: Settings, isRandom: {
   timeBetween: boolean;
   followDepth: boolean;
   timeout: boolean;

--- a/app/ts/main/bw/resultHandler.ts
+++ b/app/ts/main/bw/resultHandler.ts
@@ -10,9 +10,8 @@ import { Result, DnsLookupError } from '../../common/errors';
 import type { IpcMainEvent } from 'electron';
 
 const debug = debugModule('main.bw.resultHandler');
-const settings = loadSettings();
 
-export function processData(
+export async function processData(
   bulkWhois: BulkWhois,
   reqtime: any[],
   event: IpcMainEvent,
@@ -20,7 +19,8 @@ export function processData(
   index: number,
   data: string | Result<boolean, DnsLookupError> | null = null,
   isError = false,
-): void {
+): Promise<void> {
+  const settings = await loadSettings();
   let lastweight: number;
   const { sender } = event;
   const { results, stats } = bulkWhois;

--- a/app/ts/main/bw/scheduler.ts
+++ b/app/ts/main/bw/scheduler.ts
@@ -11,7 +11,6 @@ import { processData } from './resultHandler';
 import type { IpcMainEvent } from 'electron';
 
 const debug = debugModule('main.bw.scheduler');
-const settings = loadSettings();
 
 export function processDomain(
   bulkWhois: BulkWhois,
@@ -43,6 +42,7 @@ export function processDomain(
     debug(formatString('Looking up domain: {0}', domainSetup.domain));
 
     try {
+      const settings = await loadSettings();
       data =
         settings['lookup.general'].type == 'whois'
           ? await whoisLookup(domainSetup.domain!, {
@@ -50,7 +50,7 @@ export function processDomain(
               timeout: domainSetup.timeout,
             })
           : await dns.hasNsServers(domainSetup.domain!);
-      processData(bulkWhois, reqtime, event, domainSetup.domain!, domainSetup.index!, data, false);
+      await processData(bulkWhois, reqtime, event, domainSetup.domain!, domainSetup.index!, data, false);
     } catch (e) {
       console.log(e);
       console.trace();

--- a/app/ts/main/sw.ts
+++ b/app/ts/main/sw.ts
@@ -18,8 +18,8 @@ const {
 } = electron;
 import { formatString } from '../common/stringformat';
 
-import { loadSettings } from '../common/settings';
-const settings = loadSettings();
+import { loadSettings, Settings } from '../common/settings';
+
 
 /*
   ipcMain.on('sw:lookup', function(...) {...});
@@ -46,12 +46,13 @@ ipcMain.on('sw:lookup', async function(event, domain) {
   ipcMain.on('sw:openlink', function(...) {...});
     Open link or copy to clipboard
  */
-ipcMain.on('sw:openlink', function(event, domain) {
+ipcMain.on('sw:openlink', async function(event, domain) {
+  const settings = await loadSettings();
   const {
     'lookup.misc': misc
   } = settings;
 
-  misc.onlyCopy ? copyToClipboard(event, domain) : openUrl(event, domain);
+  misc.onlyCopy ? copyToClipboard(event, domain) : openUrl(event, domain, settings);
 
   return;
 });
@@ -82,7 +83,7 @@ function copyToClipboard(event: IpcMainEvent, domain: string): void {
     event
     domain
  */
-function openUrl(event: IpcMainEvent, domain: string): void {
+function openUrl(event: IpcMainEvent, domain: string, settings: Settings): void {
   const {
     'app.window': appWindow,
   } = settings;

--- a/app/ts/renderer.ts
+++ b/app/ts/renderer.ts
@@ -17,7 +17,7 @@ import { formatString } from './common/stringformat';
 (window as any).dialog = dialog;
 (window as any).remote = remote;
 
-let settings: Settings = loadSettings();
+let settings: Settings;
 
 interface DebugMessage {
   channel: 'app:debug';
@@ -33,7 +33,8 @@ function sendDebug(message: string): void {
   $(document).ready(function() {...});
     When document is ready
  */
-$(document).ready(function() {
+$(document).ready(async function() {
+  settings = await loadSettings();
   const {
     'custom.configuration': configuration
   } = settings;
@@ -49,7 +50,7 @@ $(document).ready(function() {
   if (fs.existsSync(configPath)) {
     sendDebug('Reading persistent configurations');
     settings = JSON.parse(
-      fs.readFileSync(configPath, 'utf8')
+      await fs.promises.readFile(configPath, 'utf8')
     ) as Settings;
   } else {
     sendDebug('Using default configurations');

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -18,7 +18,7 @@ let bwaFileContents: any;
   ipcRenderer.on('bwa:fileinput.confirmation', function(...) {...});
     File input, path and information confirmation container
  */
-ipcRenderer.on('bwa:fileinput.confirmation', function(event, filePath: string | string[] | null = null, isDragDrop = false) {
+ipcRenderer.on('bwa:fileinput.confirmation', async function(event, filePath: string | string[] | null = null, isDragDrop = false) {
   let bwaFileStats: FileStats; // File stats, size, last changed, etc
 
   $('#bwaFileSpanInfo').text('Waiting for file...');
@@ -37,7 +37,7 @@ ipcRenderer.on('bwa:fileinput.confirmation', function(event, filePath: string | 
       bwaFileStats.filename = (filePath as string).replace(/^.*[\\\/]/, '');
       bwaFileStats.humansize = conversions.byteToHumanFileSize(bwaFileStats.size, settings['lookup.misc'].useStandardSize);
       $('#bwaFileSpanInfo').text('Loading file contents...');
-      bwaFileContents = Papa.parse(fs.readFileSync(filePath as string).toString(), {
+      bwaFileContents = Papa.parse((await fs.promises.readFile(filePath as string)).toString(), {
         header: true
       });
     } else {
@@ -45,7 +45,7 @@ ipcRenderer.on('bwa:fileinput.confirmation', function(event, filePath: string | 
       bwaFileStats.filename = (filePath as string[])[0].replace(/^.*[\\\/]/, '');
       bwaFileStats.humansize = conversions.byteToHumanFileSize(bwaFileStats.size, settings['lookup.misc'].useStandardSize);
       $('#bwaFileSpanInfo').text('Loading file contents...');
-      bwaFileContents = Papa.parse(fs.readFileSync((filePath as string[])[0]).toString(), {
+      bwaFileContents = Papa.parse((await fs.promises.readFile((filePath as string[])[0])).toString(), {
         header: true
       });
     }

--- a/app/ts/renderer/darkmode.ts
+++ b/app/ts/renderer/darkmode.ts
@@ -16,7 +16,7 @@ $(document).ready(() => {
       const state = checkbox.is(':checked');
       settings.theme = settings.theme || { darkMode: false };
       settings.theme.darkMode = state;
-      saveSettings(settings);
+      void saveSettings(settings);
       applyDarkMode(state);
     });
   }

--- a/test/openUrl.test.ts
+++ b/test/openUrl.test.ts
@@ -30,20 +30,20 @@ describe('openUrl', () => {
     loadURLMock.mockClear();
   });
 
-  test('opens new window for valid http url', () => {
+  test('opens new window for valid http url', async () => {
     settings['lookup.misc'].onlyCopy = false;
     const handler = ipcMainHandlers['sw:openlink'];
-    handler({ sender: { send: jest.fn() } } as any, 'https://example.com');
+    await handler({ sender: { send: jest.fn() } } as any, 'https://example.com');
 
     expect(BrowserWindowMock).toHaveBeenCalled();
     expect(loadURLMock).toHaveBeenCalledWith('https://example.com');
   });
 
-  test('rejects invalid url', () => {
+  test('rejects invalid url', async () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     settings['lookup.misc'].onlyCopy = false;
     const handler = ipcMainHandlers['sw:openlink'];
-    handler({ sender: { send: jest.fn() } } as any, 'ftp://example.com');
+    await handler({ sender: { send: jest.fn() } } as any, 'ftp://example.com');
 
     expect(BrowserWindowMock).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalled();

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -6,7 +6,7 @@ import { loadSettings, settings } from '../app/ts/common/settings';
 
 
 describe('settings load', () => {
-  test('falls back to defaults when config is corrupt', () => {
+  test('falls back to defaults when config is corrupt', async () => {
     const tmpDir = fs.mkdtempSync(path.join(__dirname, 'config')); 
     mockGetPath.mockReturnValue(tmpDir);
 
@@ -15,7 +15,7 @@ describe('settings load', () => {
     settings['custom.configuration'].filepath = configName;
     fs.writeFileSync(path.join(tmpDir, 'bad.json'), '{ invalid json');
 
-    const loaded = loadSettings();
+    const loaded = await loadSettings();
 
     original['custom.configuration'].filepath = configName;
     expect(loaded).toEqual(original);

--- a/test/settingsReload.test.ts
+++ b/test/settingsReload.test.ts
@@ -9,16 +9,16 @@ import { nsLookup } from '../app/ts/common/dnsLookup';
 import { loadSettings, saveSettings, settings } from '../app/ts/common/settings';
 
 describe('settings reload', () => {
-  test('convertDomain reflects saved settings', () => {
+  test('convertDomain reflects saved settings', async () => {
     const tmpDir = fs.mkdtempSync(path.join(__dirname, 'config'));
     mockGetPath.mockReturnValue(tmpDir);
     const originalAlg = settings['lookup.conversion'].algorithm;
     const configName = 'reload.json';
     settings['custom.configuration'].filepath = configName;
 
-    const cfg = loadSettings();
+    const cfg = await loadSettings();
     cfg['lookup.conversion'].algorithm = 'ascii';
-    saveSettings(cfg);
+    await saveSettings(cfg);
 
     const result = convertDomain('t\u00E4st.de');
     expect(result).toBe('tst.de');
@@ -35,9 +35,9 @@ describe('settings reload', () => {
     const configName = 'dns.json';
     settings['custom.configuration'].filepath = configName;
 
-    const cfg = loadSettings();
+    const cfg = await loadSettings();
     cfg['lookup.general'].psl = false;
-    saveSettings(cfg);
+    await saveSettings(cfg);
 
     const resolveMock = jest.spyOn(dns, 'resolve').mockResolvedValue([]);
     await nsLookup('sub.example.com');


### PR DESCRIPTION
## Summary
- migrate sync fs methods to fs.promises
- return promises from settings load/save helpers
- adjust main process and renderer to await new functions
- update bw modules and sw handler for async settings
- revise darkmode saving and BWA file parsing
- fix availability and patterns modules to use exported settings
- update tests for async behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859ac1ade588325b5afd8c0e2b66e4a