### PR TITLE
Fix getDomainSetup test

### DIFF
--- a/test/getDomainSetup.test.ts
+++ b/test/getDomainSetup.test.ts
@@ -18,7 +18,7 @@ describe('getDomainSetup', () => {
     settings['lookup.randomize.timeout'].minimum = 10;
     settings['lookup.randomize.timeout'].maximum = 20;
 
-    const result = getDomainSetup({
+    const result = getDomainSetup(settings, {
       timeBetween: true,
       followDepth: true,
       timeout: true,


### PR DESCRIPTION
## Summary
- fix `getDomainSetup` test to pass the settings argument

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6859ba2c22408325a9ca209ad8689397