### PR TITLE
Fix ts-jest warning

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,11 +3,6 @@ module.exports = {
   testEnvironment: 'node',
   testMatch: ['**/test/**/*.test.ts'],
   transform: {
-    '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.json' }]
-  },
-  globals: {
-    'ts-jest': {
-      diagnostics: false
-    }
+    '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.json', diagnostics: false }]
   }
 };

--- a/test/getDomainSetup.test.ts
+++ b/test/getDomainSetup.test.ts
@@ -18,7 +18,7 @@ describe('getDomainSetup', () => {
     settings['lookup.randomize.timeout'].minimum = 10;
     settings['lookup.randomize.timeout'].maximum = 20;
 
-    const result = getDomainSetup({
+    const result = getDomainSetup(settings, {
       timeBetween: true,
       followDepth: true,
       timeout: true,


### PR DESCRIPTION
## Summary
- update Jest config to pass ts-jest options directly in `transform`
- fix test to use settings argument for `getDomainSetup`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859ba464dc083259e1c58dedeeb4e55