### PR TITLE
Refactor loops to avoid for..in on arrays

### DIFF
--- a/app/ts/main/bw/process.ts
+++ b/app/ts/main/bw/process.ts
@@ -83,7 +83,7 @@ ipcMain.on('bw:lookup', async function(event: IpcMainEvent, domains: string[], t
   domainsPending.push(...compileQueue(input.domains, input.tlds, tldSeparator));
 
   // Process compiled domains into future requests
-  for (let domain in domainsPending) {
+  for (const [index, domain] of domainsPending.entries()) {
 
     domainSetup = getDomainSetup(settings, {
       timeBetween: settings['lookup.randomize.timeBetween'].randomize,
@@ -91,14 +91,14 @@ ipcMain.on('bw:lookup', async function(event: IpcMainEvent, domains: string[], t
       timeout: settings['lookup.randomize.timeout'].randomize
     });
     domainSetup.timebetween = settings['lookup.general'].useDnsTimeBetweenOverride ? settings['lookup.general'].dnsTimeBetween : domainSetup.timebetween;
-    domainSetup.domain = domainsPending[domain];
-    domainSetup.index = Number(domain);
+    domainSetup.domain = domain;
+    domainSetup.index = index;
 
     debug(formatString('Using timebetween, {0}, follow, {1}, timeout, {2}', domainSetup.timebetween, domainSetup.follow, domainSetup.timeout));
 
     processDomain(bulkWhois, reqtime, domainSetup, event);
 
-    stats.domains.processed = Number(domainSetup.index) + 1;
+    stats.domains.processed = domainSetup.index + 1;
     sender.send('bw:status.update', 'domains.processed', stats.domains.processed);
 
   } // End processing for loop

--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -71,8 +71,8 @@ function showTable() {
 
   // Generate header column content
   header.content = '<tr>\n';
-  for (const column in header.columns) {
-    header.content += formatString('\t<th><abbr title="{0}">{1}</abbr></th>\n', header.columns[column], getInitials(header.columns[column]));
+  for (const column of header.columns) {
+    header.content += formatString('\t<th><abbr title="{0}">{1}</abbr></th>\n', column, getInitials(column));
   }
   header.content += '</tr>';
 
@@ -80,11 +80,11 @@ function showTable() {
 
   // Generate record fields
   body.content = '';
-  for (const record in body.records) {
+  for (const record of body.records) {
     body.content += '<tr>\n';
 
-    for (const field in body.records[record]) {
-      body.content += formatString('\t<td>{0}</td>\n', body.records[record][field]);
+    for (const value of Object.values(record)) {
+      body.content += formatString('\t<td>{0}</td>\n', value);
     }
     body.content += '</tr>\n';
   }

--- a/test/getDomainSetup.test.ts
+++ b/test/getDomainSetup.test.ts
@@ -18,7 +18,7 @@ describe('getDomainSetup', () => {
     settings['lookup.randomize.timeout'].minimum = 10;
     settings['lookup.randomize.timeout'].maximum = 20;
 
-    const result = getDomainSetup({
+    const result = getDomainSetup(settings, {
       timeBetween: true,
       followDepth: true,
       timeout: true,


### PR DESCRIPTION
## Summary
- use `for...of` with `.entries()` when processing pending domains
- iterate arrays with `for...of` in analyser
- adjust unit test to updated `getDomainSetup` signature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859bafc9974832593730f3bc95df3dc