### PR TITLE
Refactor openUrl and strengthen URL validation

### DIFF
--- a/app/ts/main/sw.ts
+++ b/app/ts/main/sw.ts
@@ -52,7 +52,7 @@ ipcMain.on('sw:openlink', async function(event, domain) {
     'lookup.misc': misc
   } = settings;
 
-  misc.onlyCopy ? copyToClipboard(event, domain) : openUrl(event, domain, settings);
+  misc.onlyCopy ? copyToClipboard(event, domain) : openUrl(domain, settings);
 
   return;
 });
@@ -80,10 +80,10 @@ function copyToClipboard(event: IpcMainEvent, domain: string): void {
   openUrl
     Opens a URL in a new browser window (potential security risk)
   parameters
-    event
     domain
- */
-function openUrl(event: IpcMainEvent, domain: string, settings: Settings): void {
+    settings
+*/
+function openUrl(domain: string, settings: Settings): void {
   const {
     'app.window': appWindow,
   } = settings;
@@ -91,11 +91,13 @@ function openUrl(event: IpcMainEvent, domain: string, settings: Settings): void 
   let target: URL;
   try {
     target = new URL(domain);
-    if (target.protocol !== 'http:' && target.protocol !== 'https:') {
-      throw new Error('invalid protocol');
-    }
   } catch {
     console.warn(`Invalid URL: ${domain}`);
+    return;
+  }
+  const protocol = target.protocol.toLowerCase();
+  if (protocol !== 'http:' && protocol !== 'https:') {
+    console.warn(`Invalid protocol: ${target.protocol}`);
     return;
   }
 
@@ -110,7 +112,7 @@ function openUrl(event: IpcMainEvent, domain: string, settings: Settings): void 
 
   hwnd.setSkipTaskbar(true);
   hwnd.setMenu(null);
-  hwnd.loadURL(domain);
+  hwnd.loadURL(target.href);
 
   hwnd.on('closed', function() {
     hwnd = null;

--- a/test/openUrl.test.ts
+++ b/test/openUrl.test.ts
@@ -36,7 +36,7 @@ describe('openUrl', () => {
     await handler({ sender: { send: jest.fn() } } as any, 'https://example.com');
 
     expect(BrowserWindowMock).toHaveBeenCalled();
-    expect(loadURLMock).toHaveBeenCalledWith('https://example.com');
+    expect(loadURLMock).toHaveBeenCalledWith('https://example.com/');
   });
 
   test('rejects invalid url', async () => {
@@ -44,6 +44,17 @@ describe('openUrl', () => {
     settings['lookup.misc'].onlyCopy = false;
     const handler = ipcMainHandlers['sw:openlink'];
     await handler({ sender: { send: jest.fn() } } as any, 'ftp://example.com');
+
+    expect(BrowserWindowMock).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  test('rejects url without http protocol', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    settings['lookup.misc'].onlyCopy = false;
+    const handler = ipcMainHandlers['sw:openlink'];
+    await handler({ sender: { send: jest.fn() } } as any, 'example.com');
 
     expect(BrowserWindowMock).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- remove unused `event` param in `openUrl`
- validate protocols explicitly and normalize URL used for loading
- adjust tests for updated logic and add case for missing protocol

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859be1703dc832583fbc390bcc93b4f