### PR TITLE
Add unit tests for bwa ipc handlers

### DIFF
--- a/test/bwaAnalyser.test.ts
+++ b/test/bwaAnalyser.test.ts
@@ -1,0 +1,27 @@
+const ipcMainHandlers: Record<string, (...args: any[]) => any> = {};
+
+jest.mock('electron', () => ({
+  ipcMain: {
+    on: (channel: string, listener: (...args: any[]) => void) => {
+      ipcMainHandlers[channel] = listener;
+    },
+  },
+  dialog: {},
+  app: undefined,
+  BrowserWindow: class {},
+  Menu: {},
+}));
+
+import '../app/ts/main/bwa/analyser';
+
+describe('bwa analyser handler', () => {
+  test('forwards results to renderer', () => {
+    const handler = ipcMainHandlers['bwa:analyser.start'];
+    const send = jest.fn();
+    const contents = { id: [1], domain: ['example.com'] } as any;
+
+    handler({ sender: { send } } as any, contents);
+
+    expect(send).toHaveBeenCalledWith('bwa:analyser.tablegen', contents);
+  });
+});

--- a/test/bwaFileinput.test.ts
+++ b/test/bwaFileinput.test.ts
@@ -1,0 +1,47 @@
+const ipcMainHandlers: Record<string, (...args: any[]) => any> = {};
+export const mockShowOpenDialogSync = jest.fn();
+
+jest.mock('electron', () => ({
+  ipcMain: {
+    on: (channel: string, listener: (...args: any[]) => void) => {
+      ipcMainHandlers[channel] = listener;
+    },
+  },
+  dialog: { showOpenDialogSync: mockShowOpenDialogSync },
+  app: undefined,
+  BrowserWindow: class {},
+  Menu: {},
+}));
+
+import '../app/ts/main/bwa/fileinput';
+
+describe('bwa fileinput handler', () => {
+  beforeEach(() => {
+    mockShowOpenDialogSync.mockReset();
+  });
+
+  test('sends selected file path to renderer', () => {
+    const handler = ipcMainHandlers['bwa:input.file'];
+    mockShowOpenDialogSync.mockReturnValue('/tmp/test.txt');
+    const send = jest.fn();
+
+    handler({ sender: { send } } as any);
+
+    expect(mockShowOpenDialogSync).toHaveBeenCalledWith({
+      title: 'Select wordlist file',
+      buttonLabel: 'Open',
+      properties: ['openFile', 'showHiddenFiles'],
+    });
+    expect(send).toHaveBeenCalledWith('bwa:fileinput.confirmation', '/tmp/test.txt');
+  });
+
+  test('forwards undefined when no file selected', () => {
+    const handler = ipcMainHandlers['bwa:input.file'];
+    mockShowOpenDialogSync.mockReturnValue(undefined);
+    const send = jest.fn();
+
+    handler({ sender: { send } } as any);
+
+    expect(send).toHaveBeenCalledWith('bwa:fileinput.confirmation', undefined);
+  });
+});


### PR DESCRIPTION
## Summary
- test bwa file input ipc handler event logic
- test bwa analyser ipc handler event logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859be572e5483258b1c0406981df3a9