### PR TITLE
Improve file read error handling

### DIFF
--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -9,7 +9,7 @@ try {
 } catch {
   remote = (electron as any).remote;
 }
-const { app } = electron;
+const { app, ipcRenderer } = electron as any;
 import debugModule from 'debug';
 const debug = debugModule('common.settings');
 
@@ -105,6 +105,9 @@ export async function load(): Promise<Settings> {
       }
     } catch (e) {
       debug(`Failed to load custom configuration with error: ${e}`);
+      if (!isMainProcess && ipcRenderer) {
+        ipcRenderer.send('app:error', `Failed to load configuration: ${e}`);
+      }
     }
   }
 

--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -94,9 +94,13 @@ app.on('ready', async function() {
   const configPath = path.join(app.getPath('userData'), configuration.filepath);
   if (fs.existsSync(configPath)) {
     debug("Reading persistent configurations");
-    settings = JSON.parse(
-      await fs.promises.readFile(configPath, 'utf8')
-    ) as MainSettings;
+    try {
+      const raw = await fs.promises.readFile(configPath, 'utf8');
+      settings = JSON.parse(raw) as MainSettings;
+    } catch (e) {
+      debug(`Failed to read persistent configurations: ${e}`);
+      dialog.showErrorBox('Error', String(e));
+    }
   } else {
     debug("Using default configurations");
   }
@@ -222,6 +226,17 @@ ipcMain.on('app:minimize', function() {
  */
 ipcMain.on('app:debug', function(event: IpcMainEvent, message: any) {
   debugb(message);
+
+  return;
+});
+
+/*
+  ipcMain.on('app:error', function(...) {...});
+    Application error event
+ */
+ipcMain.on('app:error', function(event: IpcMainEvent, message: any) {
+  debug(`Error: ${message}`);
+  dialog.showErrorBox('Error', String(message));
 
   return;
 });

--- a/app/ts/renderer/bw/fileinput.ts
+++ b/app/ts/renderer/bw/fileinput.ts
@@ -40,17 +40,29 @@ ipcRenderer.on('bw:fileinput.confirmation', async function(event, filePath: stri
     if (isDragDrop === true) {
       $('#bwEntry').addClass('is-hidden');
       $('#bwFileinputloading').removeClass('is-hidden');
-      bwFileStats = (await fs.promises.stat(filePath as string)) as FileStats;
-      bwFileStats.filename = (filePath as string).replace(/^.*[\\\/]/, '');
-      bwFileStats.humansize = conversions.byteToHumanFileSize(bwFileStats.size, misc.useStandardSize);
-      $('#bwFileSpanInfo').text('Loading file contents...');
-      bwFileContents = await fs.promises.readFile(filePath as string);
+      try {
+        bwFileStats = (await fs.promises.stat(filePath as string)) as FileStats;
+        bwFileStats.filename = (filePath as string).replace(/^.*[\\\/]/, '');
+        bwFileStats.humansize = conversions.byteToHumanFileSize(bwFileStats.size, misc.useStandardSize);
+        $('#bwFileSpanInfo').text('Loading file contents...');
+        bwFileContents = await fs.promises.readFile(filePath as string);
+      } catch (e) {
+        ipcRenderer.send('app:error', `Failed to read file: ${e}`);
+        $('#bwFileSpanInfo').text('Failed to load file');
+        return;
+      }
     } else {
-      bwFileStats = (await fs.promises.stat((filePath as string[])[0])) as FileStats;
-      bwFileStats.filename = (filePath as string[])[0].replace(/^.*[\\\/]/, '');
-      bwFileStats.humansize = conversions.byteToHumanFileSize(bwFileStats.size, misc.useStandardSize);
-      $('#bwFileSpanInfo').text('Loading file contents...');
-      bwFileContents = await fs.promises.readFile((filePath as string[])[0]);
+      try {
+        bwFileStats = (await fs.promises.stat((filePath as string[])[0])) as FileStats;
+        bwFileStats.filename = (filePath as string[])[0].replace(/^.*[\\\/]/, '');
+        bwFileStats.humansize = conversions.byteToHumanFileSize(bwFileStats.size, misc.useStandardSize);
+        $('#bwFileSpanInfo').text('Loading file contents...');
+        bwFileContents = await fs.promises.readFile((filePath as string[])[0]);
+      } catch (e) {
+        ipcRenderer.send('app:error', `Failed to read file: ${e}`);
+        $('#bwFileSpanInfo').text('Failed to load file');
+        return;
+      }
     }
     $('#bwFileSpanInfo').text('Getting line count...');
     bwFileStats.linecount = bwFileContents.toString().split('\n').length;

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -33,21 +33,33 @@ ipcRenderer.on('bwa:fileinput.confirmation', async function(event, filePath: str
     if (isDragDrop === true) {
       $('#bwaEntry').addClass('is-hidden');
       $('#bwaFileinputloading').removeClass('is-hidden');
-      bwaFileStats = fs.statSync(filePath as string) as FileStats;
-      bwaFileStats.filename = (filePath as string).replace(/^.*[\\\/]/, '');
-      bwaFileStats.humansize = conversions.byteToHumanFileSize(bwaFileStats.size, settings['lookup.misc'].useStandardSize);
-      $('#bwaFileSpanInfo').text('Loading file contents...');
-      bwaFileContents = Papa.parse((await fs.promises.readFile(filePath as string)).toString(), {
-        header: true
-      });
+      try {
+        bwaFileStats = fs.statSync(filePath as string) as FileStats;
+        bwaFileStats.filename = (filePath as string).replace(/^.*[\\\/]/, '');
+        bwaFileStats.humansize = conversions.byteToHumanFileSize(bwaFileStats.size, settings['lookup.misc'].useStandardSize);
+        $('#bwaFileSpanInfo').text('Loading file contents...');
+        bwaFileContents = Papa.parse((await fs.promises.readFile(filePath as string)).toString(), {
+          header: true
+        });
+      } catch (e) {
+        ipcRenderer.send('app:error', `Failed to read file: ${e}`);
+        $('#bwaFileSpanInfo').text('Failed to load file');
+        return;
+      }
     } else {
-      bwaFileStats = fs.statSync((filePath as string[])[0]) as FileStats;
-      bwaFileStats.filename = (filePath as string[])[0].replace(/^.*[\\\/]/, '');
-      bwaFileStats.humansize = conversions.byteToHumanFileSize(bwaFileStats.size, settings['lookup.misc'].useStandardSize);
-      $('#bwaFileSpanInfo').text('Loading file contents...');
-      bwaFileContents = Papa.parse((await fs.promises.readFile((filePath as string[])[0])).toString(), {
-        header: true
-      });
+      try {
+        bwaFileStats = fs.statSync((filePath as string[])[0]) as FileStats;
+        bwaFileStats.filename = (filePath as string[])[0].replace(/^.*[\\\/]/, '');
+        bwaFileStats.humansize = conversions.byteToHumanFileSize(bwaFileStats.size, settings['lookup.misc'].useStandardSize);
+        $('#bwaFileSpanInfo').text('Loading file contents...');
+        bwaFileContents = Papa.parse((await fs.promises.readFile((filePath as string[])[0])).toString(), {
+          header: true
+        });
+      } catch (e) {
+        ipcRenderer.send('app:error', `Failed to read file: ${e}`);
+        $('#bwaFileSpanInfo').text('Failed to load file');
+        return;
+      }
     }
     //console.log(bwaFileContents.data[0]);
     $('#bwaFileSpanInfo').text('Getting line count...');

--- a/test/settingsReadError.test.ts
+++ b/test/settingsReadError.test.ts
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+import '../test/electronMock';
+import { mockGetPath, mockIpcSend } from '../test/electronMock';
+import { loadSettings, settings } from '../app/ts/common/settings';
+
+describe('settings load error handling', () => {
+  test('sends IPC message when read fails', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(__dirname, 'config'));
+    mockGetPath.mockReturnValue(tmpDir);
+    settings['custom.configuration'].filepath = 'fail.json';
+    jest.spyOn(fs.promises, 'readFile').mockRejectedValueOnce(new Error('fail'));
+
+    const original = JSON.parse(JSON.stringify(settings));
+    const loaded = await loadSettings();
+
+    expect(loaded).toEqual(original);
+    expect(mockIpcSend).toHaveBeenCalledWith('app:error', expect.stringContaining('fail'));
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- handle persistent config read errors in the main process
- add IPC error handler to main
- show renderer read failures via IPC
- wrap file read/stat calls in try/catch
- notify users about config load failures
- test read failure handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859be61f35c832584d14e7538ad3c04