### PR TITLE
Add typed result record and update handlers

### DIFF
--- a/app/ts/main/bw/scheduler.ts
+++ b/app/ts/main/bw/scheduler.ts
@@ -14,7 +14,7 @@ const debug = debugModule('main.bw.scheduler');
 
 export function processDomain(
   bulkWhois: BulkWhois,
-  reqtime: any[],
+  reqtime: number[],
   domainSetup: DomainSetup,
   event: IpcMainEvent,
 ): void {

--- a/app/ts/main/bw/types.ts
+++ b/app/ts/main/bw/types.ts
@@ -54,6 +54,20 @@ export interface BulkWhoisResults {
   requesttime: (string | number | null)[];
 }
 
+export interface ProcessedResult {
+  id: number;
+  domain: string | null;
+  status: string | null;
+  registrar: string | null;
+  company: string | null;
+  updatedate: string | null;
+  creationdate: string | null;
+  expirydate: string | null;
+  whoisreply: string | null;
+  whoisjson: Record<string, unknown> | null;
+  requesttime: string | number | null;
+}
+
 export interface BulkWhois {
   input: BulkWhoisInput;
   stats: BulkWhoisStats;


### PR DESCRIPTION
## Summary
- define `ProcessedResult` interface
- use typed arrays in `resultHandler` and `scheduler`
- propagate the new typing for request times and results JSON

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859be4bf08c83259526649545404d43