### PR TITLE
Fix Bulma loading in dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "postbuild": "node postbuild.js",
     "watch": "cross-env DEBUG=* tsc -w",
     "watch-assets": "node watch-assets.js",
-    "dev": "concurrently \"npm:watch\" \"npm:watch-assets\" \"electronmon .\"",
+    "dev": "npm run build && npm run postbuild && concurrently \"npm:watch\" \"npm:watch-assets\" \"electronmon .\"",
     "lint": "eslint \"app/**/*.ts\" \"test/**/*.ts\"",
     "test": "jest",
     "prebuild": "node prebuild.js"

--- a/postbuild.js
+++ b/postbuild.js
@@ -11,3 +11,12 @@ for (const folder of folders) {
   const dest = path.join(distDir, folder);
   copyRecursiveSync(src, dest);
 }
+
+// Ensure Bulma CSS is available in the final package. We keep Bulma in
+// node_modules to avoid committing the large CSS file. Here we copy the
+// necessary files into the dist directory so that style.css can @import them.
+const bulmaSrc = path.join(__dirname, 'node_modules', 'bulma', 'css');
+const bulmaDest = path.join(distDir, 'css', 'bulma', 'css');
+if (fs.existsSync(bulmaSrc)) {
+  copyRecursiveSync(bulmaSrc, bulmaDest);
+}

--- a/watch-assets.js
+++ b/watch-assets.js
@@ -22,6 +22,13 @@ for (const folder of folders) {
   copyRecursiveSync(src, dest);
 }
 
+// Also copy Bulma CSS from node_modules so style.css can import it.
+const bulmaSrc = path.join(__dirname, 'node_modules', 'bulma', 'css');
+const bulmaDest = path.join(distDir, 'css', 'bulma', 'css');
+if (fs.existsSync(bulmaSrc)) {
+  copyRecursiveSync(bulmaSrc, bulmaDest);
+}
+
 const patterns = folders.map(f => `app/${f}/**/*`);
 const watcher = watchboy(patterns, { cwd: __dirname });
 


### PR DESCRIPTION
## Summary
- ensure `npm run dev` builds and copies Bulma before launching electron

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859c1297f2883259e7e40cb48dc7bd2