### PR TITLE
Silently handle settings load failure

### DIFF
--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -99,9 +99,7 @@ function watchConfig(): void {
       debug(`Reloaded custom configuration at ${cfg}`);
     } catch (e) {
       debug(`Failed to reload configuration with error: ${e}`);
-      if (!isMainProcess && ipcRenderer) {
-        ipcRenderer.send('app:error', `Failed to load configuration: ${e}`);
-      }
+      // Silently ignore reload errors
     }
   });
 }
@@ -131,9 +129,7 @@ export async function load(): Promise<Settings> {
       }
     } catch (e) {
       debug(`Failed to load custom configuration with error: ${e}`);
-      if (!isMainProcess && ipcRenderer) {
-        ipcRenderer.send('app:error', `Failed to load configuration: ${e}`);
-      }
+      // Silently ignore loading errors
     }
   }
 

--- a/test/settingsReadError.test.ts
+++ b/test/settingsReadError.test.ts
@@ -5,7 +5,7 @@ import { mockGetPath, mockIpcSend } from '../test/electronMock';
 import { loadSettings, settings } from '../app/ts/common/settings';
 
 describe('settings load error handling', () => {
-  test('sends IPC message when read fails', async () => {
+  test('fails silently when read fails', async () => {
     const tmpDir = fs.mkdtempSync(path.join(__dirname, 'config'));
     mockGetPath.mockReturnValue(tmpDir);
     settings['custom.configuration'].filepath = 'fail.json';
@@ -15,7 +15,7 @@ describe('settings load error handling', () => {
     const loaded = await loadSettings();
 
     expect(loaded).toEqual(original);
-    expect(mockIpcSend).toHaveBeenCalledWith('app:error', expect.stringContaining('fail'));
+    expect(mockIpcSend).not.toHaveBeenCalled();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary
- ignore errors when reloading settings
- ignore errors when initially loading settings
- update test expecting IPC message to expect silence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859c68543608325894b4e719895e682