### PR TITLE
Fix openUrl typing and test coverage

### DIFF
--- a/app/ts/main/sw.ts
+++ b/app/ts/main/sw.ts
@@ -1,6 +1,6 @@
 
 import electron from 'electron';
-import type { IpcMainEvent } from 'electron';
+import type { IpcMainEvent, BrowserWindow as ElectronBrowserWindow } from 'electron';
 import * as path from 'path';
 import * as url from 'url';
 import { lookup as whoisLookup } from '../common/lookup';
@@ -102,7 +102,7 @@ function openUrl(domain: string, settings: Settings): void {
 
   debug(formatString('Opening {0} on a new window', domain));
 
-  let hwnd: any = new BrowserWindow({
+  let hwnd: ElectronBrowserWindow | null = new BrowserWindow({
     frame: true,
     height: appWindow.height,
     width: appWindow.width,

--- a/test/openUrl.test.ts
+++ b/test/openUrl.test.ts
@@ -50,6 +50,17 @@ describe('openUrl', () => {
     warnSpy.mockRestore();
   });
 
+  test('rejects malformed url string', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    settings['lookup.misc'].onlyCopy = false;
+    const handler = ipcMainHandlers['sw:openlink'];
+    await handler({ sender: { send: jest.fn() } } as any, 'http://');
+
+    expect(BrowserWindowMock).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
   test('rejects url without http protocol', async () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     settings['lookup.misc'].onlyCopy = false;


### PR DESCRIPTION
## Summary
- type `hwnd` as `BrowserWindow | null`
- ensure cleanup closure works without `any`
- test invalid URLs to confirm window creation only for valid ones

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859c72433e08325ba779e479a349522