### PR TITLE
Switch dark mode toggle to dropdown

### DIFF
--- a/app/html/tabs/op/opEntry.html
+++ b/app/html/tabs/op/opEntry.html
@@ -42,10 +42,12 @@
   <tr>
     <th colspan="2">
       dark mode <span class="content is-small">(enable dark theme)</span>
-      <label class="switch" style="margin-left: 0.5em;">
-        <input id="theme.darkMode" type="checkbox">
-        <span class="check"></span>
-      </label>
+      <div class="select" style="margin-left: 0.5em;">
+        <select id="theme.darkMode">
+          <option value="false">light</option>
+          <option value="true">dark</option>
+        </select>
+      </div>
     </th>
   </tr>
   <tr>

--- a/app/ts/renderer/darkmode.ts
+++ b/app/ts/renderer/darkmode.ts
@@ -7,13 +7,13 @@ function applyDarkMode(enabled: boolean): void {
 }
 
 $(document).ready(() => {
-  const checkbox = $('#theme\\.darkMode');
+  const select = $('#theme\\.darkMode');
   const stored = settings.theme?.darkMode ?? false;
   applyDarkMode(stored);
-  if (checkbox.length) {
-    checkbox.prop('checked', stored);
-    checkbox.on('change', () => {
-      const state = checkbox.is(':checked');
+  if (select.length) {
+    select.val(stored ? 'true' : 'false');
+    select.on('change', () => {
+      const state = select.val() === 'true';
       settings.theme = settings.theme || { darkMode: false };
       settings.theme.darkMode = state;
       void saveSettings(settings);


### PR DESCRIPTION
## Summary
- replace dark mode switch with a dropdown in `opEntry.html`
- update dark mode script to handle dropdown selection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859cc677f108325ab5597478f876c7d