### PR TITLE
Implement Bulma dark mode

### DIFF
--- a/app/html/mainPanel.html
+++ b/app/html/mainPanel.html
@@ -17,7 +17,6 @@
 
   <link href="../css/cousine.css" rel="stylesheet">
   <link href="../css/style.css" rel="stylesheet">
-  <link id="dark-theme" href="../css/dark.css" rel="stylesheet" disabled>
   <link href="../css/tables.css" rel="stylesheet">
   <!--<link href="../css/fontawesome/all.min.css" rel="stylesheet">-->
   <script>

--- a/app/ts/renderer/darkmode.ts
+++ b/app/ts/renderer/darkmode.ts
@@ -2,8 +2,12 @@ import $ from 'jquery';
 import { settings, saveSettings } from '../common/settings';
 
 function applyDarkMode(enabled: boolean): void {
-  const link = document.getElementById('dark-theme') as HTMLLinkElement | null;
-  if (link) link.disabled = !enabled;
+  const html = document.documentElement;
+  if (enabled) {
+    html.setAttribute('data-theme', 'dark');
+  } else {
+    html.setAttribute('data-theme', 'light');
+  }
 }
 
 $(document).ready(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@electron/packager": "^18.3.6",
         "@electron/remote": "^2.1.2",
         "@fortawesome/fontawesome-free": "^6.7.2",
-        "bulma": "^0.9.2",
+        "bulma": "^1.0.4",
         "change-case": "^4.1.2",
         "cp": "^0.2.0",
         "csv": "^5.4.0",
@@ -3395,9 +3395,9 @@
       "license": "MIT"
     },
     "node_modules/bulma": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.9.4.tgz",
-      "integrity": "sha512-86FlT5+1GrsgKbPLRRY7cGDg8fsJiP/jzTqXXVqiUZZ2aZT8uemEOHlU1CDU+TxklPEZ11HZNNWclRBBecP4CQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bulma/-/bulma-1.0.4.tgz",
+      "integrity": "sha512-Ffb6YGXDiZYX3cqvSbHWqQ8+LkX6tVoTcZuVB3lm93sbAVXlO0D6QlOTMnV6g18gILpAXqkG2z9hf9z4hCjz2g==",
       "license": "MIT"
     },
     "node_modules/cacheable-lookup": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@electron/packager": "^18.3.6",
     "@electron/remote": "^2.1.2",
     "@fortawesome/fontawesome-free": "^6.7.2",
-    "bulma": "^0.9.2",
+    "bulma": "^1.0.4",
     "change-case": "^4.1.2",
     "cp": "^0.2.0",
     "csv": "^5.4.0",


### PR DESCRIPTION
## Summary
- upgrade Bulma to v1.0.4
- remove custom dark.css usage
- toggle Bulma dark theme with `data-theme` attribute

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859ce0916308325ac1824c7c562451a