### PR TITLE
Implement auto-save for options

### DIFF
--- a/app/html/tabs/op/opEntry.html
+++ b/app/html/tabs/op/opEntry.html
@@ -3,6 +3,12 @@
   For basic usage changes to these settings are not recommended as they can result in crashing, malfunction or unexpected behavior as direct result.<br>
   You'll need to restart the application to fully apply any changes.</h5>
 <hr>
+<p id="opSavedIndicator" class="has-text-success is-hidden">
+  <span class="icon is-small">
+    <i class="fas fa-check"></i>
+  </span>
+  Saved
+</p>
 <table id="toTable" class="table is-striped is-hoverable is-fullwidth">
   <tr>
     <th colspan=2>

--- a/app/ts/renderer/index.ts
+++ b/app/ts/renderer/index.ts
@@ -3,3 +3,4 @@ import './sw';
 import './bw';
 import './bwa';
 import './darkmode';
+import './options';

--- a/app/ts/renderer/options.ts
+++ b/app/ts/renderer/options.ts
@@ -1,0 +1,59 @@
+import $ from 'jquery';
+import { settings, saveSettings } from '../common/settings';
+
+function getValue(path: string): any {
+  return path.split('.').reduce((obj: any, key: string) => (obj ? obj[key] : undefined), settings);
+}
+
+function setValue(path: string, value: any): void {
+  const keys = path.split('.');
+  let obj: any = settings;
+  for (let i = 0; i < keys.length - 1; i++) {
+    const k = keys[i];
+    if (!(k in obj)) obj[k] = {};
+    obj = obj[k];
+  }
+  obj[keys[keys.length - 1]] = value;
+}
+
+function parseValue(val: string): any {
+  if (val === 'true') return true;
+  if (val === 'false') return false;
+  if (/^-?\d+(\.\d+)?$/.test(val)) return Number(val);
+  return val;
+}
+
+function showSaved(): void {
+  const indicator = $('#opSavedIndicator');
+  indicator.removeClass('is-hidden');
+  setTimeout(() => indicator.addClass('is-hidden'), 1500);
+}
+
+$(document).ready(() => {
+  const container = $('#opEntry');
+  container.find('input[id], select[id]').each((_, el) => {
+    const $el = $(el);
+    const id = $el.attr('id');
+    if (!id) return;
+    const path = id.replace(/^appSettings\./, 'app.');
+    const val = getValue(path);
+    if (val !== undefined) {
+      if ($el.is(':checkbox')) {
+        $el.prop('checked', Boolean(val));
+      } else {
+        $el.val(String(val));
+      }
+    }
+  });
+
+  container.on('change', 'input[id], select[id]', function () {
+    const $el = $(this);
+    const id = $el.attr('id');
+    if (!id) return;
+    const path = id.replace(/^appSettings\./, 'app.');
+    const raw = $el.is(':checkbox') ? $el.prop('checked') : $el.val();
+    const val = typeof raw === 'string' ? parseValue(raw) : raw;
+    setValue(path, val);
+    void saveSettings(settings).then(showSaved);
+  });
+});


### PR DESCRIPTION
## Summary
- show a green checkmark when options are saved
- automatically save settings when options change
- load option values on page load

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859cf32fbac832598ab29f910344302