### PR TITLE
Remove no-margin-left from nav extended menu

### DIFF
--- a/app/html/navigation/navTop.html
+++ b/app/html/navigation/navTop.html
@@ -1,7 +1,7 @@
 <nav role="navigation" aria-label="main navigation" class="navbar" style="-webkit-app-region: drag">
   <div class="navbar-brand">
 
-    <a id="navButtonExtendedmenu" role="button" class="navbar-burger no-margin-left" aria-label="menu" aria-expanded="false" style="-webkit-app-region: no-drag">
+    <a id="navButtonExtendedmenu" role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" style="-webkit-app-region: no-drag">
       <span aria-hidden="true"></span>
       <span aria-hidden="true"></span>
       <span aria-hidden="true"></span>


### PR DESCRIPTION
## Summary
- remove `no-margin-left` CSS class from extended menu nav button

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d322c79c8325bca079fbf28ec0fe