### PR TITLE
Fix toTable text visibility in dark mode

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -153,3 +153,7 @@ html.has-navbar-fixed-top {
   height: 100%;
   border-radius: 0;
 }
+
+html[data-theme='dark'] #toTable .button {
+  color: #363636;
+}


### PR DESCRIPTION
## Summary
- ensure tools table button text remains dark in dark mode to match light backgrounds

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d2898b408325a24998fa9c8a14d0