### PR TITLE
Fix hero layout overflow

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -162,3 +162,14 @@ html[data-theme='dark'] #toTable .button {
 :root {
   scrollbar-width: thin;
 }
+
+/* Scrollable hero body container */
+#contents-container.hero-body {
+  display: block;
+  overflow-y: auto;
+  height: calc(100vh - var(--bulma-navbar-height));
+}
+
+.hero-head {
+  z-index: 1;
+}


### PR DESCRIPTION
## Summary
- allow `#contents-container` to scroll and account for navbar height
- keep hero header above other elements

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ebc1c53483259bfd415eecfa4c80