### PR TITLE
Fix TypeScript syntax issues

### DIFF
--- a/app/ts/main/singlewhois.ts
+++ b/app/ts/main/singlewhois.ts
@@ -48,7 +48,7 @@ ipcMain.on('singlewhois:lookup', async function(event, domain) {
  */
 ipcMain.on('singlewhois:openlink', function(event, domain) {
   const {
-    lookupMisc': misc
+    lookupMisc: misc
   } = settings;
 
   misc.onlyCopy ? copyToClipboard(event, domain) : openUrl(domain, settings);

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -34,7 +34,7 @@ ipcRenderer.on('bwa:fileinput.confirmation', async function(event, filePath: str
       try {
         bwaFileStats = fs.statSync(filePath as string) as FileStats;
         bwaFileStats.filename = (filePath as string).replace(/^.*[\\\/]/, '');
-        bwaFileStats.humansize = conversions.byteToHumanFileSize(bwaFileStats.size, settings[lookupMisc'].useStandardSize);
+        bwaFileStats.humansize = conversions.byteToHumanFileSize(bwaFileStats.size, settings.lookupMisc.useStandardSize);
         $('#bwaFileSpanInfo').text('Loading file contents...');
         bwaFileContents = Papa.parse((await fs.promises.readFile(filePath as string)).toString(), {
           header: true
@@ -48,7 +48,7 @@ ipcRenderer.on('bwa:fileinput.confirmation', async function(event, filePath: str
       try {
         bwaFileStats = fs.statSync((filePath as string[])[0]) as FileStats;
         bwaFileStats.filename = (filePath as string[])[0].replace(/^.*[\\\/]/, '');
-        bwaFileStats.humansize = conversions.byteToHumanFileSize(bwaFileStats.size, settings[lookupMisc'].useStandardSize);
+        bwaFileStats.humansize = conversions.byteToHumanFileSize(bwaFileStats.size, settings.lookupMisc.useStandardSize);
         $('#bwaFileSpanInfo').text('Loading file contents...');
         bwaFileContents = Papa.parse((await fs.promises.readFile((filePath as string[])[0])).toString(), {
           header: true


### PR DESCRIPTION
## Summary
- fix destructuring syntax in `singlewhois.ts`
- correct property access for `lookupMisc` in `fileinput.ts`

## Testing
- `npm run build`
- `npm test` *(fails: settingsReload.test.ts, whoiswrapper.test.ts, dnsLookup.test.ts, convertDomain.test.ts, isDomainAvailable.test.ts, patterns.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6859f0de50ec83258862845774617d69