### PR TITLE
Fix singlewhois openlink destructuring

### DIFF
--- a/app/ts/main/singlewhois.ts
+++ b/app/ts/main/singlewhois.ts
@@ -47,9 +47,7 @@ ipcMain.on('singlewhois:lookup', async function(event, domain) {
     Open link or copy to clipboard
  */
 ipcMain.on('singlewhois:openlink', function(event, domain) {
-  const {
-    lookupMisc: misc
-  } = settings;
+  const misc = settings.lookupMisc;
 
   misc.onlyCopy ? copyToClipboard(event, domain) : openUrl(domain, settings);
 


### PR DESCRIPTION
## Summary
- fix singlewhois openlink destructuring alias causing runtime error

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859f2695f18832580cd5a09ab45f032