### PR TITLE
Add Prettier formatting workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,6 +23,8 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm install
+      - name: Check formatting
+        run: npm run format -- --check
       - run: npm run lint
 
   type-check:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+release_builds/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "printWidth": 100
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "watch-assets": "node watch-assets.js",
     "dev": "npm run build && npm run postbuild && concurrently \"npm:watch\" \"npm:watch-assets\" \"electronmon .\"",
     "lint": "eslint \"app/**/*.ts\" \"test/**/*.ts\"",
+    "format": "prettier --ignore-path .prettierignore .",
     "test": "jest",
     "prebuild": "node prebuild.js"
   },

--- a/readme.md
+++ b/readme.md
@@ -169,6 +169,8 @@ After installing, execute `npm test` to run the project's unit tests.
 Development packages such as `@types/node` and `@types/jest` are required for TypeScript compilation and running tests. The `prebuild` script will auto-install dependencies if `node_modules` is missing.
 Use `npm run dev` to watch source files and automatically reload the application during development. Static assets such as stylesheets are synced to `dist` while this command runs, so CSS changes are picked up without rebuilding.
 
+Run `npm run format -- --write` before committing to apply Prettier formatting. CI will verify formatting with `npm run format -- --check`.
+
 
 ## Settings
 


### PR DESCRIPTION
## Summary
- add Prettier config and ignore files
- add `npm run format` script
- check formatting in CI
- mention formatting instructions in readme

## Testing
- `npm ci`
- `npm run lint`
- `npm run format -- --check` *(fails: code style issues found in 86 files)*
- `npm test` *(fails: multiple unit tests report TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_6859f68980488325af5e10b13005e32c