### PR TITLE
Add cross-platform workflow matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,9 +11,10 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [18.x, 20.x, 22.x, 23.x, 24.x]
     steps:
       - uses: actions/checkout@v4
@@ -28,10 +29,11 @@ jobs:
       - run: npm run lint
 
   type-check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: lint
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [18.x, 20.x, 22.x, 23.x, 24.x]
     steps:
       - uses: actions/checkout@v4
@@ -44,10 +46,11 @@ jobs:
       - run: npx tsc --noEmit
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: type-check
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [18.x, 20.x, 22.x, 23.x, 24.x]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- run matrix across ubuntu, windows and macOS
- keep package build on Linux

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: settings undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6859fc0aa72883259e3bc74faceb2ef9