### PR TITLE
Add electron cache to packaging workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -74,6 +74,13 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
+      - name: Cache Electron
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/electron
+            ~/.cache/electron-builder
+          key: ${{ runner.os }}-electron-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         run: npm install
       - run: npm run package-linux


### PR DESCRIPTION
## Summary
- cache Electron downloads in package job so subsequent runs are faster

## Testing
- `npm test`
- `npm run lint`
- `npm run format -- --check` *(fails: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_6859fdd0d7348325a547951841eead2e