### PR TITLE
Enable coverage reports

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -61,6 +61,11 @@ jobs:
       - name: Install dependencies
         run: npm install
       - run: npm test
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-${{ matrix.os }}-${{ matrix.node-version }}
+          path: coverage/
 
   package:
     needs: build

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ release_builds/
 node_modules/
 dist/
 
+coverage/
+
 settings.json
 reload.json
 .DS_Store

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,5 +4,7 @@ module.exports = {
   testMatch: ['**/test/**/*.test.ts'],
   transform: {
     '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.json', diagnostics: false }]
-  }
+  },
+  collectCoverage: true,
+  coverageDirectory: 'coverage'
 };

--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,7 @@ Check out and download the latest release for your architecture/OS.
 
 ![Latest tag](https://img.shields.io/github/tag/whois-team/whoisdigger.svg?label=Latest%20tag&style=flat)
 [![Check out releases](https://img.shields.io/badge/Checkout%20releases-%20-orange.svg)](https://github.com/whois-team/whoisdigger/releases)
+[![Coverage](https://img.shields.io/badge/coverage-generated%20in%20CI-blue.svg)](https://github.com/whois-team/whoisdigger/actions/workflows/node.js.yml)
 
 ### Latest changes
 
@@ -168,6 +169,7 @@ dependencies before building. This script runs whenever you execute `npm run bui
 
 Run `npm ci` before testing or linting to install dependencies exactly as locked.
 After installing, execute `npm test` to run the project's unit tests.
+Running tests also generates a coverage report in the `coverage/` directory.
 Development packages such as `@types/node` and `@types/jest` are required for TypeScript compilation and running tests. The `prebuild` script will auto-install dependencies if `node_modules` is missing.
 Use `npm run dev` to watch source files and automatically reload the application during development. Static assets such as stylesheets are synced to `dist` while this command runs, so CSS changes are picked up without rebuilding.
 


### PR DESCRIPTION
## Summary
- collect Jest coverage and save it to `coverage/`
- ignore the coverage directory
- upload coverage artifact in CI workflow
- show a CI coverage badge in the README
- note that tests generate coverage reports

## Testing
- `npm run format -- --check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859fff864248325abce52ba5eeca058