### PR TITLE
Add proxy helper utilities

### DIFF
--- a/app/ts/appsettings.ts
+++ b/app/ts/appsettings.ts
@@ -90,6 +90,8 @@ const appSettings = {
       // Lookup proxy
       enable: false, // Enable proxy requests (default: false)
       mode: 'single', // Proxy request mode, 'single' - fixed single proxy, 'multi' - multiple proxies (default: 'single')
+      single: '', // Single proxy address host:port
+      list: [], // Proxy list for multi mode
       /*
       multimode
         Multi proxy mode
@@ -222,6 +224,8 @@ export const appSettingsDescriptions: Record<string, string> = {
   'lookupRandomizeTimeBetween.maximum': 'Maximum delay',
   'lookupProxy.enable': 'Enable proxy requests',
   'lookupProxy.mode': 'Proxy mode',
+  'lookupProxy.single': 'Single proxy address',
+  'lookupProxy.list': 'Proxy list',
   'lookupProxy.multimode': 'Proxy rotation mode',
   'lookupProxy.check': 'Check proxy health',
   'lookupProxy.checktype': 'Proxy health check type',

--- a/app/ts/common/index.ts
+++ b/app/ts/common/index.ts
@@ -5,6 +5,7 @@ import { parseRawData as ParseRawData } from './parser';
 import { lookup as WhoisLookup } from './lookup';
 import DnsLookup from './dnsLookup';
 import WordlistTools from './wordlist';
+import { getProxy } from './proxy';
 
 export {
   Conversions,
@@ -13,5 +14,6 @@ export {
   ParseRawData,
   WhoisLookup,
   DnsLookup,
-  WordlistTools
+  WordlistTools,
+  getProxy
 };

--- a/app/ts/common/lookup.ts
+++ b/app/ts/common/lookup.ts
@@ -4,6 +4,7 @@ import uts46 from 'idna-uts46';
 import whois from 'whois';
 import debugModule from 'debug';
 import { settings, Settings } from './settings';
+import { getProxy } from './proxy';
 
 const debug = debugModule('common.whoisWrapper');
 
@@ -73,6 +74,10 @@ export function getWhoisOptions(): Record<string, unknown> {
   options.follow = getWhoisParameters(follow);
   options.timeout = getWhoisParameters(timeout);
   options.verbose = general.verbose;
+  const proxy = getProxy();
+  if (proxy) {
+    options.proxy = proxy;
+  }
 
   return options;
 }

--- a/app/ts/common/proxy.ts
+++ b/app/ts/common/proxy.ts
@@ -1,0 +1,55 @@
+import { settings } from './settings';
+
+export interface ProxyInfo {
+  ipaddress: string;
+  port: number;
+  type?: number;
+}
+
+let index = 0;
+
+export function resetProxyRotation(): void {
+  index = 0;
+}
+
+export function getProxy(): ProxyInfo | undefined {
+  const proxy = settings.lookupProxy;
+  if (!proxy || !proxy.enable) {
+    return undefined;
+  }
+
+  let list: string[] = [];
+  if (proxy.mode === 'single' && typeof proxy.single === 'string') {
+    list = [proxy.single];
+  } else if (proxy.mode === 'multi' && Array.isArray(proxy.list)) {
+    list = proxy.list;
+  }
+
+  if (list.length === 0) {
+    return undefined;
+  }
+
+  let entry: string;
+  switch (proxy.multimode) {
+    case 'random':
+      entry = list[Math.floor(Math.random() * list.length)];
+      break;
+    case 'ascending':
+      index = Math.min(index + 1, list.length - 1);
+      entry = list[index];
+      break;
+    case 'descending':
+      index = index <= 0 ? list.length - 1 : index - 1;
+      entry = list[index];
+      break;
+    default:
+      entry = list[index];
+      index = (index + 1) % list.length;
+      break;
+  }
+
+  const [ip, port] = entry.split(':');
+  const portNum = parseInt(port ?? '0', 10);
+  if (!ip || !portNum) return undefined;
+  return { ipaddress: ip, port: portNum, type: 5 };
+}

--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -30,6 +30,15 @@ export interface Settings {
   lookupRandomizeFollow: { randomize: boolean; minimumDepth: number; maximumDepth: number };
   lookupRandomizeTimeout: { randomize: boolean; minimum: number; maximum: number };
   lookupRandomizeTimeBetween: { randomize: boolean; minimum: number; maximum: number };
+  lookupProxy: {
+    enable: boolean;
+    mode: string;
+    multimode: string;
+    check: boolean;
+    checktype: string;
+    single?: string;
+    list?: string[];
+  };
   lookupAssumptions: {
     uniregistry: boolean;
     ratelimit: boolean;

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -1,0 +1,38 @@
+import './electronMock';
+import { settings } from '../app/ts/common/settings';
+import { getProxy, resetProxyRotation } from '../app/ts/common/proxy';
+
+describe('proxy helper', () => {
+  afterEach(() => {
+    resetProxyRotation();
+    settings.lookupProxy.enable = false;
+    settings.lookupProxy.single = '';
+    settings.lookupProxy.list = [];
+  });
+
+  test('returns undefined when disabled', () => {
+    settings.lookupProxy.enable = false;
+    expect(getProxy()).toBeUndefined();
+  });
+
+  test('returns single proxy when enabled', () => {
+    settings.lookupProxy.enable = true;
+    settings.lookupProxy.mode = 'single';
+    settings.lookupProxy.single = '1.2.3.4:1080';
+    const proxy = getProxy();
+    expect(proxy).toEqual({ ipaddress: '1.2.3.4', port: 1080, type: 5 });
+  });
+
+  test('rotates proxies sequentially', () => {
+    settings.lookupProxy.enable = true;
+    settings.lookupProxy.mode = 'multi';
+    settings.lookupProxy.list = ['1.1.1.1:8080', '2.2.2.2:8080'];
+    settings.lookupProxy.multimode = 'sequential';
+    const first = getProxy();
+    const second = getProxy();
+    const third = getProxy();
+    expect(first).toEqual({ ipaddress: '1.1.1.1', port: 8080, type: 5 });
+    expect(second).toEqual({ ipaddress: '2.2.2.2', port: 8080, type: 5 });
+    expect(third).toEqual({ ipaddress: '1.1.1.1', port: 8080, type: 5 });
+  });
+});

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -114,6 +114,16 @@ declare module 'app/ts/common/parseRawData' {
   export default parseRawData;
 }
 
+declare module 'app/ts/common/proxy' {
+  export interface ProxyInfo {
+    ipaddress: string;
+    port: number;
+    type?: number;
+  }
+  export function getProxy(): ProxyInfo | undefined;
+  export function resetProxyRotation(): void;
+}
+
 declare module 'app/ts/main/bw/auxiliary' {
   import type { IpcMainEvent } from 'electron';
   export function resetUiCounters(event: IpcMainEvent): void;


### PR DESCRIPTION
## Summary
- allow single or rotating proxy use during lookups
- export proxy helper from common index
- expose proxy configuration in settings and defaults
- test proxy utility behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a066a2fdc8325a0bcffce925aad19