### PR TITLE
Add cross-env debug script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "npm run build && npm run postbuild && electron .",
     "debug-powershell": "@powershell -Command $env:DEBUG='*';npm start;",
     "debug-cmd": "set DEBUG=* & npm start",
+    "debug": "cross-env DEBUG=* npm start",
     "package-mac": "npm run build && npm run postbuild && @electron/packager . --overwrite --platform=darwin --arch=x64 --icon=app/icons/app.icns --prune=true --out=release_builds",
     "package-win": "npm run build && npm run postbuild && @electron/packager . whoisdigger --overwrite --asar --platform=win32 --arch=ia32 --icon=app/icons/app.ico --prune=true --out=release_builds --version-string.CompanyName=\"WhoisTeam\" --version-string.FileDescription=\"WhoisTeam Whoisdigger\" --version-string.ProductName=\"whoisdigger\"",
     "package-linux": "npm run build && npm run postbuild && @electron/packager . whoisdigger --overwrite --asar --platform=linux --arch=x64 --icon=app/icons/app.png --prune=true --out=release_builds",

--- a/readme.md
+++ b/readme.md
@@ -105,6 +105,12 @@ which will compile the source to `dist` and launch the application.
 
 ### Debug
 
+Run with debugging enabled:
+
+```
+npm run debug
+```
+
 Windows Powershell
 
 ```


### PR DESCRIPTION
## Summary
- add a cross-platform `debug` npm script
- mention the new script in the Debug section of the readme

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a73ab4b948325b5d6bfe32141c14d