### PR TITLE
Add concurrency to Node.js CI workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,6 +9,10 @@ on:
     branches: ['**']
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary
- add `concurrency` to Node.js CI so only one run per branch executes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a73e64b388325bf84a7873024a778