### PR TITLE
Fix build error for better-sqlite3 types

### DIFF
--- a/app/ts/common/requestCache.ts
+++ b/app/ts/common/requestCache.ts
@@ -1,4 +1,5 @@
 import Database from 'better-sqlite3';
+import type { Database as DatabaseType } from 'better-sqlite3';
 import fs from 'fs';
 import path from 'path';
 import { settings, getUserDataPath } from './settings';
@@ -6,9 +7,9 @@ import debugModule from 'debug';
 
 const debug = debugModule('common.requestCache');
 
-let db: Database | undefined;
+let db: DatabaseType | undefined;
 
-function init(): Database | undefined {
+function init(): DatabaseType | undefined {
   const { requestCache } = settings;
   if (!requestCache || !requestCache.enabled) return undefined;
   if (db) return db;

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "whois": "^2.13.0"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "@types/jest": "^30.0.0",
         "@types/jquery": "^3.5.32",
         "@types/node": "^24.0.3",
@@ -2353,6 +2354,16 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.20.7"
+      }
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/cacheable-request": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "whois": "^2.13.0"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/jest": "^30.0.0",
     "@types/jquery": "^3.5.32",
     "@types/node": "^24.0.3",


### PR DESCRIPTION
## Summary
- add `@types/better-sqlite3`
- use `DatabaseType` from `better-sqlite3` in `requestCache`

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a78c2c4d08325884698f77e378a14