### PR TITLE
Reuse electron cache in e2e job

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -83,6 +83,13 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
+      - name: Cache Electron
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/electron
+            ~/.cache/electron-builder
+          key: ${{ runner.os }}-electron-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         run: npm install
       - name: Build


### PR DESCRIPTION
## Summary
- duplicate Electron cache step from package job
- run this cache step before installing dependencies in the e2e job

## Testing
- `npm test` *(fails: Jest encountered unexpected token errors)*

------
https://chatgpt.com/codex/tasks/task_e_685a7e4d8b60832599b89f3c3f51ff46