### PR TITLE
Improve availability check with patterns

### DIFF
--- a/app/ts/common/availability.ts
+++ b/app/ts/common/availability.ts
@@ -2,6 +2,7 @@ import debugModule from 'debug';
 import { getDate } from './conversions';
 import { toJSON } from './parser';
 import { settings as appSettings, Settings } from './settings';
+import { checkPatterns } from './whoiswrapper/patterns';
 
 const debug = debugModule('common.whoisWrapper');
 let settings: Settings = appSettings;
@@ -23,6 +24,10 @@ export function isDomainAvailable(
   resultsJSON?: Record<string, unknown>
 ): string {
   const { lookupAssumptions: assumptions } = settings;
+
+  const patternResult = checkPatterns(resultsText, resultsJSON);
+  const defaultResult = assumptions.unparsable ? 'available' : 'error:unparsable';
+  if (patternResult !== defaultResult) return patternResult;
 
   if (!resultsJSON) resultsJSON = toJSON(resultsText) as Record<string, unknown>;
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
   transform: {
     '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.json', diagnostics: false }]
   },
+  setupFiles: ['<rootDir>/test/jest.setup.ts'],
   collectCoverage: true,
   coverageDirectory: 'coverage'
 };

--- a/test/isDomainAvailable.test.ts
+++ b/test/isDomainAvailable.test.ts
@@ -18,6 +18,11 @@ describe('isDomainAvailable', () => {
     expect(isDomainAvailable(reply)).toBe('error:ratelimiting');
   });
 
+  test('handles not found messages', () => {
+    const reply = 'NOT FOUND';
+    expect(isDomainAvailable(reply)).toBe('available');
+  });
+
   test('returns error for empty replies', () => {
     expect(isDomainAvailable('')).toBe('error:nocontent');
   });

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -1,0 +1,20 @@
+jest.mock('change-case', () => ({
+  camelCase: (input: string) => {
+    const parts = input
+      .replace(/^[^a-zA-Z0-9]+/, '')
+      .split(/[^a-zA-Z0-9]+/);
+    return parts
+      .map((p, i) =>
+        i === 0 ? p.toLowerCase() : p.charAt(0).toUpperCase() + p.slice(1)
+      )
+      .join('');
+  }
+}));
+
+jest.mock('html-entities', () => ({
+  XmlEntities: class {
+    decode(input: string): string {
+      return input;
+    }
+  }
+}));

--- a/test/patterns.test.ts
+++ b/test/patterns.test.ts
@@ -28,6 +28,11 @@ describe('whois patterns', () => {
     expect(checkPatterns(reply)).toBe('error:ratelimiting');
   });
 
+  test('detects not found replies', () => {
+    const reply = 'NOT FOUND';
+    expect(checkPatterns(reply)).toBe('available');
+  });
+
   test('returns error for empty replies', () => {
     expect(checkPatterns('')).toBe('error:nocontent');
   });


### PR DESCRIPTION
## Summary
- use pattern-based logic in `isDomainAvailable`
- configure Jest to load simple mocks
- add pattern tests for `NOT FOUND`
- verify `isDomainAvailable` handles pattern-based replies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a8366e36c8325b72bdececd653bf7