### PR TITLE
Refactor file-input filename handling

### DIFF
--- a/app/ts/renderer/bw/fileinput.ts
+++ b/app/ts/renderer/bw/fileinput.ts
@@ -1,5 +1,6 @@
 import * as conversions from '../../common/conversions';
 import fs from 'fs';
+import path from 'path';
 import type { FileStats } from '../../common/fileStats';
 import debugModule from 'debug';
 const debug = debugModule('renderer.bw.fileinput');
@@ -44,7 +45,7 @@ ipcRenderer.on(
         $('#bwFileinputloading').removeClass('is-hidden');
         try {
           bwFileStats = (await fs.promises.stat(filePath as string)) as FileStats;
-          bwFileStats.filename = (filePath as string).replace(/^.*[\\\/]/, '');
+          bwFileStats.filename = path.basename(filePath as string);
           bwFileStats.humansize = conversions.byteToHumanFileSize(
             bwFileStats.size,
             misc.useStandardSize
@@ -59,7 +60,7 @@ ipcRenderer.on(
       } else {
         try {
           bwFileStats = (await fs.promises.stat((filePath as string[])[0])) as FileStats;
-          bwFileStats.filename = (filePath as string[])[0].replace(/^.*[\\\/]/, '');
+          bwFileStats.filename = path.basename((filePath as string[])[0]);
           bwFileStats.humansize = conversions.byteToHumanFileSize(
             bwFileStats.size,
             misc.useStandardSize

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -4,6 +4,7 @@ import type { FileStats } from '../../common/fileStats';
 import Papa from 'papaparse';
 import datatables from 'datatables';
 const dt = datatables();
+import path from 'path';
 import { settings } from '../../common/settings';
 
 import { ipcRenderer } from 'electron';
@@ -34,7 +35,7 @@ ipcRenderer.on(
         $('#bwaFileinputloading').removeClass('is-hidden');
         try {
           bwaFileStats = fs.statSync(filePath as string) as FileStats;
-          bwaFileStats.filename = (filePath as string).replace(/^.*[\\\/]/, '');
+          bwaFileStats.filename = path.basename(filePath as string);
           bwaFileStats.humansize = conversions.byteToHumanFileSize(
             bwaFileStats.size,
             settings.lookupMisc.useStandardSize
@@ -54,7 +55,7 @@ ipcRenderer.on(
       } else {
         try {
           bwaFileStats = fs.statSync((filePath as string[])[0]) as FileStats;
-          bwaFileStats.filename = (filePath as string[])[0].replace(/^.*[\\\/]/, '');
+          bwaFileStats.filename = path.basename((filePath as string[])[0]);
           bwaFileStats.humansize = conversions.byteToHumanFileSize(
             bwaFileStats.size,
             settings.lookupMisc.useStandardSize


### PR DESCRIPTION
## Summary
- use `path.basename()` instead of regex for filename extraction in renderer modules
- import `path` in those modules

## Testing
- `npm test` *(fails: Jest encountered unexpected token errors)*

------
https://chatgpt.com/codex/tasks/task_e_685a837d88e883259c680a85227ef3bc