### PR TITLE
Fix navigation imports

### DIFF
--- a/app/ts/renderer.ts
+++ b/app/ts/renderer.ts
@@ -10,9 +10,6 @@ import { formatString } from './common/stringformat';
 
 (window as any).$ = $;
 (window as any).jQuery = $;
-(window as any).ipcRenderer = ipcRenderer;
-(window as any).dialog = dialog;
-(window as any).remote = remote;
 
 interface DebugMessage {
   channel: 'app:debug';

--- a/app/ts/renderer/navigation.ts
+++ b/app/ts/renderer/navigation.ts
@@ -1,3 +1,5 @@
+import { ipcRenderer } from 'electron';
+import * as remote from '@electron/remote';
 import { formatString } from '../common/stringformat';
 import $ from 'jquery';
 

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -151,8 +151,6 @@ declare module 'html-entities' {
 }
 
 declare const $: any;
-declare const ipcRenderer: any;
-declare const remote: any;
 declare const settings: any;
 
 declare global {


### PR DESCRIPTION
## Summary
- import `ipcRenderer` and `remote` in the navigation renderer
- stop exporting Electron APIs as globals
- remove global typings for `ipcRenderer` and `remote`

## Testing
- `npm run build`
- `npm test` *(fails: SyntaxError Unexpected token 'export')*

------
https://chatgpt.com/codex/tasks/task_e_685a839511fc83259c92fe4c4d70fbcb