### PR TITLE
Fix main window path handling

### DIFF
--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -116,7 +116,10 @@ app.on('ready', async function () {
   enableRemote(mainWindow.webContents);
 
   // mainWindow, Main window URL load
-  mainWindow.loadFile(path.join(__dirname, appUrl.pathname));
+  const loadPath = path.isAbsolute(appUrl.pathname)
+    ? path.normalize(appUrl.pathname)
+    : path.join(__dirname, appUrl.pathname);
+  mainWindow.loadFile(loadPath);
 
   // Some more debugging messages
   debug(formatString("'settings.url.protocol': {0}", appUrl.protocol));


### PR DESCRIPTION
## Summary
- handle absolute paths when loading the main window

## Testing
- `npm test` *(fails: Jest encountered unexpected token in change-case)*

------
https://chatgpt.com/codex/tasks/task_e_685a85431fa88325ac84a5c3142bbd1c