### PR TITLE
Replace console logging with debug

### DIFF
--- a/app/ts/main/bw/scheduler.ts
+++ b/app/ts/main/bw/scheduler.ts
@@ -60,8 +60,7 @@ export function processDomain(
           false
         );
       } catch (e) {
-        console.log(e);
-        console.trace();
+        debug(e);
       }
     },
     domainSetup.timebetween * (domainSetup.index! - stats.domains.sent + 1)

--- a/postbuild.js
+++ b/postbuild.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 const { copyRecursiveSync } = require('./scripts/copyRecursive');
+const debug = require('debug')('postbuild');
 
 const folders = ['html', 'fonts', 'icons'];
 const appDir = path.join(__dirname, 'app');
@@ -14,7 +15,7 @@ for (const folder of folders) {
 }
 
 // Bundle and minify CSS from app/css into dist/app/css
-console.log('Bundling CSS...');
+debug('Bundling CSS...');
 const result = spawnSync('npm', ['run', 'build:css'], { stdio: 'inherit', shell: true });
 if (result.error || result.status !== 0) {
   console.error('CSS bundling failed.');

--- a/prebuild.js
+++ b/prebuild.js
@@ -1,11 +1,12 @@
 const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
+const debug = require('debug')('prebuild');
 
 const modulesPath = path.join(__dirname, 'node_modules');
 
 if (!fs.existsSync(modulesPath)) {
-  console.log('node_modules not found. Running "npm install" to install dependencies...');
+  debug('node_modules not found. Running "npm install" to install dependencies...');
   const result = spawnSync('npm', ['install'], { stdio: 'inherit', shell: true });
 
   if (result.error || result.status !== 0) {
@@ -14,5 +15,5 @@ if (!fs.existsSync(modulesPath)) {
     process.exit(result.status || 1);
   }
 
-  console.log('\nDependencies installed successfully. Continuing build...');
+  debug('\nDependencies installed successfully. Continuing build...');
 }

--- a/test/e2e/run.js
+++ b/test/e2e/run.js
@@ -2,6 +2,7 @@ const path = require('path');
 const assert = require('assert');
 const { spawn } = require('child_process');
 const { remote } = require('webdriverio');
+const debug = require('debug')('test:e2e');
 
 (async () => {
   const electronPath = require('electron');
@@ -51,7 +52,7 @@ const { remote } = require('webdriverio');
     });
     assert.ok(minimized, 'Window did not minimize via IPC');
 
-    console.log('E2E tests passed');
+    debug('E2E tests passed');
     await browser.deleteSession();
   } catch (err) {
     console.error(err);

--- a/watch-assets.js
+++ b/watch-assets.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const watchboy = require('watchboy');
 const { copyRecursiveSync } = require('./scripts/copyRecursive');
+const debug = require('debug')('watch-assets');
 
 const folders = ['html', 'css', 'fonts', 'icons'];
 const appDir = path.join(__dirname, 'app');
@@ -13,7 +14,7 @@ function copyFile(src) {
   const dest = path.join(distDir, rel);
   fs.mkdirSync(path.dirname(dest), { recursive: true });
   fs.copyFileSync(src, dest);
-  console.log(`[watch-assets] copied ${rel}`);
+  debug(`copied ${rel}`);
 }
 
 for (const folder of folders) {
@@ -35,4 +36,4 @@ const watcher = watchboy(patterns, { cwd: __dirname });
 watcher.on('add', ({ path: p }) => copyFile(p));
 watcher.on('change', ({ path: p }) => copyFile(p));
 
-watcher.on('ready', () => console.log('[watch-assets] watching assets...'));
+watcher.on('ready', () => debug('watching assets...'));


### PR DESCRIPTION
## Summary
- replace leftover `console.log` and `console.trace` calls with `debug()`
- include debug import in scripts and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a8670c93083259f69c2f4dbab8947