### PR TITLE
Fix runtime script loading

### DIFF
--- a/app/html/mainPanel.html
+++ b/app/html/mainPanel.html
@@ -15,7 +15,7 @@
     <link href="../css/style.css" rel="stylesheet" />
     <link href="../css/tables.css" rel="stylesheet" />
     <!--<link href="../css/fontawesome/all.min.css" rel="stylesheet">-->
-    <script src="../ts/mainPanel.js"></script>
+    <script>require('../ts/mainPanel.js');</script>
   </head>
 
   <body>
@@ -100,8 +100,8 @@
     </div>
   </body>
   <footer>
-    <script src="../ts/renderer/loadcontents.js"></script>
-    <script src="../ts/renderer.js" defer></script>
+    <script>require('../ts/renderer/loadcontents.js');</script>
+    <script>require('../ts/renderer.js');</script>
     <!--<script defer src="../js/renderer/singlewhois.js"></script>-->
   </footer>
 </html>


### PR DESCRIPTION
## Summary
- load renderer scripts via `require` instead of `script src`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a874d04f483259ee8d57496777cac