### PR TITLE
Fix CSP inline script violations

### DIFF
--- a/app/html/mainPanel.html
+++ b/app/html/mainPanel.html
@@ -15,7 +15,7 @@
     <link href="../css/style.css" rel="stylesheet" />
     <link href="../css/tables.css" rel="stylesheet" />
     <!--<link href="../css/fontawesome/all.min.css" rel="stylesheet">-->
-    <script>require('../ts/mainPanel.js');</script>
+    <script src="../ts/mainPanel.js"></script>
   </head>
 
   <body>
@@ -100,8 +100,8 @@
     </div>
   </body>
   <footer>
-    <script>require('../ts/renderer/loadcontents.js');</script>
-    <script>require('../ts/renderer.js');</script>
+    <script src="../ts/renderer/loadcontents.js"></script>
+    <script src="../ts/renderer.js"></script>
     <!--<script defer src="../js/renderer/singlewhois.js"></script>-->
   </footer>
 </html>

--- a/app/html/mainPanel.html
+++ b/app/html/mainPanel.html
@@ -15,7 +15,7 @@
     <link href="../css/style.css" rel="stylesheet" />
     <link href="../css/tables.css" rel="stylesheet" />
     <!--<link href="../css/fontawesome/all.min.css" rel="stylesheet">-->
-    <script src="../ts/mainPanel.js"></script>
+    <script src="./startup.js"></script>
   </head>
 
   <body>
@@ -100,8 +100,7 @@
     </div>
   </body>
   <footer>
-    <script src="../ts/renderer/loadcontents.js"></script>
-    <script src="../ts/renderer.js"></script>
+    <!-- Scripts are loaded via startup.js to comply with CSP -->
     <!--<script defer src="../js/renderer/singlewhois.js"></script>-->
   </footer>
 </html>

--- a/app/html/startup.js
+++ b/app/html/startup.js
@@ -1,0 +1,3 @@
+require('../ts/mainPanel.js');
+require('../ts/renderer/loadcontents.js');
+require('../ts/renderer.js');


### PR DESCRIPTION
## Summary
- reference scripts by `src` in `mainPanel.html` to avoid violating the default CSP

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a88a3430c832593f9b9d00c476d52