### PR TITLE
Switch renderer window actions to IPC

### DIFF
--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -4,7 +4,7 @@ import debugModule from 'debug';
 import { loadSettings, settings as store } from './common/settings';
 import type { Settings as BaseSettings } from './common/settings';
 import { formatString } from './common/stringformat';
-import { initialize as initializeRemote, enable as enableRemote } from '@electron/remote/main';
+import { initialize as initializeRemote } from '@electron/remote/main';
 import type { IpcMainEvent } from 'electron';
 
 const debug = debugModule('main');
@@ -113,7 +113,6 @@ app.on('ready', async function () {
       spellcheck: webPreferences.spellcheck // Enable builtin spellchecker
     }
   });
-  enableRemote(mainWindow.webContents);
 
   // mainWindow, Main window URL load
   const loadPath = path.isAbsolute(appUrl.pathname)
@@ -171,17 +170,34 @@ function startup() {
 }
 
 /*
-  ipcMain.on('app:minimize', function() {...});
+  ipcMain.handle('app:toggleDevtools', function() {...});
+    Toggle developer tools
+ */
+ipcMain.handle('app:toggleDevtools', function () {
+  mainWindow.webContents.toggleDevTools();
+});
+
+/*
+  ipcMain.handle('app:minimize', function() {...});
     Application minimize event
  */
-ipcMain.on('app:minimize', function () {
+ipcMain.handle('app:minimize', function () {
   const { appWindow } = settings;
   if (appWindow.minimizable) {
     debug('App minimized');
     mainWindow.minimize();
   }
+});
 
-  return;
+/*
+  ipcMain.handle('app:close', function() {...});
+    Close the application window
+ */
+ipcMain.handle('app:close', function () {
+  const { appWindow } = settings;
+  if (appWindow.closable) {
+    mainWindow.close();
+  }
 });
 
 /*

--- a/app/ts/renderer.ts
+++ b/app/ts/renderer.ts
@@ -1,6 +1,5 @@
 // Base path --> assets/html
 import { ipcRenderer, dialog } from 'electron';
-import * as remote from '@electron/remote';
 import type { IpcRendererEvent } from 'electron';
 import $ from 'jquery';
 

--- a/app/ts/renderer/navigation.ts
+++ b/app/ts/renderer/navigation.ts
@@ -1,5 +1,4 @@
 import { ipcRenderer } from 'electron';
-import * as remote from '@electron/remote';
 import { formatString } from '../common/stringformat';
 import $ from 'jquery';
 
@@ -33,7 +32,7 @@ $(document).on('dragover', function (event) {
     On click: Button toggle developer tools
  */
 $(document).on('click', '#navButtonDevtools', function () {
-  remote.getCurrentWindow().toggleDevTools();
+  void ipcRenderer.invoke('app:toggleDevtools');
   ipcRenderer.send('app:debug', '#navButtonDevtools was clicked');
 
   return;
@@ -138,7 +137,7 @@ $(document).on('click', '#navButtonExtendedmenu', function () {
  */
 $(document).on('click', '#navButtonMinimize', function () {
   ipcRenderer.send('app:debug', '#navButtonMinimize was clicked');
-  remote.getCurrentWindow().minimize();
+  void ipcRenderer.invoke('app:minimize');
 
   return;
 });
@@ -149,7 +148,7 @@ $(document).on('click', '#navButtonMinimize', function () {
  */
 $(document).on('click', '#navButtonExit', function () {
   ipcRenderer.send('app:debug', '#navButtonExit was clicked');
-  remote.getCurrentWindow().close();
+  void ipcRenderer.invoke('app:close');
 
   return;
 });


### PR DESCRIPTION
## Summary
- remove `enableRemote()` usage
- handle toggle devtools, minimize, and close through IPC
- update renderer code to use `ipcRenderer.invoke`

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a8986cf20832589f0440e3e7323fe