### PR TITLE
Add job timeouts

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   lint:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -34,6 +35,7 @@ jobs:
 
   type-check:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     needs: lint
     strategy:
       matrix:
@@ -51,6 +53,7 @@ jobs:
 
   build:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     needs: type-check
     strategy:
       matrix:
@@ -74,6 +77,7 @@ jobs:
   e2e:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         node-version: [20.x]
@@ -100,6 +104,7 @@ jobs:
   package:
     needs: e2e
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x, 23.x, 24.x]
@@ -128,6 +133,7 @@ jobs:
   package-windows:
     needs: e2e
     runs-on: windows-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x, 23.x, 24.x]
@@ -156,6 +162,7 @@ jobs:
   package-macos:
     needs: e2e
     runs-on: macos-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x, 23.x, 24.x]


### PR DESCRIPTION
## Summary
- set `timeout-minutes: 30` for each job in the CI workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a8ef298e483259affd028cc6a7ad9