### PR TITLE
Add fail-fast option to CI matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,6 +17,7 @@ jobs:
   lint:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [18.x, 20.x, 22.x, 23.x, 24.x]
@@ -36,6 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: lint
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [18.x, 20.x, 22.x, 23.x, 24.x]
@@ -53,6 +55,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: type-check
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [18.x, 20.x, 22.x, 23.x, 24.x]
@@ -75,6 +78,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version: [20.x]
     steps:
@@ -101,6 +105,7 @@ jobs:
     needs: e2e
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version: [18.x, 20.x, 22.x, 23.x, 24.x]
     steps:
@@ -129,6 +134,7 @@ jobs:
     needs: e2e
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version: [18.x, 20.x, 22.x, 23.x, 24.x]
     steps:
@@ -157,6 +163,7 @@ jobs:
     needs: e2e
     runs-on: macos-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version: [18.x, 20.x, 22.x, 23.x, 24.x]
     steps:


### PR DESCRIPTION
## Summary
- disable `fail-fast` for matrix runs in Node workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a8f1be96c8325b158f3bc7a792de3