### PR TITLE
Use npm ci for packaging jobs

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -145,7 +145,7 @@ jobs:
             ~/.cache/electron-builder
           key: ${{ runner.os }}-electron-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - run: npm run package-win
       - run: mv release_builds release_builds-${{ matrix.node-version }}
       - uses: actions/upload-artifact@v4
@@ -173,7 +173,7 @@ jobs:
             ~/.cache/electron-builder
           key: ${{ runner.os }}-electron-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - run: npm run package-mac
       - run: mv release_builds release_builds-${{ matrix.node-version }}
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- speed up dependency install on Windows and macOS packaging jobs by using `npm ci`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685a8f47b64c8325979b2eb285342b3b