### PR TITLE
Fix drag-and-drop init after DOM ready

### DIFF
--- a/app/ts/renderer/bw/fileinput.ts
+++ b/app/ts/renderer/bw/fileinput.ts
@@ -180,28 +180,32 @@ $(document).on('click', '#bwFileButtonConfirm', function () {
     Bulk whois file input by drag and drop
  */
 (function dragDropInitialization() {
-  const holder = document.getElementById('bwMainContainer') as HTMLElement;
-  holder.ondragover = function () {
-    return false;
-  };
+  $(document).ready(() => {
+    const holder = document.getElementById('bwMainContainer') as HTMLElement | null;
+    if (!holder) return;
 
-  holder.ondragleave = function () {
-    return false;
-  };
+    holder.ondragover = function () {
+      return false;
+    };
 
-  holder.ondragend = function () {
-    return false;
-  };
+    holder.ondragleave = function () {
+      return false;
+    };
 
-  holder.ondrop = function (event) {
-    event.preventDefault();
-    for (const f of Array.from(event.dataTransfer!.files)) {
-      const file = f as any;
-      ipcRenderer.send('app:debug', `File(s) you dragged here: ${file.path}`);
-      ipcRenderer.send('ondragstart', file.path);
-    }
-    return false;
-  };
+    holder.ondragend = function () {
+      return false;
+    };
+
+    holder.ondrop = function (event) {
+      event.preventDefault();
+      for (const f of Array.from(event.dataTransfer!.files)) {
+        const file = f as any;
+        ipcRenderer.send('app:debug', `File(s) you dragged here: ${file.path}`);
+        ipcRenderer.send('ondragstart', file.path);
+      }
+      return false;
+    };
+  });
 })();
 
 /*


### PR DESCRIPTION
## Summary
- initialize bulk whois drag-and-drop after DOM is ready

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a9128ade08325a3d8991092f8b877