### PR TITLE
Add GitHub Actions to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary
- include GitHub Actions directory in Dependabot config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a93a8cd9883258efa3076a476a165