### PR TITLE
Fix husky install warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "jest",
     "test:e2e": "xvfb-run -a node test/e2e/run.js",
     "prebuild": "node prebuild.js",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "author": "supermarsx",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- remove deprecated `husky install` usage in `prepare` script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a96e935e883259d3859362cea1148