### PR TITLE
Fix console warnings

### DIFF
--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -10,6 +10,9 @@ import type { IpcMainEvent } from 'electron';
 const debug = debugModule('main');
 const debugb = debugModule('renderer');
 
+// Disable Chromium Autofill feature to silence devtools warnings in Electron
+app.commandLine.appendSwitch('disable-features', 'Autofill');
+
 interface AppWindowSettings {
   frame: boolean;
   show: boolean;


### PR DESCRIPTION
## Summary
- disable Chromium autofill features to stop devtools warnings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a972d6b2883258453573e3d8ea7d0