### PR TITLE
Add Handlebars precompile step

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 release_builds/
+package-lock.json

--- a/app/ts/renderer/templateLoader.ts
+++ b/app/ts/renderer/templateLoader.ts
@@ -1,10 +1,10 @@
 import $ from 'jquery';
-import Handlebars from 'handlebars';
+import Handlebars from 'handlebars/runtime';
 
 export async function loadTemplate(selector: string, template: string, context: any = {}): Promise<void> {
-  const response = await fetch(`./templates/${template}`);
-  const text = await response.text();
-  const compiled = Handlebars.compile(text);
+  const module = await import(`../compiled-templates/${template.replace(/\\.hbs$/, '.js')}`);
+  const precompiled = module.default || module;
+  const compiled = Handlebars.template(precompiled);
   const html = compiled(context);
   $(selector).html(html);
 }

--- a/postbuild.js
+++ b/postbuild.js
@@ -2,9 +2,10 @@ const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 const { copyRecursiveSync } = require('./scripts/copyRecursive');
+const { precompileTemplates } = require('./scripts/precompileTemplates');
 const debug = require('debug')('postbuild');
 
-const folders = ['html', 'html/templates', 'fonts', 'icons'];
+const folders = ['html', 'html/templates', 'fonts', 'icons', 'compiled-templates'];
 const appDir = path.join(__dirname, 'app');
 const distDir = path.join(__dirname, 'dist', 'app');
 
@@ -30,3 +31,6 @@ const bulmaDest = path.join(distDir, 'css', 'bulma', 'css');
 if (fs.existsSync(bulmaSrc)) {
   copyRecursiveSync(bulmaSrc, bulmaDest);
 }
+
+// Precompile Handlebars templates into dist/app/compiled-templates
+precompileTemplates(path.join(distDir, 'compiled-templates'));

--- a/scripts/precompileTemplates.js
+++ b/scripts/precompileTemplates.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+function precompileTemplates(outputDir = path.join(__dirname, '..', 'app', 'compiled-templates')) {
+  const templatesDir = path.join(__dirname, '..', 'app', 'html', 'templates');
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  const handlebarBin = path.join(__dirname, '..', 'node_modules', 'handlebars', 'bin', 'handlebars');
+
+  for (const file of fs.readdirSync(templatesDir)) {
+    if (path.extname(file) !== '.hbs') continue;
+    const src = path.join(templatesDir, file);
+    const result = spawnSync('node', [handlebarBin, src, '-s'], { encoding: 'utf8' });
+    if (result.error || result.status !== 0) {
+      console.error(`Failed to precompile ${file}`);
+      process.exit(result.status || 1);
+    }
+    const compiled = result.stdout.trim();
+    const outPath = path.join(outputDir, file.replace(/\.hbs$/, '.js'));
+    fs.writeFileSync(outPath, `module.exports = ${compiled};\n`);
+  }
+}
+
+if (require.main === module) {
+  const dir = process.argv[2];
+  precompileTemplates(dir && path.resolve(dir));
+}
+
+module.exports = { precompileTemplates };

--- a/watch-assets.js
+++ b/watch-assets.js
@@ -4,7 +4,7 @@ const watchboy = require('watchboy');
 const { copyRecursiveSync } = require('./scripts/copyRecursive');
 const debug = require('debug')('watch-assets');
 
-const folders = ['html', 'html/templates', 'css', 'fonts', 'icons'];
+const folders = ['html', 'html/templates', 'css', 'fonts', 'icons', 'compiled-templates'];
 const appDir = path.join(__dirname, 'app');
 const distDir = path.join(__dirname, 'dist', 'app');
 


### PR DESCRIPTION
## Summary
- add script to precompile Handlebars templates
- copy the compiled templates during postbuild and watch-assets
- load precompiled templates at runtime
- ignore `package-lock.json` for prettier

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685aa5fb4b008325b6e249a71d540828