### PR TITLE
Add cache closing

### DIFF
--- a/app/ts/common/requestCache.ts
+++ b/app/ts/common/requestCache.ts
@@ -67,4 +67,15 @@ export function setCached(type: string, domain: string, response: string): void 
   }
 }
 
-export default { getCached, setCached };
+export function closeCache(): void {
+  if (db) {
+    try {
+      db.close();
+    } catch (e) {
+      debug(`Cache close failed: ${e}`);
+    }
+    db = undefined;
+  }
+}
+
+export default { getCached, setCached, closeCache };

--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -4,6 +4,7 @@ import debugModule from 'debug';
 import { loadSettings, settings as store } from './common/settings';
 import type { Settings as BaseSettings } from './common/settings';
 import { formatString } from './common/stringformat';
+import { closeCache } from './common/requestCache';
 import { initialize as initializeRemote, enable as enableRemote } from '@electron/remote/main';
 import type { IpcMainEvent } from 'electron';
 
@@ -151,6 +152,7 @@ app.on('ready', async function () {
 
     if (appWindow.closable) {
       debug('Exiting application');
+      closeCache();
       app.quit();
     }
 

--- a/test/requestCache.test.ts
+++ b/test/requestCache.test.ts
@@ -1,6 +1,6 @@
 import '../test/electronMock';
 import { settings } from '../app/ts/common/settings';
-import { getCached, setCached } from '../app/ts/common/requestCache';
+import { getCached, setCached, closeCache } from '../app/ts/common/requestCache';
 import fs from 'fs';
 import path from 'path';
 
@@ -30,5 +30,10 @@ describe('requestCache', () => {
     await new Promise((r) => setTimeout(r, 1100));
     const res = getCached('whois', 'expire.com');
     expect(res).toBeUndefined();
+  });
+
+  test('closeCache does not throw when cache disabled', () => {
+    settings.requestCache.enabled = false;
+    expect(() => closeCache()).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- close SQLite cache database when the app exits
- expose `closeCache` helper in the cache module
- test closing the cache while disabled

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685aba361a748325941bf2d7b7ec0884