### PR TITLE
Use forEach for formatting strings

### DIFF
--- a/app/ts/common/stringformat.ts
+++ b/app/ts/common/stringformat.ts
@@ -8,8 +8,8 @@
 
 export function formatString(str: string, ...args: unknown[]): string {
   let result = str;
-  for (const k in args) {
-    result = result.replace(new RegExp(`\\{${k}\\}`, 'g'), String(args[k]));
-  }
+  args.forEach((arg, i) => {
+    result = result.replace(new RegExp(`\\{${i}\\}`, 'g'), String(arg));
+  });
   return result;
 }


### PR DESCRIPTION
## Summary
- refactor formatString to use `args.forEach`

## Testing
- `npm test -- -t stringformat`

------
https://chatgpt.com/codex/tasks/task_e_685abde3dce083258088aaa605391b94