### PR TITLE
Fix hbs precompilation for CJS

### DIFF
--- a/scripts/precompileTemplates.js
+++ b/scripts/precompileTemplates.js
@@ -25,7 +25,7 @@ function precompileTemplates(outputDir = path.join(__dirname, '..', 'app', 'comp
     }
     const compiled = result.stdout.trim();
     const outPath = path.join(outputDir, file.replace(/\.hbs$/, '.js'));
-    fs.writeFileSync(outPath, `export default ${compiled};\n`);
+    fs.writeFileSync(outPath, `module.exports = ${compiled};\n`);
   }
 }
 


### PR DESCRIPTION
## Summary
- precompile Handlebars templates as CommonJS modules

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685abd870e588325a42e690d303b3b07