### PR TITLE
Make wordlist helpers asynchronous

### DIFF
--- a/app/ts/common/wordlist.ts
+++ b/app/ts/common/wordlist.ts
@@ -1,9 +1,9 @@
-import fs from 'fs';
+import { promises as fs } from 'fs';
 
-export function concatFiles(...files: string[]): string[] {
+export async function concatFiles(...files: string[]): Promise<string[]> {
   const lines: string[] = [];
   for (const file of files) {
-    const data = fs.readFileSync(file, 'utf8');
+    const data = await fs.readFile(file, 'utf8');
     lines.push(...data.split(/\r?\n/));
   }
   return lines;
@@ -16,8 +16,8 @@ export interface SplitOptions {
   pattern?: RegExp;
 }
 
-export function splitFiles(options: SplitOptions): string[][] {
-  const lines = concatFiles(...options.files);
+export async function splitFiles(options: SplitOptions): Promise<string[][]> {
+  const lines = await concatFiles(...options.files);
   const result: string[][] = [];
 
   if (options.pattern) {

--- a/test/wordlist.test.ts
+++ b/test/wordlist.test.ts
@@ -15,21 +15,21 @@ import {
 } from '../app/ts/common/wordlist';
 
 describe('wordlist tools', () => {
-  test('concatFiles joins files', () => {
+  test('concatFiles joins files', async () => {
     const p1 = path.join(__dirname, 'f1.txt');
     const p2 = path.join(__dirname, 'f2.txt');
     fs.writeFileSync(p1, 'a\nb');
     fs.writeFileSync(p2, 'c\nd');
-    const lines = concatFiles(p1, p2);
+    const lines = await concatFiles(p1, p2);
     expect(lines).toEqual(['a', 'b', 'c', 'd']);
     fs.unlinkSync(p1);
     fs.unlinkSync(p2);
   });
 
-  test('splitFiles by lines', () => {
+  test('splitFiles by lines', async () => {
     const p = path.join(__dirname, 'f3.txt');
     fs.writeFileSync(p, 'a\nb\nc\nd');
-    const parts = splitFiles({ files: [p], maxLines: 2 });
+    const parts = await splitFiles({ files: [p], maxLines: 2 });
     expect(parts).toEqual([
       ['a', 'b'],
       ['c', 'd']


### PR DESCRIPTION
## Summary
- use `fs.promises` in `concatFiles` and `splitFiles`
- make `concatFiles` and `splitFiles` return promises
- adjust tests to await the new asynchronous functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ac13c3a208325a75024d614d82592