### PR TITLE
Add proxy rotation tests

### DIFF
--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -35,4 +35,40 @@ describe('proxy helper', () => {
     expect(second).toEqual({ ipaddress: '2.2.2.2', port: 8080, type: 5 });
     expect(third).toEqual({ ipaddress: '1.1.1.1', port: 8080, type: 5 });
   });
+
+  test('cycles proxies ascending', () => {
+    settings.lookupProxy.enable = true;
+    settings.lookupProxy.mode = 'multi';
+    settings.lookupProxy.list = [
+      '1.1.1.1:8080',
+      '2.2.2.2:8080',
+      '3.3.3.3:8080'
+    ];
+    settings.lookupProxy.multimode = 'ascending';
+    const first = getProxy();
+    const second = getProxy();
+    const third = getProxy();
+    expect(first).toEqual({ ipaddress: '2.2.2.2', port: 8080, type: 5 });
+    expect(second).toEqual({ ipaddress: '3.3.3.3', port: 8080, type: 5 });
+    expect(third).toEqual({ ipaddress: '3.3.3.3', port: 8080, type: 5 });
+  });
+
+  test('cycles proxies descending', () => {
+    settings.lookupProxy.enable = true;
+    settings.lookupProxy.mode = 'multi';
+    settings.lookupProxy.list = [
+      '1.1.1.1:8080',
+      '2.2.2.2:8080',
+      '3.3.3.3:8080'
+    ];
+    settings.lookupProxy.multimode = 'descending';
+    const first = getProxy();
+    const second = getProxy();
+    const third = getProxy();
+    const fourth = getProxy();
+    expect(first).toEqual({ ipaddress: '3.3.3.3', port: 8080, type: 5 });
+    expect(second).toEqual({ ipaddress: '2.2.2.2', port: 8080, type: 5 });
+    expect(third).toEqual({ ipaddress: '1.1.1.1', port: 8080, type: 5 });
+    expect(fourth).toEqual({ ipaddress: '3.3.3.3', port: 8080, type: 5 });
+  });
 });


### PR DESCRIPTION
## Summary
- cover proxy cycling in ascending/descending modes

## Testing
- `npm test` *(fails: wordlistTools.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_685ac5cdd3f883259fb36d1b17c0a4e1