### PR TITLE
Fix proxy rotation order

### DIFF
--- a/app/ts/common/proxy.ts
+++ b/app/ts/common/proxy.ts
@@ -35,8 +35,8 @@ export function getProxy(): ProxyInfo | undefined {
       entry = list[Math.floor(Math.random() * list.length)];
       break;
     case 'ascending':
-      index = Math.min(index + 1, list.length - 1);
       entry = list[index];
+      index = (index + 1) % list.length;
       break;
     case 'descending':
       index = index <= 0 ? list.length - 1 : index - 1;

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -35,4 +35,17 @@ describe('proxy helper', () => {
     expect(second).toEqual({ ipaddress: '2.2.2.2', port: 8080, type: 5 });
     expect(third).toEqual({ ipaddress: '1.1.1.1', port: 8080, type: 5 });
   });
+
+  test('rotates proxies ascending with wraparound', () => {
+    settings.lookupProxy.enable = true;
+    settings.lookupProxy.mode = 'multi';
+    settings.lookupProxy.list = ['3.3.3.3:9090', '4.4.4.4:9090'];
+    settings.lookupProxy.multimode = 'ascending';
+    const first = getProxy();
+    const second = getProxy();
+    const third = getProxy();
+    expect(first).toEqual({ ipaddress: '3.3.3.3', port: 9090, type: 5 });
+    expect(second).toEqual({ ipaddress: '4.4.4.4', port: 9090, type: 5 });
+    expect(third).toEqual({ ipaddress: '3.3.3.3', port: 9090, type: 5 });
+  });
 });

--- a/test/wordlistTools.test.ts
+++ b/test/wordlistTools.test.ts
@@ -5,8 +5,8 @@ import { splitFiles, shuffleLines, dedupeLines } from '../app/ts/common/wordlist
 describe('wordlist tools advanced', () => {
   const sample = path.join(__dirname, '..', 'sample_lists', '3letter_alpha.list');
 
-  test('splitFiles divides sample list by maxLines', () => {
-    const parts = splitFiles({ files: [sample], maxLines: 5 });
+  test('splitFiles divides sample list by maxLines', async () => {
+    const parts = await splitFiles({ files: [sample], maxLines: 5 });
     expect(parts).toEqual([
       ['aaq', 'bha', 'dyv', 'fed', 'gxp'],
       ['irq', 'jee', 'nvi', 'onr', 'xgh'],
@@ -14,10 +14,10 @@ describe('wordlist tools advanced', () => {
     ]);
   });
 
-  test('splitFiles respects pattern option', () => {
+  test('splitFiles respects pattern option', async () => {
     const p = path.join(__dirname, 'pattern.txt');
     fs.writeFileSync(p, 'a\n---\nb\nc\n---\nd');
-    const parts = splitFiles({ files: [p], pattern: /^---$/ });
+    const parts = await splitFiles({ files: [p], pattern: /^---$/ });
     expect(parts).toEqual([
       ['a'],
       ['b', 'c'],
@@ -26,10 +26,10 @@ describe('wordlist tools advanced', () => {
     fs.unlinkSync(p);
   });
 
-  test('splitFiles splits by maxSize bytes', () => {
+  test('splitFiles splits by maxSize bytes', async () => {
     const p = path.join(__dirname, 'size.txt');
     fs.writeFileSync(p, 'a\nbb\nccc');
-    const parts = splitFiles({ files: [p], maxSize: 4 });
+    const parts = await splitFiles({ files: [p], maxSize: 4 });
     expect(parts).toEqual([
       ['a'],
       ['bb'],
@@ -38,10 +38,10 @@ describe('wordlist tools advanced', () => {
     fs.unlinkSync(p);
   });
 
-  test('splitFiles uses maxLines over maxSize when both set', () => {
+  test('splitFiles uses maxLines over maxSize when both set', async () => {
     const p = path.join(__dirname, 'pref.txt');
     fs.writeFileSync(p, '1\n2\n3\n4\n5\n6');
-    const parts = splitFiles({ files: [p], maxLines: 2, maxSize: 100 });
+    const parts = await splitFiles({ files: [p], maxLines: 2, maxSize: 100 });
     expect(parts).toEqual([
       ['1', '2'],
       ['3', '4'],
@@ -50,8 +50,8 @@ describe('wordlist tools advanced', () => {
     fs.unlinkSync(p);
   });
 
-  test('splitFiles with no files returns empty array', () => {
-    expect(splitFiles({ files: [] })).toEqual([[]]);
+  test('splitFiles with no files returns empty array', async () => {
+    expect(await splitFiles({ files: [] })).toEqual([[]]);
   });
 
   test('shuffleLines deterministic order with mocked random', () => {


### PR DESCRIPTION
## Summary
- fix order for ascending proxy rotation
- await async `splitFiles` calls in tests
- add regression test for ascending proxy mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ac66f48a08325a7c23cfa3226fe3b