### PR TITLE
Update test instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -174,7 +174,7 @@ dependencies before building. This script runs whenever you execute `npm run bui
 
 ## Development setup
 
-Run `npm ci` before testing or linting to install dependencies exactly as locked.
+Run `npm install` or `npm ci` before testing or linting to ensure all dependencies are installed.
 After installing, execute `npm test` to run the project's unit tests.
 Running tests also generates a coverage report in the `coverage/` directory.
 Development packages such as `@types/node` and `@types/jest` are required for TypeScript compilation and running tests. The `prebuild` script will auto-install dependencies if `node_modules` is missing.


### PR DESCRIPTION
## Summary
- clarify that dependencies must be installed before running tests

## Testing
- `npm install`
- `npm test` *(fails: wordlistTools suite)*

------
https://chatgpt.com/codex/tasks/task_e_685ac68450688325927af2017801f9ae