### PR TITLE
Fix asset watch test to monitor mainPanel

### DIFF
--- a/test/watch-assets.test.ts
+++ b/test/watch-assets.test.ts
@@ -37,8 +37,8 @@ describe('watch-assets', () => {
       require('../scripts/watch-assets');
     });
 
-    const src = path.join(__dirname, '..', 'app', 'html', 'index.html');
-    const dest = path.join(__dirname, '..', 'dist', 'app', 'html', 'index.html');
+    const src = path.join(__dirname, '..', 'app', 'html', 'mainPanel.html');
+    const dest = path.join(__dirname, '..', 'dist', 'app', 'html', 'mainPanel.html');
 
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     emitter.emit('change', { path: src });


### PR DESCRIPTION
## Summary
- update asset watch test to look for `mainPanel.html` instead of `index.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685aceb19a608325a08010533c335bde