### PR TITLE
Render mainPanel at build time

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -208,6 +208,8 @@ compiles the application into the `dist` folder and then invokes
 Running `npm run build` automatically executes the `prebuild` script. `scripts/prebuild.js` installs dependencies using `npm install` if `node_modules` is missing.
 `scripts/postbuild.js` then bundles CSS using PostCSS by calling `npm run build:css`,
 which minifies files from `app/css` into `dist/app/css`.
+It also precompiles Handlebars templates and writes `dist/app/html/mainPanel.html`
+from `app/html/templates/mainPanel.hbs`.
 
 MacOS
 

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -38,20 +38,22 @@ precompileTemplates(path.join(distDir, 'compiled-templates'));
 
 // After precompilation, register the partials with Handlebars and render
 // the mainPanel template to static HTML.
-const Handlebars = require('handlebars');
-const compiledDir = path.join(distDir, 'compiled-templates');
+const Handlebars = require('handlebars/runtime');
+const partialDir = path.join(distDir, 'compiled-templates');
 
-for (const file of fs.readdirSync(compiledDir)) {
-  if (!file.endsWith('.js') || file === 'mainPanel.js') continue;
-  const name = path.basename(file, '.js');
-  // require returns the template specification object produced by handlebars
-  const spec = require(path.join(compiledDir, file));
-  Handlebars.registerPartial(name, Handlebars.template(spec));
+for (const file of fs.readdirSync(partialDir)) {
+  if (file === 'mainPanel.js' || !file.endsWith('.js')) continue;
+  const spec = require(path.join(partialDir, file));
+  Handlebars.registerPartial(
+    path.basename(file, '.js'),
+    Handlebars.template(spec)
+  );
 }
 
-const mainSpec = require(path.join(compiledDir, 'mainPanel.js'));
+const mainSpec = require(path.join(partialDir, 'mainPanel.js'));
 const mainTemplate = Handlebars.template(mainSpec);
 const htmlOut = mainTemplate({});
 
 const outPath = path.join(distDir, 'html', 'mainPanel.html');
+fs.rmSync(outPath, { force: true });
 fs.writeFileSync(outPath, htmlOut);


### PR DESCRIPTION
## Summary
- generate `mainPanel.html` during postbuild
- load compiled templates as Handlebars partials
- document new `postbuild.js` output in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ad273fdb08325a98ebac778e98186