### PR TITLE
Update tsconfig to exclude generated templates

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,8 @@
     "moduleResolution": "node",
     "allowJs": true,
     "noEmit": false,
-    "rootDir": "app/ts",
-    "outDir": "dist/app/ts",
+    "rootDir": "app",
+    "outDir": "dist/app",
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,
@@ -18,5 +18,5 @@
     "noImplicitThis": true
   },
   "include": ["app/ts/**/*.ts", "**/*.d.ts"],
-  "exclude": ["test"]
+  "exclude": ["test", "app/compiled-templates"]
 }


### PR DESCRIPTION
## Summary
- exclude generated Handlebars templates from TypeScript build
- adjust `rootDir`/`outDir` so compilation succeeds when templates exist

## Testing
- `npm run prebuild`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ad42df4508325942b75043baa08ec