### PR TITLE
Stop recompiling templates during asset watch

### DIFF
--- a/scripts/watch-assets.js
+++ b/scripts/watch-assets.js
@@ -45,16 +45,10 @@ const watcher = watchboy(patterns, { cwd: rootDir });
 
 watcher.on('add', ({ path: p }) => {
   copyFile(p);
-  if (p.startsWith(path.join(appDir, 'html', 'templates'))) {
-    precompileTemplates();
-  }
 });
 
 watcher.on('change', ({ path: p }) => {
   copyFile(p);
-  if (p.startsWith(path.join(appDir, 'html', 'templates'))) {
-    precompileTemplates();
-  }
 });
 
 watcher.on('ready', () => debug('watching assets...'));

--- a/test/watch-assets.test.ts
+++ b/test/watch-assets.test.ts
@@ -48,16 +48,18 @@ describe('watch-assets', () => {
     expect(copyFileMock).toHaveBeenCalledWith(src, dest);
   });
 
-  test('precompiles templates when a template changes', () => {
+  test("doesn't recompile templates when a template changes", () => {
     jest.isolateModules(() => {
       require('../scripts/watch-assets');
     });
+
+    precompileMock.mockClear();
 
     const src = path.join(__dirname, '..', 'app', 'html', 'templates', 'test.hbs');
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     emitter.emit('change', { path: src });
     logSpy.mockRestore();
 
-    expect(precompileMock).toHaveBeenCalled();
+    expect(precompileMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- stop recompiling templates on every change
- update tests for new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685adbfeb9888325aa6aa7abf4528b7b