### PR TITLE
Fix CSP meta injection in renderer

### DIFF
--- a/app/ts/renderer/loadcontents.ts
+++ b/app/ts/renderer/loadcontents.ts
@@ -5,8 +5,16 @@ import { loadTemplate } from './templateLoader';
   loadHtml (self-executing)
     Loads HTML files inside the renderer
  */
+
 (async function loadHtml() {
-  await loadTemplate('html', 'mainPanel.hbs');
+  // Only inject the full template when the page wasn't
+  // loaded from the precompiled HTML file. If the CSP
+  // meta tag already exists in the document head,
+  // mainPanel.hbs has been rendered and injecting it
+  // again would break the DOM and CSP enforcement.
+  if (!document.head.querySelector('meta[http-equiv="Content-Security-Policy"]')) {
+    await loadTemplate('html', 'mainPanel.hbs');
+  }
 
   return;
 })();


### PR DESCRIPTION
## Summary
- avoid injecting the main HTML template when it already exists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685adc46c74c83259597e67406673017