### PR TITLE
Use decode from html-entities

### DIFF
--- a/app/ts/common/parser.ts
+++ b/app/ts/common/parser.ts
@@ -1,13 +1,12 @@
 import * as changeCase from 'change-case';
-import { XmlEntities } from 'html-entities';
+import { decode } from 'html-entities';
 
 export function preStringStrip(str: string): string {
   return str.toString().replace(/\:\t{1,2}/g, ': ');
 }
 
 function stripHTMLEntities(rawData: string): string {
-  const entities = new XmlEntities();
-  return entities.decode(rawData);
+  return decode(rawData);
 }
 
 function filterColonChar(rawData: string): string {

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -12,9 +12,5 @@ jest.mock('change-case', () => ({
 }));
 
 jest.mock('html-entities', () => ({
-  XmlEntities: class {
-    decode(input: string): string {
-      return input;
-    }
-  }
+  decode: (input: string) => input,
 }));

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -145,9 +145,7 @@ declare module 'change-case' {
 }
 
 declare module 'html-entities' {
-  export class XmlEntities {
-    decode(input: string): string;
-  }
+  export function decode(input: string): string;
 }
 
 declare const $: any;


### PR DESCRIPTION
## Summary
- update parser to use `decode` helper
- adjust custom TS types
- mock `html-entities` decode in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685aeb7447908325ab48c5848410f7eb