### PR TITLE
Delay options initialization until settings loaded

### DIFF
--- a/app/ts/renderer/options.ts
+++ b/app/ts/renderer/options.ts
@@ -114,7 +114,7 @@ $(document).ready(() => {
   const container = $('#opEntry');
   const table = $('#opTable');
   buildEntries(appDefaults.settings, '', table);
-  populateInputs();
+  // Wait for the final settings to load before populating fields
 
   const status = $('#custom-settings-status');
   const customLoaded = sessionStorage.getItem('customSettingsLoaded') === 'true';


### PR DESCRIPTION
## Summary
- populate inputs only after the `settings-loaded` event so values are final

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b025b0bb8832594ec9eaa254de8d5