### PR TITLE
Add Handlebars template loader tests

### DIFF
--- a/test/registerPartials.test.ts
+++ b/test/registerPartials.test.ts
@@ -1,0 +1,62 @@
+const partialNames = [
+  'bwEntry',
+  'bwExport',
+  'bwExportLoading',
+  'bwFileInputConfirm',
+  'bwFileInputLoading',
+  'bwProcessing',
+  'bwWordlistConfirm',
+  'bwWordlistInput',
+  'bwWordlistLoading',
+  'bwaAnalyser',
+  'bwaEntry',
+  'bwaFileInputLoading',
+  'bwaFileinputconfirm',
+  'bwaProcess',
+  'navBottom',
+  'navTop',
+  'opEntry',
+  'singlewhois',
+  'toEntry',
+  'he',
+  'modals'
+];
+
+jest.mock('handlebars/runtime', () => {
+  const template = jest.fn((pre: any) => `compiled-${pre.name}`);
+  const registerPartial = jest.fn();
+  return { __esModule: true, default: { template, registerPartial } };
+});
+
+for (const name of partialNames) {
+  jest.mock(`../app/compiled-templates/${name}.js`, () => ({
+    __esModule: true,
+    default: { name }
+  }), { virtual: true });
+}
+
+const handlebars = require('handlebars/runtime').default;
+const { registerPartials } = require('../app/ts/renderer/registerPartials');
+
+describe('registerPartials', () => {
+  beforeEach(() => {
+    (handlebars.registerPartial as jest.Mock).mockClear();
+    (handlebars.template as jest.Mock).mockClear();
+  });
+
+  test('registers compiled partials with Handlebars', () => {
+    registerPartials();
+
+    expect((handlebars.template as jest.Mock).mock.calls.length).toBe(partialNames.length);
+    expect((handlebars.registerPartial as jest.Mock).mock.calls.length).toBe(partialNames.length);
+
+    partialNames.forEach((name, index) => {
+      const precompiled = { name };
+      expect((handlebars.template as jest.Mock).mock.calls[index][0]).toEqual(precompiled);
+      expect((handlebars.registerPartial as jest.Mock).mock.calls[index]).toEqual([
+        name,
+        `compiled-${name}`
+      ]);
+    });
+  });
+});

--- a/test/templateLoader.test.ts
+++ b/test/templateLoader.test.ts
@@ -1,0 +1,31 @@
+/** @jest-environment jsdom */
+
+import jQuery from 'jquery';
+
+jest.mock('handlebars/runtime', () => {
+  const compiledFn = jest.fn((ctx: any) => `<span>${ctx.text}</span>`);
+  const template = jest.fn(() => compiledFn);
+  return { __esModule: true, default: { template } };
+});
+
+jest.mock('../app/compiled-templates/mock.js', () => ({
+  __esModule: true,
+  default: { name: 'mock' }
+}), { virtual: true });
+
+import { loadTemplate } from '../app/ts/renderer/templateLoader';
+const handlebars = require('handlebars/runtime').default;
+
+beforeAll(() => {
+  (window as any).$ = (window as any).jQuery = jQuery;
+});
+
+describe('loadTemplate', () => {
+  test('dynamically loads template and inserts html', async () => {
+    document.body.innerHTML = '<div id="target"></div>';
+    await loadTemplate('#target', 'mock.hbs', { text: 'hello' });
+
+    expect(handlebars.template).toHaveBeenCalledWith({ name: 'mock' });
+    expect(jQuery('#target').html()).toBe('<span>hello</span>');
+  });
+});


### PR DESCRIPTION
## Summary
- test that `registerPartials` registers compiled partials
- test that `loadTemplate` dynamically imports templates and injects html

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b0391ca988325877434e2343c22cf