### PR TITLE
Fix proxy ascending rotation

### DIFF
--- a/app/ts/common/proxy.ts
+++ b/app/ts/common/proxy.ts
@@ -35,7 +35,7 @@ export function getProxy(): ProxyInfo | undefined {
       entry = list[Math.floor(Math.random() * list.length)];
       break;
     case 'ascending':
-      index = Math.min(index + 1, list.length - 1);
+      index = (index + 1) % list.length;
       entry = list[index];
       break;
     case 'descending':

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -50,7 +50,7 @@ describe('proxy helper', () => {
     const third = getProxy();
     expect(first).toEqual({ ipaddress: '2.2.2.2', port: 8080, type: 5 });
     expect(second).toEqual({ ipaddress: '3.3.3.3', port: 8080, type: 5 });
-    expect(third).toEqual({ ipaddress: '3.3.3.3', port: 8080, type: 5 });
+    expect(third).toEqual({ ipaddress: '1.1.1.1', port: 8080, type: 5 });
   });
 
   test('cycles proxies descending', () => {


### PR DESCRIPTION
## Summary
- cycle back to the first entry after the last one when proxy multimode is `ascending`
- ensure tests check rotation order for sequential, ascending and descending modes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b0edb1fac8325bd9f2efb2e6b1ef1