### PR TITLE
Trigger populateInputs on options tab

### DIFF
--- a/app/ts/renderer/navigation.ts
+++ b/app/ts/renderer/navigation.ts
@@ -1,6 +1,7 @@
 import { ipcRenderer } from 'electron';
 import { formatString } from '../common/stringformat';
 import $ from 'jquery';
+import { populateInputs } from './options';
 
 /*
   $(document).on('drop', function(...) {...});
@@ -51,6 +52,9 @@ $(document).on('click', 'section.tabs ul li', function () {
 
     $(this).addClass('is-active');
     $('#' + tabName).addClass('current');
+    if (tabName === 'opMainContainer') {
+      populateInputs();
+    }
   }
   ipcRenderer.send('app:debug', formatString('#section.tabs switched to data tab, {0}', tabName));
 

--- a/app/ts/renderer/options.ts
+++ b/app/ts/renderer/options.ts
@@ -80,7 +80,7 @@ function buildEntries(obj: any, prefix: string, table: JQuery<HTMLElement>): voi
   });
 }
 
-function populateInputs(): void {
+export function populateInputs(): void {
   $('#opTable')
     .find('input[id], select[id]')
     .each((_, el) => {


### PR DESCRIPTION
## Summary
- export `populateInputs` from `options.ts`
- when switching to the Options tab, call `populateInputs` so settings refresh

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b127dfe1083259887affc6e0e9798