### PR TITLE
Add feedback toast on settings reload

### DIFF
--- a/app/ts/renderer/options.ts
+++ b/app/ts/renderer/options.ts
@@ -6,6 +6,7 @@ import {
   saveSettings,
   validateSettings,
   loadSettings,
+  customSettingsLoaded,
   getUserDataPath
 } from '../common/settings';
 import appDefaults, { appSettingsDescriptions } from '../appsettings';
@@ -197,7 +198,12 @@ $(document).ready(() => {
 
   $('#reloadSettings').on('click', async () => {
     await loadSettings();
+    sessionStorage.setItem('customSettingsLoaded', customSettingsLoaded ? 'true' : 'false');
     populateInputs();
+    showToast(
+      customSettingsLoaded ? 'Configuration reloaded' : 'Failed to reload configuration',
+      customSettingsLoaded
+    );
   });
 
   $('#saveConfig').on('click', async () => {


### PR DESCRIPTION
## Summary
- reload settings should show a toast with success/failure status

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bb0c142448325910c12f95ccc708a