### PR TITLE
Use npm install in CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - name: Install dependencies
-        run: npm ci --no-audit --no-fund
+        run: npm install --no-audit --no-fund
       - name: Check formatting
         run: npm run format -- --check
       - run: npm run lint
@@ -50,7 +50,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - name: Install dependencies
-        run: npm ci --no-audit --no-fund
+        run: npm install --no-audit --no-fund
       - run: npx tsc --noEmit
 
   build:
@@ -69,7 +69,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - name: Install dependencies
-        run: npm ci --no-audit --no-fund
+        run: npm install --no-audit --no-fund
       - run: npm test
       - uses: actions/upload-artifact@v4
         if: always()
@@ -124,7 +124,7 @@ jobs:
             ~/.cache/electron-builder
           key: ${{ runner.os }}-electron-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
-        run: npm ci --no-audit --no-fund
+        run: npm install --no-audit --no-fund
       - name: Build
         run: npm run build
       - name: Run e2e tests
@@ -153,7 +153,7 @@ jobs:
             ~/.cache/electron-builder
           key: ${{ runner.os }}-electron-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
-        run: npm ci --no-audit --no-fund
+        run: npm install --no-audit --no-fund
       - run: npm run package-linux
       - run: mv release_builds release_builds-${{ matrix.node-version }}
       - uses: actions/upload-artifact@v4
@@ -184,7 +184,7 @@ jobs:
             ~/.cache/electron-builder
           key: ${{ runner.os }}-electron-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
-        run: npm ci --no-audit --no-fund
+        run: npm install --no-audit --no-fund
       - run: npm run package-win
       - run: mv release_builds release_builds-${{ matrix.node-version }}
       - uses: actions/upload-artifact@v4
@@ -215,7 +215,7 @@ jobs:
             ~/.cache/electron-builder
           key: ${{ runner.os }}-electron-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
-        run: npm ci --no-audit --no-fund
+        run: npm install --no-audit --no-fund
       - run: npm run package-mac
       - run: mv release_builds release_builds-${{ matrix.node-version }}
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- update GitHub workflow to use `npm install` instead of `npm ci`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b132cdde883258888b0e955d428a1