### PR TITLE
Add search to configuration options

### DIFF
--- a/app/html/tabs/op/opEntry.html
+++ b/app/html/tabs/op/opEntry.html
@@ -10,6 +10,18 @@
   Settings not loaded in this session.
 </p>
 <p id="custom-settings-status" class="has-text-info"></p>
+<div class="field mb-2">
+  <p class="control has-icons-left">
+    <input
+      id="opSearch"
+      class="input is-small"
+      type="text"
+      placeholder="Search options"
+    />
+    <span class="icon is-small is-left"><i class="fas fa-search"></i></span>
+  </p>
+</div>
+<p id="opSearchNoResults" class="has-text-centered is-hidden">No configuration found.</p>
 <div class="mb-2 has-text-right">
   <button id="restoreDefaults" class="button is-small is-danger">Restore defaults</button>
   <button id="reloadSettings" class="button is-small is-info">Reload</button>

--- a/app/html/templates/opEntry.hbs
+++ b/app/html/templates/opEntry.hbs
@@ -10,6 +10,20 @@
   Settings not loaded in this session.
 </p>
 <p id="custom-settings-status" class="has-text-info"></p>
+<div class="field mb-2">
+  <p class="control has-icons-left">
+    <input
+      id="opSearch"
+      class="input is-small"
+      type="text"
+      placeholder="Search options"
+    />
+    <span class="icon is-small is-left"><i class="fas fa-search"></i></span>
+  </p>
+</div>
+<p id="opSearchNoResults" class="has-text-centered is-hidden">
+  No configuration found.
+</p>
 <div class="mb-2 has-text-right">
   <button id="restoreDefaults" class="button is-small is-danger">Restore defaults</button>
   <button id="reloadSettings" class="button is-small is-info">Reload</button>

--- a/app/ts/renderer/options.ts
+++ b/app/ts/renderer/options.ts
@@ -54,7 +54,7 @@ const enumOptions: Record<string, string[]> = {
 function buildEntries(obj: any, prefix: string, table: JQuery<HTMLElement>): void {
   Object.entries(obj).forEach(([key, value]) => {
     if (value && typeof value === 'object' && !Array.isArray(value)) {
-      table.append(`<tr><th colspan="2"><h4 class="title is-5">${key}</h4></th></tr>`);
+      table.append(`<tr class="group-row"><th colspan="2"><h4 class="title is-5">${key}</h4></th></tr>`);
       buildEntries(value, prefix ? `${prefix}.${key}` : key, table);
     } else {
       const path = prefix ? `${prefix}.${key}` : key;
@@ -128,10 +128,42 @@ function showToast(message: string, success: boolean): void {
   }, 3000);
 }
 
+function filterOptions(term: string): void {
+  const needle = term.trim().toLowerCase();
+  const rows = $('#opTable tr');
+  if (!needle) {
+    rows.show();
+    $('#opSearchNoResults').addClass('is-hidden');
+    return;
+  }
+
+  rows.each(function () {
+    const $row = $(this);
+    if ($row.hasClass('group-row')) {
+      $row.show();
+      return;
+    }
+    $row.toggle($row.text().toLowerCase().includes(needle));
+  });
+
+  $('#opTable .group-row').each(function () {
+    const $group = $(this);
+    const visible = $group.nextUntil('.group-row').filter(':visible').length > 0;
+    $group.toggle(visible);
+  });
+
+  const anyVisible = rows.not('.group-row').filter(':visible').length > 0;
+  $('#opSearchNoResults').toggleClass('is-hidden', anyVisible);
+}
+
 $(document).ready(() => {
   const container = $('#opEntry');
   const table = $('#opTable');
   buildEntries(appDefaults.settings, '', table);
+  filterOptions('');
+  $('#opSearch').on('input', function () {
+    filterOptions($(this).val() as string);
+  });
   // Wait for the final settings to load before populating fields
 
   const status = $('#custom-settings-status');


### PR DESCRIPTION
## Summary
- add search input on Options page
- filter options list as user types and show a 'No configuration found' message

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685bb12f645883258f7597d1fae3bbcc