### PR TITLE
Group modals in dedicated containers

### DIFF
--- a/app/html/misc/modals.html
+++ b/app/html/misc/modals.html
@@ -1,7 +1,8 @@
-<!-- Close whoisdigger, modal -->
-<div id="appModalExit" class="modal">
-  <div class="modal-background"></div>
-  <div class="modal-card">
+<div id="appModalsContainer">
+  <!-- Close whoisdigger, modal -->
+  <div id="appModalExit" class="modal">
+    <div class="modal-background"></div>
+    <div class="modal-card">
     <header class="modal-card-head">
       <p class="modal-card-title">Close whoisdigger?</p>
       <button class="delete" aria-label="close"></button>
@@ -15,13 +16,13 @@
       <button id="appModalExitButtonYes" class="button is-danger">Yes</button>
       <button id="appModalExitButtonNo" class="button">No</button>
     </footer>
+    </div>
   </div>
-</div>
 
-<!-- Restore defaults confirmation -->
-<div id="restoreDefaultsModal" class="modal">
-  <div class="modal-background"></div>
-  <div class="modal-card">
+  <!-- Restore defaults confirmation -->
+  <div id="restoreDefaultsModal" class="modal">
+    <div class="modal-background"></div>
+    <div class="modal-card">
     <header class="modal-card-head">
       <p class="modal-card-title">Restore defaults?</p>
       <button class="delete" aria-label="close"></button>
@@ -31,13 +32,13 @@
       <button id="restoreDefaultsYes" class="button is-danger">Yes</button>
       <button id="restoreDefaultsNo" class="button">No</button>
     </footer>
+    </div>
   </div>
-</div>
 
-<!-- Delete configuration confirmation -->
-<div id="deleteConfigModal" class="modal">
-  <div class="modal-background"></div>
-  <div class="modal-card">
+  <!-- Delete configuration confirmation -->
+  <div id="deleteConfigModal" class="modal">
+    <div class="modal-background"></div>
+    <div class="modal-card">
     <header class="modal-card-head">
       <p class="modal-card-title">Delete configuration?</p>
       <button class="delete" aria-label="close"></button>
@@ -47,5 +48,6 @@
       <button id="deleteConfigYes" class="button is-danger">Yes</button>
       <button id="deleteConfigNo" class="button">No</button>
     </footer>
+    </div>
   </div>
 </div>

--- a/app/html/templates/bwProcessing.hbs
+++ b/app/html/templates/bwProcessing.hbs
@@ -1,24 +1,26 @@
 <!-- Cancel Bulk whois modal -->
-<div id="bwProcessingModalStop" class="modal">
-  <div class="modal-background"></div>
-  <div class="modal-card">
-    <header class="modal-card-head">
-      <p class="modal-card-title">Stop bulk whois?</p>
-    </header>
-    <section class="modal-card-body">
+<div id="bwProcessingModals">
+  <div id="bwProcessingModalStop" class="modal">
+    <div class="modal-background"></div>
+    <div class="modal-card">
+      <header class="modal-card-head">
+        <p class="modal-card-title">Stop bulk whois?</p>
+      </header>
+      <section class="modal-card-body">
       Are you sure you want to stop your bulk whois lookup?
       <br />
       Make sure you want to save all the current results, discard them or continue processing.
-    </section>
-    <footer class="modal-card-foot uk-text-center">
+      </section>
+      <footer class="modal-card-foot uk-text-center">
       <button id="bwProcessingModalStopButtonStop" class="button is-danger">
         Stop without saving
       </button>
       <button id="bwProcessingModalStopButtonStopsave" class="button is-warning">
         Stop and save
       </button>
-      <button id="bwProcessingModalStopButtonContinue" class="button">Continue</button>
-    </footer>
+        <button id="bwProcessingModalStopButtonContinue" class="button">Continue</button>
+      </footer>
+    </div>
   </div>
 </div>
 <!-- Processing bulk whois -->

--- a/app/html/templates/bwaAnalyser.hbs
+++ b/app/html/templates/bwaAnalyser.hbs
@@ -1,16 +1,18 @@
 <!-- Close Bulk whois analyser, modal -->
-<div id="bwaAnalyserModalClose" class="modal">
-  <div class="modal-background"></div>
-  <div class="modal-card">
-    <header class="modal-card-head">
-      <p class="modal-card-title">Close analyser session?</p>
-      <button class="delete" aria-label="close"></button>
-    </header>
-    <section class="modal-card-body">Are you sure you want to close your analyser session?</section>
-    <footer class="modal-card-foot uk-text-center">
-      <button id="bwaAnalyserModalCloseButtonYes" class="button is-warning">Yes</button>
-      <button id="bwaAnalyserModalCloseButtonNo" class="button">No</button>
-    </footer>
+<div id="bwaAnalyserModals">
+  <div id="bwaAnalyserModalClose" class="modal">
+    <div class="modal-background"></div>
+    <div class="modal-card">
+      <header class="modal-card-head">
+        <p class="modal-card-title">Close analyser session?</p>
+        <button class="delete" aria-label="close"></button>
+      </header>
+      <section class="modal-card-body">Are you sure you want to close your analyser session?</section>
+      <footer class="modal-card-foot uk-text-center">
+        <button id="bwaAnalyserModalCloseButtonYes" class="button is-warning">Yes</button>
+        <button id="bwaAnalyserModalCloseButtonNo" class="button">No</button>
+      </footer>
+    </div>
   </div>
 </div>
 

--- a/app/html/templates/modals.hbs
+++ b/app/html/templates/modals.hbs
@@ -1,5 +1,6 @@
-<!-- Close whoisdigger, modal -->
-<div id="appModalExit" class="modal">
+<div id="appModalsContainer">
+  <!-- Close whoisdigger, modal -->
+  <div id="appModalExit" class="modal">
   <div class="modal-background"></div>
   <div class="modal-card">
     <header class="modal-card-head">
@@ -16,10 +17,10 @@
       <button id="appModalExitButtonNo" class="button">No</button>
     </footer>
   </div>
-</div>
+  </div>
 
-<!-- Restore defaults confirmation -->
-<div id="restoreDefaultsModal" class="modal">
+  <!-- Restore defaults confirmation -->
+  <div id="restoreDefaultsModal" class="modal">
   <div class="modal-background"></div>
   <div class="modal-card">
     <header class="modal-card-head">
@@ -32,10 +33,10 @@
       <button id="restoreDefaultsNo" class="button">No</button>
     </footer>
   </div>
-</div>
+  </div>
 
-<!-- Delete configuration confirmation -->
-<div id="deleteConfigModal" class="modal">
+  <!-- Delete configuration confirmation -->
+  <div id="deleteConfigModal" class="modal">
   <div class="modal-background"></div>
   <div class="modal-card">
     <header class="modal-card-head">
@@ -47,5 +48,6 @@
       <button id="deleteConfigYes" class="button is-danger">Yes</button>
       <button id="deleteConfigNo" class="button">No</button>
     </footer>
+  </div>
   </div>
 </div>

--- a/app/html/templates/singlewhois.hbs
+++ b/app/html/templates/singlewhois.hbs
@@ -29,42 +29,44 @@
   <a class="singlewhoisMessageWhoisOpen" href="#">Check the whois request response.</a>
 </div>
 
-<div id="singlewhoisMessageWhois" class="modal">
-  <div class="modal-background"></div>
-  <div class="modal-content">
-    <div class="box">
-      <div class="highlight-full">
-        <figure class="highlight">
-          <pre id="singlewhoisMessageWhoisResults" class="has-text-left"></pre>
-        </figure>
+<div id="singlewhoisModals">
+  <div id="singlewhoisMessageWhois" class="modal">
+    <div class="modal-background"></div>
+    <div class="modal-content">
+      <div class="box">
+        <div class="highlight-full">
+          <figure class="highlight">
+            <pre id="singlewhoisMessageWhoisResults" class="has-text-left"></pre>
+          </figure>
+        </div>
       </div>
     </div>
+    <button
+      id="singlewhoisMessageWhoisClose"
+      class="modal-close is-large"
+      aria-label="close"
+    ></button>
   </div>
-  <button
-    id="singlewhoisMessageWhoisClose"
-    class="modal-close is-large"
-    aria-label="close"
-  ></button>
-</div>
 
-<div id="singlewhoisDomainCopied" class="modal">
-  <div class="modal-background"></div>
-  <div class="modal-content">
-    <div class="box">
-      <div class="highlight-full">
-        <figure class="highlight">
-          <pre class="has-text-left">
-            The domain url has been copied
-          </pre>
-        </figure>
+  <div id="singlewhoisDomainCopied" class="modal">
+    <div class="modal-background"></div>
+    <div class="modal-content">
+      <div class="box">
+        <div class="highlight-full">
+          <figure class="highlight">
+            <pre class="has-text-left">
+              The domain url has been copied
+            </pre>
+          </figure>
+        </div>
       </div>
     </div>
+    <button
+      id="singlewhoisDomainCopiedClose"
+      class="modal-close is-large"
+      aria-label="close"
+    ></button>
   </div>
-  <button
-    id="singlewhoisDomainCopiedClose"
-    class="modal-close is-large"
-    aria-label="close"
-  ></button>
 </div>
 
 <div class="container is-hidden">


### PR DESCRIPTION
## Summary
- wrap general modals partial in `appModalsContainer`
- add containers for single whois, bulk processing and analyser modals
- mirror the modal container structure for the misc HTML copy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bb20948948325a9b4945f94e33200