### PR TITLE
Add open config button

### DIFF
--- a/app/html/templates/opEntry.hbs
+++ b/app/html/templates/opEntry.hbs
@@ -28,6 +28,7 @@
   <button id="restoreDefaults" class="button is-small is-danger">Restore defaults</button>
   <button id="reloadSettings" class="button is-small is-info">Reload</button>
   <button id="saveConfig" class="button is-small is-success">Save</button>
+  <button id="openConfigPath" class="button is-small is-info">Open config file</button>
   <button id="deleteConfig" class="button is-small is-danger">Delete config</button>
 </div>
 <table id="opTable" class="table is-striped is-hoverable is-fullwidth has-text-left"></table>

--- a/app/ts/renderer/options.ts
+++ b/app/ts/renderer/options.ts
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import fs from 'fs';
 import path from 'path';
+import { shell } from 'electron';
 import {
   settings,
   saveSettings,
@@ -246,6 +247,17 @@ $(document).ready(() => {
         : 'Failed to save configuration',
       res === 'SAVED' || res === undefined
     );
+  });
+
+  $('#openConfigPath').on('click', async () => {
+    const filePath = path.join(
+      getUserDataPath(),
+      settings.customConfiguration.filepath
+    );
+    const result = await shell.openPath(filePath);
+    if (result) {
+      showToast('Failed to open configuration file', false);
+    }
   });
 
   $('#deleteConfig').on('click', () => {


### PR DESCRIPTION
## Summary
- allow opening the custom configuration file directly from Options
- enable the new button in the options template

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bb7b99dc08325a8b89afaacf6ce3f