### PR TITLE
Prevent asset watcher from scanning user data

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,5 +88,8 @@
     "babel-jest": "^30.0.2",
     "@babel/core": "^7.27.4",
     "@babel/preset-env": "^7.27.2"
+  },
+  "electronmon": {
+    "patterns": ["!dist/app/data/**"]
   }
 }


### PR DESCRIPTION
## Summary
- add electronmon ignore pattern for `dist/app/data`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bd85c219c832594a3f33336887dfb