### PR TITLE
Open data folder from options

### DIFF
--- a/app/html/templates/opEntry.hbs
+++ b/app/html/templates/opEntry.hbs
@@ -28,7 +28,7 @@
   <button id="restoreDefaults" class="button is-small is-danger">Restore defaults</button>
   <button id="reloadSettings" class="button is-small is-info">Reload</button>
   <button id="saveConfig" class="button is-small is-success">Save</button>
-  <button id="openConfigPath" class="button is-small is-info">Open config file</button>
+  <button id="openDataFolder" class="button is-small is-info">Open data folder</button>
   <button id="deleteConfig" class="button is-small is-danger">Delete config</button>
 </div>
 <table id="opTable" class="table is-striped is-hoverable is-fullwidth has-text-left"></table>

--- a/app/ts/renderer/options.ts
+++ b/app/ts/renderer/options.ts
@@ -240,15 +240,11 @@ $(document).ready(() => {
     );
   });
 
-  $('#openConfigPath').on('click', async () => {
-    const filePath = path.join(getUserDataPath(), settings.customConfiguration.filepath);
-    await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
-    if (!fs.existsSync(filePath)) {
-      await fs.promises.writeFile(filePath, JSON.stringify(settings, null, 2));
-    }
-    const result = await shell.openPath(filePath);
+  $('#openDataFolder').on('click', async () => {
+    const dataDir = getUserDataPath();
+    const result = await shell.openPath(dataDir);
     if (result) {
-      showToast('Failed to open configuration file', false);
+      showToast('Failed to open data directory', false);
     }
   });
 


### PR DESCRIPTION
## Summary
- rename "Open config file" button to "Open data folder"
- adjust click handler to open the user data directory instead of a config file

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685be45635a483258596d76f1bf69614