### PR TITLE
Add app reload functionality

### DIFF
--- a/app/html/templates/opEntry.hbs
+++ b/app/html/templates/opEntry.hbs
@@ -29,6 +29,7 @@
   <button id="reloadSettings" class="button is-small is-info">Reload</button>
   <button id="saveConfig" class="button is-small is-success">Save</button>
   <button id="openDataFolder" class="button is-small is-info">Open data folder</button>
+  <button id="reloadApp" class="button is-small is-warning">Reload App</button>
   <button id="deleteConfig" class="button is-small is-danger">Delete config</button>
 </div>
 <table id="opTable" class="table is-striped is-hoverable is-fullwidth has-text-left"></table>

--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -208,6 +208,15 @@ ipcMain.handle('app:close', function () {
 });
 
 /*
+  ipcMain.handle('app:reload', function(...) {...});
+    Relaunch the application
+ */
+ipcMain.handle('app:reload', function () {
+  app.relaunch();
+  app.exit(0);
+});
+
+/*
   ipcMain.on('app:debug', function(...) {...});
     Application debug event
  */

--- a/app/ts/renderer/options.ts
+++ b/app/ts/renderer/options.ts
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import fs from 'fs';
 import path from 'path';
-import { shell } from 'electron';
+import { shell, ipcRenderer } from 'electron';
 import {
   settings,
   saveSettings,
@@ -245,6 +245,14 @@ $(document).ready(() => {
     const result = await shell.openPath(dataDir);
     if (result) {
       showToast('Failed to open data directory', false);
+    }
+  });
+
+  $('#reloadApp').on('click', async () => {
+    try {
+      await ipcRenderer.invoke('app:reload');
+    } catch {
+      showToast('Failed to reload application', false);
     }
   });
 

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -33,6 +33,7 @@ declare module 'electron' {
 
   interface RendererToMainIpc {
     'app:minimize': [];
+    'app:reload': [];
     'app:debug': [message: any];
     'bw:lookup': [string[], string[]];
     'bw:lookup.pause': [];


### PR DESCRIPTION
## Summary
- add a "Reload App" button in the options view
- invoke a new ipc event from options.ts to restart the app
- handle `app:reload` in main process by relaunching
- extend custom IPC types

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685be9966bc48325bbacb037dd0de619