### PR TITLE
Add settings liveReload option with auto update

### DIFF
--- a/app/ts/appsettings.ts
+++ b/app/ts/appsettings.ts
@@ -153,6 +153,10 @@ const appSettings = {
       averages: true, // enable average calcs
       stopwatch: true // enable elapsed and remaining time to complete
     },
+    ui: {
+      // User interface options
+      liveReload: true // Reload settings on change (default: true)
+    },
     lookupMisc: {
       // Lookup miscellaneous configurations
       useStandardSize: true, // Use metric size measures for filesizes instead of IEC (ex: kB kilobyte (1000) instead of KiB kibibyte (1024)) (default: true)
@@ -253,6 +257,7 @@ export const appSettingsDescriptions: Record<string, string> = {
   'performanceBulkRequest.timers': 'Bulk lookup timers',
   'performanceBulkRequest.averages': 'Bulk lookup averages',
   'performanceBulkRequest.stopwatch': 'Bulk lookup stopwatch',
+  'ui.liveReload': 'Reload configuration automatically',
   'lookupMisc.useStandardSize': 'Use metric units for file sizes',
   'lookupMisc.asfOverride': 'Override average smoothing factor',
   'lookupMisc.averageSmoothingFactor': 'Average smoothing factor',

--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -53,6 +53,7 @@ export interface Settings {
   };
   customConfiguration: { filepath: string; load: boolean; save: boolean };
   theme: { darkMode: boolean };
+  ui: { liveReload: boolean };
   [key: string]: any;
 }
 
@@ -139,9 +140,15 @@ function watchConfig(): void {
       try {
         settings = mergeDefaults(parsed);
         debug(`Reloaded custom configuration at ${cfg}`);
+        if (typeof window !== 'undefined' && settings.ui?.liveReload) {
+          window.dispatchEvent(new Event('settings-reloaded'));
+        }
       } catch (mergeError) {
         settings = JSON.parse(JSON.stringify(defaultSettings));
         debug(`Failed to merge configuration with error: ${mergeError}`);
+        if (typeof window !== 'undefined' && settings.ui?.liveReload) {
+          window.dispatchEvent(new Event('settings-reloaded'));
+        }
       }
     } catch (e) {
       debug(`Failed to reload configuration with error: ${e}`);

--- a/app/ts/renderer/options.ts
+++ b/app/ts/renderer/options.ts
@@ -178,6 +178,12 @@ $(document).ready(() => {
     populateInputs();
   });
 
+  window.addEventListener('settings-reloaded', () => {
+    const loaded = sessionStorage.getItem('customSettingsLoaded') === 'true';
+    status.text(loaded ? 'Custom settings loaded.' : 'Custom settings not loaded.');
+    populateInputs();
+  });
+
   container.on('change', 'input[id], select[id]', function () {
     const $el = $(this);
     const id = $el.attr('id');


### PR DESCRIPTION
## Summary
- introduce `ui.liveReload` setting defaulting to `true`
- describe the new setting in `appSettingsDescriptions`
- extend `Settings` interface to include `ui`
- dispatch `settings-reloaded` event when configuration file changes and liveReload is enabled
- update options page to refresh when settings are reloaded

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685beccee0508325a3444201a1c196e3