### PR TITLE
Add file watchers for renderer inputs

### DIFF
--- a/test/fileWatcher.test.ts
+++ b/test/fileWatcher.test.ts
@@ -1,0 +1,114 @@
+/** @jest-environment jsdom */
+
+import { EventEmitter } from 'events';
+import jQuery from 'jquery';
+
+const ipc = new EventEmitter() as any;
+ipc.send = jest.fn();
+
+const watchEmitter = new EventEmitter() as any;
+watchEmitter.close = jest.fn();
+
+const statMock = jest.fn();
+const readFileMock = jest.fn();
+const statSyncMock = jest.fn();
+const readFileSyncMock = jest.fn();
+const watchMock = jest.fn((path: string, options: any, listener?: (...args: any[]) => void) => {
+  if (listener) watchEmitter.on('change', listener);
+  return watchEmitter;
+});
+
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  promises: { stat: statMock, readFile: readFileMock },
+  statSync: statSyncMock,
+  readFileSync: readFileSyncMock,
+  watch: watchMock
+}));
+
+jest.mock('electron', () => ({
+  ipcRenderer: {
+    on: (channel: string, listener: (...args: any[]) => void) => ipc.on(channel, listener),
+    send: ipc.send
+  }
+}));
+
+beforeAll(() => {
+  (window as any).$ = (window as any).jQuery = jQuery;
+});
+
+beforeEach(() => {
+  statMock.mockReset();
+  readFileMock.mockReset();
+  statSyncMock.mockReset();
+  readFileSyncMock.mockReset();
+  watchMock.mockClear();
+  (watchEmitter.close as jest.Mock).mockClear();
+});
+
+test('bw watcher updates table on change', async () => {
+  document.body.innerHTML = `
+    <td id="bwFileTdName"></td>
+    <td id="bwFileTdLastmodified"></td>
+    <td id="bwFileTdLastaccess"></td>
+    <td id="bwFileTdFilesize"></td>
+    <td id="bwFileTdFilepreview"></td>
+    <span id="bwFileSpanTimebetweenmin"></span>
+    <span id="bwFileSpanTimebetweenmax"></span>
+    <span id="bwFileSpanTimebetweenminmax"></span>
+    <td id="bwFileTdEstimate"></td>
+  `;
+
+  const initialStats = { size: 10, mtime: new Date('2020-01-01'), atime: new Date('2020-01-01') } as any;
+  statMock.mockResolvedValue(initialStats);
+  readFileMock.mockResolvedValue(Buffer.from('a\nb\n'));
+  statSyncMock.mockReturnValue({ size: 20, mtime: new Date('2020-01-02'), atime: new Date('2020-01-02') } as any);
+  readFileSyncMock.mockReturnValue(Buffer.from('a\nb\nc\n'));
+
+  jest.isolateModules(() => {
+    require('../app/ts/renderer/bw/fileinput');
+  });
+
+  ipc.emit('bw:fileinput.confirmation', {}, '/tmp/test.txt', true);
+  for (let i = 0; i < 5; i++) await new Promise(res => setTimeout(res, 0));
+
+  expect(watchMock).toHaveBeenCalledWith('/tmp/test.txt', { persistent: false }, expect.any(Function));
+
+  watchEmitter.emit('change', 'change');
+  for (let i = 0; i < 5; i++) await new Promise(res => setTimeout(res, 0));
+
+  expect(statSyncMock).toHaveBeenCalled();
+  expect(readFileSyncMock).toHaveBeenCalled();
+});
+
+test('bwa watcher updates table on change', async () => {
+  document.body.innerHTML = `
+    <td id="bwaFileTdFilename"></td>
+    <td id="bwaFileTdLastmodified"></td>
+    <td id="bwaFileTdLastaccessed"></td>
+    <td id="bwaFileTdFilesize"></td>
+    <td id="bwaFileTdFilepreview"></td>
+    <textarea id="bwaFileTextareaErrors"></textarea>
+  `;
+
+  const initialStats = { size: 5, mtime: new Date('2020-03-01'), atime: new Date('2020-03-01') } as any;
+  statMock.mockResolvedValue(initialStats);
+  readFileMock.mockResolvedValue(Buffer.from('a,b\n1,2\n3,4\n'));
+  statSyncMock.mockReturnValue({ size: 8, mtime: new Date('2020-03-02'), atime: new Date('2020-03-02') } as any);
+  readFileSyncMock.mockReturnValue(Buffer.from('a,b\n1,2\n3,4\n5,6\n'));
+
+  jest.isolateModules(() => {
+    require('../app/ts/renderer/bwa/fileinput');
+  });
+
+  ipc.emit('bwa:fileinput.confirmation', {}, '/tmp/test.csv', true);
+  for (let i = 0; i < 5; i++) await new Promise(res => setTimeout(res, 0));
+
+  expect(watchMock).toHaveBeenCalledWith('/tmp/test.csv', { persistent: false }, expect.any(Function));
+
+  watchEmitter.emit('change', 'change');
+  for (let i = 0; i < 5; i++) await new Promise(res => setTimeout(res, 0));
+
+  expect(statSyncMock).toHaveBeenCalled();
+  expect(readFileSyncMock).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- watch selected files in bw and bwa views
- refresh file stats on change events
- clean up watchers when leaving confirmation views
- test that file watchers re-read the file on change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bf893377083258034239fccb7bb91