### PR TITLE
Fix TS2322 in fileinput

### DIFF
--- a/app/ts/renderer/bw/fileinput.ts
+++ b/app/ts/renderer/bw/fileinput.ts
@@ -29,7 +29,7 @@ async function refreshBwFile(pathToFile: string): Promise<void> {
       bwFileStats.size,
       misc.useStandardSize
     );
-    bwFileContents = fs.readFileSync(pathToFile);
+    bwFileContents = fs.readFileSync(pathToFile) as unknown as Buffer;
     bwFileStats.linecount = bwFileContents.toString().split('\n').length;
 
     if (lookup.randomize.timeBetween.randomize === true) {


### PR DESCRIPTION
## Summary
- handle custom Node typings returning `string` for `fs.readFileSync`

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '../compiled-templates/...')*

------
https://chatgpt.com/codex/tasks/task_e_685c023b4eb483259dceb6658d6a7a92