### PR TITLE
Fix scrollTop undefined warning

### DIFF
--- a/app/ts/renderer/options.ts
+++ b/app/ts/renderer/options.ts
@@ -406,7 +406,8 @@ $(document).ready(() => {
   const containerEl = $('#contents-container');
   containerEl.on('scroll', () => {
     if ($('#opMainContainer').hasClass('current')) {
-      backToTop.toggleClass('is-visible', containerEl.scrollTop() > 200);
+      const top = containerEl.scrollTop() ?? 0;
+      backToTop.toggleClass('is-visible', top > 200);
     } else {
       backToTop.removeClass('is-visible');
     }


### PR DESCRIPTION
## Summary
- handle undefined return from `scrollTop` when toggling back-to-top visibility

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685c173bf5fc8325b59f6c4d6ea0871d