### PR TITLE
Add compiled template typings

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -208,6 +208,7 @@ Whoisdigger uses a small build step before packaging. Each packaging command
 compiles the application into the `dist` folder and then invokes
 `@electron/packager`.
 Running `npm run build` automatically executes the `prebuild` script. `scripts/prebuild.js` installs dependencies using `npm install` if `node_modules` is missing.
+If you call `tsc` directly, run `npm run prebuild` beforehand to ensure templates are generated and dependencies exist.
 `scripts/postbuild.js` then bundles CSS using PostCSS by calling `npm run build:css`,
 which minifies files from `app/css` into `dist/app/css`.
 It also precompiles Handlebars templates and writes `dist/app/html/mainPanel.html`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,12 @@
     "skipLibCheck": true,
     "moduleDetection": "force",
     "types": ["node", "jest", "better-sqlite3"],
-    "typeRoots": ["./node_modules/@types", "./types", "./types/fontawesome-free.d.ts"],
+    "typeRoots": [
+      "./node_modules/@types",
+      "./types",
+      "./types/fontawesome-free.d.ts",
+      "./types/compiled-templates.d.ts"
+    ],
     "noImplicitAny": true,
     "strictNullChecks": true,
     "noImplicitThis": true

--- a/types/compiled-templates.d.ts
+++ b/types/compiled-templates.d.ts
@@ -1,0 +1,1 @@
+declare module 'app/compiled-templates/*.js';


### PR DESCRIPTION
## Summary
- add typings for precompiled Handlebars templates
- reference the new declarations from `tsconfig.json`
- mention running `npm run prebuild` before calling `tsc`

## Testing
- `npm run format -- --check` *(fails: Code style issues found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c290ac2d48325a96dd38b6e60991d