### PR TITLE
Add renderer options DOM interaction tests

### DIFF
--- a/test/rendererOptions.test.ts
+++ b/test/rendererOptions.test.ts
@@ -1,0 +1,79 @@
+/** @jest-environment jsdom */
+
+let jQuery: typeof import('jquery');
+let settingsModule: any;
+const invokeMock = jest.fn();
+
+jest.mock('electron', () => ({
+  ipcRenderer: { invoke: invokeMock },
+  shell: { openPath: jest.fn() }
+}));
+
+jest.mock('worker_threads', () => ({
+  Worker: jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+    postMessage: jest.fn(),
+    terminate: jest.fn()
+  }))
+}));
+
+const saveSettingsMock = jest.fn().mockResolvedValue('SAVED');
+
+jest.mock('../app/ts/common/settings', () => {
+  const actual = jest.requireActual('../app/ts/common/settings');
+  return { ...actual, saveSettings: saveSettingsMock };
+});
+
+beforeEach(() => {
+  jest.resetModules();
+  document.body.innerHTML = `
+    <div id="opEntry">
+      <div class="field">
+        <select id="appSettings.theme.darkMode">
+          <option value="true">true</option>
+          <option value="false">false</option>
+        </select>
+        <span class="result-icon"></span>
+      </div>
+    </div>
+    <button id="reloadApp"></button>
+    <table id="opTable"></table>
+    <input id="opSearch" />
+    <div id="opSearchNoResults"></div>
+  `;
+  invokeMock.mockClear();
+  saveSettingsMock.mockClear();
+});
+
+test('changing setting updates configuration', async () => {
+  jQuery = require('jquery');
+  (window as any).$ = (window as any).jQuery = jQuery;
+  settingsModule = require('../app/ts/common/settings');
+  require('../app/ts/renderer/options');
+  jQuery.ready();
+  const { settings } = settingsModule;
+
+
+  await new Promise((r) => setTimeout(r, 0));
+
+  jQuery('#appSettings\\.theme\\.darkMode').val('true').trigger('change');
+
+  await Promise.resolve();
+  expect(settings.theme.darkMode).toBe(true);
+  expect(saveSettingsMock).toHaveBeenCalled();
+});
+
+test('reloadApp invokes ipcRenderer', async () => {
+  jQuery = require('jquery');
+  (window as any).$ = (window as any).jQuery = jQuery;
+  require('../app/ts/renderer/options');
+  jQuery.ready();
+
+  await new Promise((r) => setTimeout(r, 0));
+
+  jQuery('#reloadApp').trigger('click');
+
+  await Promise.resolve();
+
+  expect(invokeMock).toHaveBeenCalledWith('app:reload');
+});


### PR DESCRIPTION
## Summary
- add rendererOptions.test.ts to verify toggling UI updates settings
- mock Electron IPC interactions and worker threads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c2923998c8325a0313aab2c98eadb