### PR TITLE
Fix default lookup to use WHOIS

### DIFF
--- a/app/ts/appsettings.ts
+++ b/app/ts/appsettings.ts
@@ -58,7 +58,7 @@ const appSettings = {
     },
     lookupGeneral: {
       // Whois lookup default values
-      type: 'dns', // Lookup type: 'whois' - regular whois request, 'dns' - dns record request (default: whois)
+      type: 'whois', // Lookup type: 'whois' - regular whois request, 'dns' - dns record request (default: whois)
       psl: true, // Enable Public Suffix List conversion, removes subdomains includes wildcards (default: true)
       server: '', // Default whois server
       verbose: false, // When true returns array of whois replies

--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -65,6 +65,9 @@ let { settings } = settingsModule;
 const defaultSettings: Settings = JSON.parse(JSON.stringify(settings));
 const defaultCustomConfiguration = settings.customConfiguration;
 export { settings };
+export function getSettings(): Settings {
+  return settings;
+}
 export let customSettingsLoaded = false;
 export default settings;
 

--- a/app/ts/main/bw/export.ts
+++ b/app/ts/main/bw/export.ts
@@ -9,7 +9,7 @@ import { formatString } from '../../common/stringformat';
 
 const { app, BrowserWindow, Menu, ipcMain, dialog, remote } = electron;
 
-import { settings } from '../../common/settings';
+import { getSettings } from '../../common/settings';
 
 /*
   ipcMain.on('bw:export', function(...) {...});
@@ -20,7 +20,7 @@ import { settings } from '../../common/settings';
     options (object) - bulk whois export options object
  */
 ipcMain.handle('bw:export', async function (event, results, options) {
-  const { lookupExport: resExports } = settings;
+  const { lookupExport: resExports } = getSettings();
 
   const { sender } = event;
 

--- a/app/ts/main/bw/fileinput.ts
+++ b/app/ts/main/bw/fileinput.ts
@@ -5,7 +5,7 @@ const debug = debugModule('main.bw.fileinput');
 const { app, BrowserWindow, Menu, ipcMain, dialog } = electron;
 import { formatString } from '../../common/stringformat';
 
-import { settings } from '../../common/settings';
+import { getSettings } from '../../common/settings';
 
 /*
   ipcMain.on('bw:input.file', function(...) {...});
@@ -35,7 +35,7 @@ ipcMain.on('bw:input.file', function (event) {
     filePath (string) - dropped file path
  */
 ipcMain.on('ondragstart', function (event, filePath) {
-  const { appWindow } = settings;
+  const { appWindow } = getSettings();
 
   const { sender } = event;
 

--- a/app/ts/main/bw/process.ts
+++ b/app/ts/main/bw/process.ts
@@ -10,7 +10,7 @@ import { processDomain, counter } from './scheduler';
 import { resetObject } from '../../common/resetObject';
 import { resetUiCounters } from './auxiliary';
 
-import { settings } from '../../common/settings';
+import { getSettings } from '../../common/settings';
 
 const { app, BrowserWindow, Menu, ipcMain, dialog, remote } = electron;
 import { formatString } from '../../common/stringformat';
@@ -30,6 +30,8 @@ ipcMain.on('bw:lookup', function (event: IpcMainEvent, domains: string[], tlds: 
   resetUiCounters(event); // Reset UI counters, pass window param
   bulkWhois = resetObject(defaultBulkWhois); // Resets the bulkWhois object to default
   reqtime = [];
+
+  const settings = getSettings();
 
   // bulkWhois section
   const { results, input, stats, processingIDs } = bulkWhois;
@@ -138,6 +140,8 @@ ipcMain.on('bw:lookup.pause', function (event: IpcMainEvent) {
  */
 ipcMain.on('bw:lookup.continue', function (event: IpcMainEvent) {
   debug('Continuing bulk whois requests');
+
+  const settings = getSettings();
 
   // Go through the remaining domains and queue them again using setTimeouts
   let follow, timeout, timebetween;

--- a/app/ts/main/bw/resultHandler.ts
+++ b/app/ts/main/bw/resultHandler.ts
@@ -2,7 +2,7 @@ import debugModule from 'debug';
 import { isDomainAvailable, getDomainParameters } from '../../common/availability';
 import { toJSON } from '../../common/parser';
 import { performance } from 'perf_hooks';
-import { settings } from '../../common/settings';
+import { getSettings } from '../../common/settings';
 import { formatString } from '../../common/stringformat';
 import type { BulkWhois, ProcessedResult } from './types';
 import * as dns from '../../common/dnsLookup';
@@ -27,6 +27,7 @@ export async function processData(
   let domainAvailable: string;
   let lastStatus: string | undefined;
   let resultsJSON: Record<string, unknown> | string;
+  const settings = getSettings();
   reqtime[index] = parseFloat((performance.now() - reqtime[index]).toFixed(2));
 
   if (reqtimes.minimum > reqtime[index]) {

--- a/app/ts/main/bw/scheduler.ts
+++ b/app/ts/main/bw/scheduler.ts
@@ -5,7 +5,7 @@ import * as dns from '../../common/dnsLookup';
 import { Result, DnsLookupError } from '../../common/errors';
 import { formatString } from '../../common/stringformat';
 import { msToHumanTime } from '../../common/conversions';
-import { settings } from '../../common/settings';
+import { getSettings } from '../../common/settings';
 import type { BulkWhois, DomainSetup } from './types';
 import { processData } from './resultHandler';
 import type { IpcMainEvent } from 'electron';
@@ -32,6 +32,7 @@ export function processDomain(
 
   processingIDs[domainSetup.index!] = setTimeout(async () => {
     let data: any;
+    const settings = getSettings();
     stats.domains.sent++;
     sender.send('bw:status.update', 'domains.sent', stats.domains.sent);
     stats.domains.waiting++;


### PR DESCRIPTION
## Summary
- use `whois` mode by default for bulk lookups
- ensure bulk WHOIS always reads the latest settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c2c66b8fc83258b698483ccee3fdc