### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:20-bullseye
+
+# Install build dependencies for native modules
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm ci --legacy-peer-deps
+
+COPY . .
+
+RUN npm run build && npm run postbuild
+
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  app:
+    build: .
+    volumes:
+      - .:/usr/src/app
+      - /tmp/.X11-unix:/tmp/.X11-unix
+    environment:
+      - DISPLAY=${DISPLAY}
+    command: npm start

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ If you clone this repo please patch `node_modules\whois\index.js` and remove the
 - [Setup](#setup)
 - [Development setup](#development-setup)
 - [Building](#building)
+- [Docker](#docker)
 - [Built with](#built-with)
 - [License](#license)
 
@@ -236,6 +237,35 @@ For convenience a single command builds packages for all platforms:
 
 ```
 npm run package-all
+```
+
+## Docker
+
+Build the Docker image:
+
+```bash
+docker build -t whoisdigger .
+```
+
+Run the application (requires X11 forwarding to display Electron):
+
+```bash
+docker run --rm -it \
+  -e DISPLAY=$DISPLAY \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
+  whoisdigger
+```
+
+Alternatively, start with docker-compose:
+
+```bash
+docker-compose up
+```
+
+Execute the test suite inside a container:
+
+```bash
+docker run --rm -it whoisdigger npm test
 ```
 
 ## Built with


### PR DESCRIPTION
## Summary
- add Dockerfile with Node-based setup and build
- provide docker-compose config
- document Docker usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c3165d3d08325a678954a028fea80