### PR TITLE
Add exit confirmation modal

### DIFF
--- a/app/ts/appsettings.ts
+++ b/app/ts/appsettings.ts
@@ -155,7 +155,8 @@ const appSettings = {
     },
     ui: {
       // User interface options
-      liveReload: true // Reload settings on change (default: true)
+      liveReload: true, // Reload settings on change (default: true)
+      confirmExit: true // Ask for confirmation before exiting the application
     },
     lookupMisc: {
       // Lookup miscellaneous configurations
@@ -258,6 +259,7 @@ export const appSettingsDescriptions: Record<string, string> = {
   'performanceBulkRequest.averages': 'Bulk lookup averages',
   'performanceBulkRequest.stopwatch': 'Bulk lookup stopwatch',
   'ui.liveReload': 'Reload configuration automatically',
+  'ui.confirmExit': 'Confirm before exiting the application',
   'lookupMisc.useStandardSize': 'Use metric units for file sizes',
   'lookupMisc.asfOverride': 'Override average smoothing factor',
   'lookupMisc.averageSmoothingFactor': 'Average smoothing factor',

--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -53,7 +53,7 @@ export interface Settings {
   };
   customConfiguration: { filepath: string; load: boolean; save: boolean };
   theme: { darkMode: boolean };
-  ui: { liveReload: boolean };
+  ui: { liveReload: boolean; confirmExit: boolean };
   [key: string]: any;
 }
 

--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -69,6 +69,7 @@ import './main/index';
 
 let settings: MainSettings;
 let mainWindow: BrowserWindow;
+let exitConfirmed = false;
 
 /*
   app.on('ready', function() {...}
@@ -143,6 +144,14 @@ app.on('ready', async function () {
     return;
   });
 
+  mainWindow.on('close', function (event) {
+    const { ui } = settings;
+    if (ui.confirmExit && !exitConfirmed) {
+      event.preventDefault();
+      mainWindow.webContents.send('app:confirm-exit');
+    }
+  });
+
   /*
     mainWindow.on('closed', function() {...});
       Quit application when main window is closed
@@ -205,6 +214,11 @@ ipcMain.handle('app:close', function () {
   if (appWindow.closable) {
     mainWindow.close();
   }
+});
+
+ipcMain.on('app:exit-confirmed', function () {
+  exitConfirmed = true;
+  mainWindow.close();
 });
 
 /*

--- a/app/ts/renderer/navigation.ts
+++ b/app/ts/renderer/navigation.ts
@@ -2,6 +2,7 @@ import { ipcRenderer } from 'electron';
 import { formatString } from '../common/stringformat';
 import $ from 'jquery';
 import { populateInputs } from './options';
+import { settings } from '../common/settings';
 
 /*
   $(document).on('drop', function(...) {...});
@@ -81,6 +82,10 @@ $(document).on('click', '.delete', function () {
 $(document).keyup(function (event) {
   if (event.keyCode === 27) {
     ipcRenderer.send('app:debug', formatString('Hotkey, Used [ESC] key, {0}', event.keyCode));
+    if ($('#appModalExit').hasClass('is-active')) {
+      $('#appModalExitButtonNo').click();
+      return;
+    }
     switch (true) {
       // Single whois tab is active
       case $('#navButtonSinglewhois').hasClass('is-active'):
@@ -152,9 +157,32 @@ $(document).on('click', '#navButtonMinimize', function () {
  */
 $(document).on('click', '#navButtonExit', function () {
   ipcRenderer.send('app:debug', '#navButtonExit was clicked');
-  void ipcRenderer.invoke('app:close');
+  if (settings.ui?.confirmExit) {
+    $('#appModalExit').addClass('is-active');
+  } else {
+    void ipcRenderer.invoke('app:close');
+  }
 
   return;
+});
+
+$(document).on('click', '#appModalExitButtonYes', function () {
+  ipcRenderer.send('app:debug', '#appModalExitButtonYes was clicked');
+  $('#appModalExit').removeClass('is-active');
+  ipcRenderer.send('app:exit-confirmed');
+});
+
+$(document).on('click', '#appModalExitButtonNo, #appModalExit .delete', function () {
+  ipcRenderer.send('app:debug', '#appModalExitButtonNo was clicked');
+  $('#appModalExit').removeClass('is-active');
+});
+
+ipcRenderer.on('app:confirm-exit', function () {
+  if (settings.ui?.confirmExit) {
+    $('#appModalExit').addClass('is-active');
+  } else {
+    void ipcRenderer.invoke('app:close');
+  }
 });
 
 /*


### PR DESCRIPTION
## Summary
- add `ui.confirmExit` setting and description
- extend settings interface for confirmExit
- hook up exit confirmation modal to main and renderer logic

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c37921b3c8325b6097bcc440077f5