### PR TITLE
Add go to bottom button in settings

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -205,3 +205,16 @@ html[data-theme='dark'] #toTable .button {
 #opBackToTop.is-visible {
   display: inline-flex;
 }
+
+/* Go to bottom button */
+#opGoToBottom {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 4rem;
+  display: none;
+  z-index: 900;
+}
+
+#opGoToBottom.is-visible {
+  display: inline-flex;
+}

--- a/app/html/templates/opEntry.hbs
+++ b/app/html/templates/opEntry.hbs
@@ -74,3 +74,8 @@
     <i class='fas fa-arrow-up'></i>
   </span>
 </button>
+<button id='opGoToBottom' class='button is-info is-small go-to-bottom'>
+  <span class='icon is-small'>
+    <i class='fas fa-arrow-down'></i>
+  </span>
+</button>

--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -52,13 +52,8 @@ export interface Settings {
     ttl: number;
   };
   customConfiguration: { filepath: string; load: boolean; save: boolean };
-<<<<<<< codex/add-theme-follow-system-preference-option
   theme: { darkMode: boolean; followSystem: boolean };
-  ui: { liveReload: boolean };
-=======
-  theme: { darkMode: boolean };
   ui: { liveReload: boolean; confirmExit: boolean };
->>>>>>> master
   [key: string]: any;
 }
 

--- a/app/ts/renderer/options.ts
+++ b/app/ts/renderer/options.ts
@@ -403,17 +403,24 @@ $(document).ready(() => {
   });
 
   const backToTop = $('#opBackToTop');
+  const goToBottom = $('#opGoToBottom');
   const containerEl = $('#contents-container');
   containerEl.on('scroll', () => {
     if ($('#opMainContainer').hasClass('current')) {
       const top = containerEl.scrollTop() ?? 0;
+      const bottom = containerEl[0].scrollHeight - containerEl.innerHeight() - top;
       backToTop.toggleClass('is-visible', top > 200);
+      goToBottom.toggleClass('is-visible', bottom > 200);
     } else {
       backToTop.removeClass('is-visible');
+      goToBottom.removeClass('is-visible');
     }
   });
   backToTop.on('click', () => {
     containerEl.animate({ scrollTop: 0 }, 300);
+  });
+  goToBottom.on('click', () => {
+    containerEl.animate({ scrollTop: containerEl[0].scrollHeight }, 300);
   });
 });
 


### PR DESCRIPTION
## Summary
- add a floating **Go to Bottom** button in the Settings page
- show or hide the button while scrolling
- enable scrolling to the bottom on click
- keep settings type definitions in sync

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c3d398a888325a99167792d7dbb28