### PR TITLE
Improve proxy validation

### DIFF
--- a/app/ts/common/proxy.ts
+++ b/app/ts/common/proxy.ts
@@ -1,4 +1,5 @@
 import { settings } from './settings';
+import { isIP } from 'net';
 
 export interface ProxyInfo {
   ipaddress: string;
@@ -49,7 +50,14 @@ export function getProxy(): ProxyInfo | undefined {
   }
 
   const [ip, port] = entry.split(':');
-  const portNum = parseInt(port ?? '0', 10);
-  if (!ip || !portNum) return undefined;
+  const portNum = parseInt(port ?? '', 10);
+
+  if (!ip || isIP(ip) === 0) {
+    return undefined;
+  }
+  if (!port || Number.isNaN(portNum) || portNum < 1 || portNum > 65535) {
+    return undefined;
+  }
+
   return { ipaddress: ip, port: portNum, type: 5 };
 }

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -63,4 +63,20 @@ describe('proxy helper', () => {
     expect(third).toEqual({ ipaddress: '1.1.1.1', port: 8080, type: 5 });
     expect(fourth).toEqual({ ipaddress: '3.3.3.3', port: 8080, type: 5 });
   });
+
+  test('returns undefined for invalid ip address', () => {
+    settings.lookupProxy.enable = true;
+    settings.lookupProxy.mode = 'single';
+    settings.lookupProxy.single = 'invalid_ip:8080';
+    expect(getProxy()).toBeUndefined();
+  });
+
+  test('returns undefined for invalid port', () => {
+    settings.lookupProxy.enable = true;
+    settings.lookupProxy.mode = 'single';
+    settings.lookupProxy.single = '1.2.3.4:70000';
+    expect(getProxy()).toBeUndefined();
+    settings.lookupProxy.single = '1.2.3.4:0';
+    expect(getProxy()).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- validate proxy IP addresses and ports
- test invalid proxy IPs and ports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c4cdebd4c8325b7a2df8de7c1cc70