### PR TITLE
Use async fs methods in file watchers

### DIFF
--- a/app/ts/renderer/bw/fileinput.ts
+++ b/app/ts/renderer/bw/fileinput.ts
@@ -23,10 +23,10 @@ async function refreshBwFile(pathToFile: string): Promise<void> {
         timeBetween: settings.lookupRandomizeTimeBetween
       }
     };
-    const bwFileStats = fs.statSync(pathToFile) as FileStats;
+    const bwFileStats = (await fs.promises.stat(pathToFile)) as FileStats;
     bwFileStats.filename = path.basename(pathToFile);
     bwFileStats.humansize = conversions.byteToHumanFileSize(bwFileStats.size, misc.useStandardSize);
-    bwFileContents = fs.readFileSync(pathToFile) as unknown as Buffer;
+    bwFileContents = await fs.promises.readFile(pathToFile);
     bwFileStats.linecount = bwFileContents.toString().split('\n').length;
 
     if (lookup.randomize.timeBetween.randomize === true) {

--- a/test/fileWatcher.test.ts
+++ b/test/fileWatcher.test.ts
@@ -86,11 +86,14 @@ test('bw watcher updates table on change', async () => {
     expect.any(Function)
   );
 
+  const beforeStat = statMock.mock.calls.length;
+  const beforeRead = readFileMock.mock.calls.length;
+
   watchEmitter.emit('change', 'change');
   for (let i = 0; i < 5; i++) await new Promise((res) => setTimeout(res, 0));
 
-  expect(statSyncMock).toHaveBeenCalled();
-  expect(readFileSyncMock).toHaveBeenCalled();
+  expect(statMock.mock.calls.length).toBeGreaterThan(beforeStat);
+  expect(readFileMock.mock.calls.length).toBeGreaterThan(beforeRead);
 });
 
 test('bwa watcher updates table on change', async () => {
@@ -130,9 +133,12 @@ test('bwa watcher updates table on change', async () => {
     expect.any(Function)
   );
 
+  const beforeStat = statMock.mock.calls.length;
+  const beforeRead = readFileMock.mock.calls.length;
+
   watchEmitter.emit('change', 'change');
   for (let i = 0; i < 5; i++) await new Promise((res) => setTimeout(res, 0));
 
-  expect(statSyncMock).toHaveBeenCalled();
-  expect(readFileSyncMock).toHaveBeenCalled();
+  expect(statMock.mock.calls.length).toBeGreaterThan(beforeStat);
+  expect(readFileMock.mock.calls.length).toBeGreaterThan(beforeRead);
 });


### PR DESCRIPTION
## Summary
- use `fs.promises.stat` and `fs.promises.readFile` inside renderer file watchers
- update BWA watcher callback
- adjust watcher tests for new async behaviour

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c5d5bb9948325aa632ff1aa8c1f9c