### PR TITLE
Add E2E navigation tests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -129,6 +129,11 @@ jobs:
         run: npm run build
       - name: Run e2e tests
         run: xvfb-run -a npm run test:e2e
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-artifacts-${{ matrix.node-version }}
+          path: test/e2e/artifacts
 
   package:
     needs: e2e

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ settings.json
 reload.json
 .DS_Store
 app/compiled-templates/
+test/e2e/artifacts/


### PR DESCRIPTION
## Summary
- extend WebdriverIO test to check tabs, bulk lookup, and dark mode persistence
- collect screenshots from E2E run in CI
- ignore saved E2E artifacts
- create a unique Chrome profile for each E2E run

## Testing
- `npm test`
- `node test/e2e/run.js` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_685c60c27988832593c930ac0528b87c