### PR TITLE
Add generateFilename test

### DIFF
--- a/app/ts/main/bw/export.ts
+++ b/app/ts/main/bw/export.ts
@@ -11,7 +11,7 @@ const { app, BrowserWindow, Menu, ipcMain, dialog, remote, shell } = electron;
 
 import { getSettings } from '../../common/settings';
 
-function generateFilename(ext: string): string {
+export function generateFilename(ext: string): string {
   function pad(n: number): string {
     return String(n).padStart(2, '0');
   }

--- a/test/generateFilename.test.ts
+++ b/test/generateFilename.test.ts
@@ -1,0 +1,32 @@
+import './electronMainMock';
+import { generateFilename } from '../app/ts/main/bw/export';
+
+describe('generateFilename', () => {
+  const RealDate = Date;
+  const RealRandom = Math.random;
+
+  beforeAll(() => {
+    class MockDate extends RealDate {
+      constructor() {
+        super('2021-01-02T03:04:05Z');
+      }
+      static now() {
+        return new RealDate('2021-01-02T03:04:05Z').getTime();
+      }
+    }
+    // @ts-ignore
+    global.Date = MockDate as DateConstructor;
+    Math.random = () => 0.1;
+  });
+
+  afterAll(() => {
+    // @ts-ignore
+    global.Date = RealDate;
+    Math.random = RealRandom;
+  });
+
+  test('returns deterministic filename with given extension', () => {
+    const result = generateFilename('.csv');
+    expect(result).toBe('bulkwhois-export-20210102030405-199999.csv');
+  });
+});


### PR DESCRIPTION
## Summary
- export `generateFilename` helper
- test filename creation with mocked Date and Math.random

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm format`

------
https://chatgpt.com/codex/tasks/task_e_685ccb4928ec8325bac3be1c38c0391f