### PR TITLE
feat: implement tools module

### DIFF
--- a/app/ts/common/tools.ts
+++ b/app/ts/common/tools.ts
@@ -1,0 +1,49 @@
+import * as WordlistTools from './wordlist';
+
+export interface ProcessOptions {
+  prefix?: string;
+  suffix?: string;
+  affix?: { prefix: string; suffix: string };
+  sort?: 'asc' | 'desc' | 'random';
+  trimSpaces?: boolean;
+  deleteBlankLines?: boolean;
+  dedupe?: boolean;
+}
+
+/*
+  processLines
+    Apply wordlist tool operations sequentially
+  parameters
+    lines (array) - lines to process
+    options (object) - processing options
+*/
+export function processLines(lines: string[], options: ProcessOptions): string[] {
+  let result = [...lines];
+
+  if (options.prefix) result = WordlistTools.addPrefix(result, options.prefix);
+  if (options.suffix) result = WordlistTools.addSuffix(result, options.suffix);
+  if (options.affix)
+    result = WordlistTools.addAffix(
+      result,
+      options.affix.prefix,
+      options.affix.suffix
+    );
+
+  if (options.trimSpaces) result = WordlistTools.trimSpaces(result);
+  if (options.deleteBlankLines) result = WordlistTools.deleteBlankLines(result);
+  if (options.dedupe) result = WordlistTools.dedupeLines(result);
+
+  switch (options.sort) {
+    case 'asc':
+      result = WordlistTools.sortLines(result);
+      break;
+    case 'desc':
+      result = WordlistTools.sortLinesReverse(result);
+      break;
+    case 'random':
+      result = WordlistTools.shuffleLines(result);
+      break;
+  }
+
+  return result;
+}

--- a/app/ts/main/index.ts
+++ b/app/ts/main/index.ts
@@ -1,3 +1,4 @@
 import './singlewhois';
 import './bw';
 import './bwa';
+import './to';

--- a/app/ts/main/to.ts
+++ b/app/ts/main/to.ts
@@ -1,0 +1,49 @@
+import electron from 'electron';
+import fs from 'fs';
+import debugModule from 'debug';
+import { processLines, ProcessOptions } from '../common/tools';
+
+const { ipcMain, dialog } = electron;
+const debug = debugModule('main.to');
+
+/*
+  ipcMain.on('to:input.file', function(event) {...});
+    Wordlist tools input file selection
+  parameters
+    event (object) - renderer object
+*/
+ipcMain.on('to:input.file', function (event) {
+  debug('Waiting for tools file selection');
+  const filePath = dialog.showOpenDialogSync({
+    title: 'Select wordlist file',
+    buttonLabel: 'Open',
+    properties: ['openFile', 'showHiddenFiles']
+  });
+  const { sender } = event;
+  debug(`Using selected file at ${filePath}`);
+  sender.send('to:fileinput.confirmation', filePath);
+});
+
+/*
+  ipcMain.handle('to:process', async function(event, filePath, options) {...});
+    Apply wordlist tools to selected file
+  parameters
+    event (object) - renderer object
+    filePath (string) - path to wordlist file
+    options (object) - processing options
+*/
+ipcMain.handle(
+  'to:process',
+  async function (event, filePath: string, options: ProcessOptions) {
+    const { sender } = event;
+    try {
+      const contents = await fs.promises.readFile(filePath, 'utf8');
+      const lines = contents.split(/\r?\n/);
+      const processed = processLines(lines, options);
+      sender.send('to:process.result', processed.join('\n'));
+    } catch (err) {
+      debug(`Processing error: ${err}`);
+      sender.send('to:process.error', (err as Error).message);
+    }
+  }
+);

--- a/app/ts/renderer/index.ts
+++ b/app/ts/renderer/index.ts
@@ -3,3 +3,4 @@ import './bw';
 import './bwa';
 import './darkmode';
 import './options';
+import './to';

--- a/app/ts/renderer/to.ts
+++ b/app/ts/renderer/to.ts
@@ -1,0 +1,59 @@
+import { ipcRenderer } from 'electron';
+import $ from 'jquery';
+
+let filePath: string | null = null;
+
+/*
+  ipcRenderer.on('to:fileinput.confirmation', function(event, path) {...});
+    Confirm selected file for tools module
+*/
+ipcRenderer.on('to:fileinput.confirmation', function (event, path) {
+  filePath = Array.isArray(path) ? path[0] : path;
+  $('#toFileSelected').text(filePath ?? '');
+});
+
+/*
+  $('#toButtonSelect').click(function() {...});
+    Open file selection dialog
+*/
+$(document).on('click', '#toButtonSelect', function () {
+  ipcRenderer.send('to:input.file');
+});
+
+/*
+  $('#toButtonProcess').click(function() {...});
+    Start processing with selected options
+*/
+$(document).on('click', '#toButtonProcess', async function () {
+  if (!filePath) return;
+  const options = collectOptions();
+  try {
+    await ipcRenderer.invoke('to:process', filePath, options);
+  } catch (e) {
+    ipcRenderer.send('app:error', `Processing failed: ${e}`);
+  }
+});
+
+/*
+  ipcRenderer.on('to:process.result', function(event, result) {...});
+    Display processed output
+*/
+ipcRenderer.on('to:process.result', function (event, result: string) {
+  $('#toOutput').text(result);
+});
+
+function collectOptions() {
+  const opts: any = {};
+  const prefix = $('#toPrefix').val() as string;
+  const suffix = $('#toSuffix').val() as string;
+  if (prefix) opts.prefix = prefix;
+  if (suffix) opts.suffix = suffix;
+  if ($('#toTrimSpaces').is(':checked')) opts.trimSpaces = true;
+  if ($('#toDeleteBlank').is(':checked')) opts.deleteBlankLines = true;
+  if ($('#toDedupe').is(':checked')) opts.dedupe = true;
+  const sortVal = $('input[name=toSort]:checked').val();
+  if (sortVal === 'asc' || sortVal === 'desc' || sortVal === 'random') {
+    opts.sort = sortVal;
+  }
+  return opts;
+}

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -1,0 +1,15 @@
+import { processLines } from '../app/ts/common/tools';
+
+describe('processLines', () => {
+  test('applies prefix, suffix and dedupe', () => {
+    const opts = { prefix: 'pre-', suffix: '-suf', dedupe: true };
+    const result = processLines(['a', 'a', 'b'], opts);
+    expect(result).toEqual(['pre-a-suf', 'pre-b-suf']);
+  });
+
+  test('sorts and trims spaces', () => {
+    const opts = { sort: 'asc', trimSpaces: true };
+    const result = processLines([' c', 'b', 'a '], opts);
+    expect(result).toEqual(['a', 'b', 'c']);
+  });
+});


### PR DESCRIPTION
## Summary
- add new wordlist tools module for processing lines
- wire wordlist tools with IPC handlers on main and renderer
- expose tools entrypoints in index files
- cover tools processing logic with tests

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685cccae6dfc83258fbb613f5bb1bb60