### PR TITLE
feat: add preload and context isolation

### DIFF
--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -115,7 +115,8 @@ app.on('ready', async function () {
       experimentalFeatures: webPreferences.experimentalFeatures, // Enable Chromium experimental features
       backgroundThrottling: webPreferences.backgroundThrottling, // Whether to throttle animations and timers when the page becomes background
       offscreen: webPreferences.offscreen, // enable offscreen rendering for the browser window
-      spellcheck: webPreferences.spellcheck // Enable builtin spellchecker
+      spellcheck: webPreferences.spellcheck, // Enable builtin spellchecker
+      preload: path.join(__dirname, 'preload.js')
     }
   });
 

--- a/app/ts/preload.ts
+++ b/app/ts/preload.ts
@@ -1,0 +1,10 @@
+import { contextBridge, ipcRenderer, shell } from 'electron';
+
+contextBridge.exposeInMainWorld('electron', {
+  send: (channel: string, ...args: unknown[]) => ipcRenderer.send(channel, ...args),
+  invoke: (channel: string, ...args: unknown[]) => ipcRenderer.invoke(channel, ...args),
+  on: (channel: string, listener: (...args: unknown[]) => void) => {
+    ipcRenderer.on(channel, (_event, ...args) => listener(...args));
+  },
+  openPath: (path: string) => shell.openPath(path)
+});

--- a/app/ts/renderer.ts
+++ b/app/ts/renderer.ts
@@ -1,11 +1,15 @@
 // Base path --> assets/html
-import { ipcRenderer, dialog } from 'electron';
-import type { IpcRendererEvent } from 'electron';
 import $ from 'jquery';
 
 import './renderer/index';
 import { loadSettings, settings, customSettingsLoaded } from './common/settings';
 import { formatString } from './common/stringformat';
+
+const electron = (window as any).electron as {
+  send: (channel: string, ...args: any[]) => void;
+  invoke: (channel: string, ...args: any[]) => Promise<any>;
+  on: (channel: string, listener: (...args: any[]) => void) => void;
+};
 
 (window as any).$ = $;
 (window as any).jQuery = $;
@@ -22,12 +26,12 @@ interface ErrorMessage {
 
 function sendDebug(message: string): void {
   const payload: DebugMessage = { channel: 'app:debug', message };
-  ipcRenderer.send(payload.channel, payload.message);
+  electron.send(payload.channel, payload.message);
 }
 
 function sendError(message: string): void {
   const payload: ErrorMessage = { channel: 'app:error', message };
-  ipcRenderer.send(payload.channel, payload.message);
+  electron.send(payload.channel, payload.message);
 }
 
 /*

--- a/app/ts/renderer/bw/export.ts
+++ b/app/ts/renderer/bw/export.ts
@@ -2,7 +2,11 @@ import * as conversions from '../../common/conversions';
 import defaultExportOptions from './export.defaults';
 import $ from 'jquery';
 
-import { ipcRenderer } from 'electron';
+const electron = (window as any).electron as {
+  send: (channel: string, ...args: any[]) => void;
+  invoke: (channel: string, ...args: any[]) => Promise<any>;
+  on: (channel: string, listener: (...args: any[]) => void) => void;
+};
 import { resetObject } from '../../common/resetObject';
 import { getExportOptions, setExportOptions, setExportOptionsEx } from './auxiliary';
 
@@ -12,14 +16,14 @@ let results: any;
 let options: any;
 
 /*
-  ipcRenderer.on('bw:result.receive', function(...) {...});
+  electron.on('bw:result.receive', function(...) {...});
     ipsum
   parameters
     event
     rcvResults
  */
-ipcRenderer.on('bw:result.receive', function (event, rcvResults) {
-  ipcRenderer.send('app:debug', formatString('Results are ready for export {0}', rcvResults));
+electron.on('bw:result.receive', function (event, rcvResults) {
+  electron.send('app:debug', formatString('Results are ready for export {0}', rcvResults));
 
   results = rcvResults;
 
@@ -27,10 +31,10 @@ ipcRenderer.on('bw:result.receive', function (event, rcvResults) {
 });
 
 /*
-  ipcRenderer.on('bw:export.cancel', function() {...});
+  electron.on('bw:export.cancel', function() {...});
     Bulk whois export cancel
  */
-ipcRenderer.on('bw:export.cancel', function () {
+electron.on('bw:export.cancel', function () {
   $('#bwExportloading').addClass('is-hidden');
   $('#bwEntry').removeClass('is-hidden');
 
@@ -46,7 +50,7 @@ $(document).on('click', '#bwExportButtonExport', async function () {
   options = getExportOptions();
   $.when($('#bwExportloading').removeClass('is-hidden').delay(10)).done(async function () {
     try {
-      await ipcRenderer.invoke('bw:export', results, options);
+      await electron.invoke('bw:export', results, options);
     } catch (err) {
       $('#bwExportErrorText').text((err as Error).message);
       $('#bwExportMessageError').removeClass('is-hidden');

--- a/app/ts/renderer/bw/process.ts
+++ b/app/ts/renderer/bw/process.ts
@@ -2,16 +2,20 @@ import * as conversions from '../../common/conversions';
 import parseRawData from '../../common/parser';
 const base = 10;
 
-import { ipcRenderer } from 'electron';
+const electron = (window as any).electron as {
+  send: (channel: string, ...args: any[]) => void;
+  invoke: (channel: string, ...args: any[]) => Promise<any>;
+  on: (channel: string, listener: (...args: any[]) => void) => void;
+};
 import $ from 'jquery';
 
 import { formatString } from '../../common/stringformat';
 
 /*
 // Receive whois lookup reply
-ipcRenderer.on('bulkwhois:results', function(event, domain, domainResults) {
+electron.on('bulkwhois:results', function(event, domain, domainResults) {
 
-  //ipcRenderer.send('app:debug', "Whois domain reply for {0}:\n {1}".format(domain, domainResults));
+  //electron.send('app:debug', "Whois domain reply for {0}:\n {1}".format(domain, domainResults));
 
 
   (function() {
@@ -33,21 +37,21 @@ ipcRenderer.on('bulkwhois:results', function(event, domain, domainResults) {
 
 /*
 // Receive bulk whois results
-ipcRenderer.on('bulkwhois:resultreceive', function(event, results) {
+electron.on('bulkwhois:resultreceive', function(event, results) {
 
 });
 */
 
 /*
-  ipcRenderer.on('bw:status.update', function(...) {...});
+  electron.on('bw:status.update', function(...) {...});
     Bulk whois processing, ui status update
   parameters
     event
     stat
     value
  */
-ipcRenderer.on('bw:status.update', function (event, stat, value) {
-  ipcRenderer.send('app:debug', formatString('{0}, value update to {1}', stat, value)); // status update
+electron.on('bw:status.update', function (event, stat, value) {
+  electron.send('app:debug', formatString('{0}, value update to {1}', stat, value)); // status update
   let percent;
   switch (stat) {
     case 'start':
@@ -150,13 +154,13 @@ $(document).on('click', '#bwProcessingButtonPause', function () {
   switch (searchStatus) {
     case 'Continue':
       setPauseButton();
-      ipcRenderer.send('bw:lookup.continue');
+      electron.send('bw:lookup.continue');
       break;
     case 'Pause':
       $('#bwProcessingButtonPause').removeClass('is-warning').addClass('is-success');
       $('#bwProcessingButtonPauseicon').removeClass('fa-pause').addClass('fa-play');
       $('#bwProcessingButtonPauseSpanText').text('Continue');
-      ipcRenderer.send('bw:lookup.pause');
+      electron.send('bw:lookup.pause');
       break;
     default:
       break;
@@ -182,7 +186,7 @@ function setPauseButton() {
     Trigger Bulk whois Stop modal
  */
 $(document).on('click', '#bwProcessingButtonStop', function () {
-  ipcRenderer.send('app:debug', 'Pausing whois & opening stop modal');
+  electron.send('app:debug', 'Pausing whois & opening stop modal');
   $('#bwProcessingButtonPause').text().includes('Pause')
     ? $('#bwProcessingButtonPause').click()
     : false;
@@ -196,7 +200,7 @@ $(document).on('click', '#bwProcessingButtonStop', function () {
     Close modal and allow continue
  */
 $(document).on('click', '#bwProcessingModalStopButtonContinue', function () {
-  ipcRenderer.send('app:debug', 'Closing Stop modal & continue');
+  electron.send('app:debug', 'Closing Stop modal & continue');
   $('#bwProcessingModalStop').removeClass('is-active');
 
   return;
@@ -207,7 +211,7 @@ $(document).on('click', '#bwProcessingModalStopButtonContinue', function () {
     Stop bulk whois entirely and scrape everything
  */
 $(document).on('click', '#bwProcessingModalStopButtonStop', function () {
-  ipcRenderer.send('app:debug', 'Closing Stop modal & going back to start');
+  electron.send('app:debug', 'Closing Stop modal & going back to start');
   $('#bwProcessingModalStop').removeClass('is-active');
   $('#bwProcessing').addClass('is-hidden');
   setPauseButton();
@@ -221,8 +225,8 @@ $(document).on('click', '#bwProcessingModalStopButtonStop', function () {
     Stop bulk whois entirely and save/export
  */
 $(document).on('click', '#bwProcessingModalStopButtonStopsave', function () {
-  ipcRenderer.send('app:debug', 'Closing Stop modal & exporting');
-  ipcRenderer.send('bw:lookup.stop');
+  electron.send('app:debug', 'Closing Stop modal & exporting');
+  electron.send('bw:lookup.stop');
   $('#bwProcessingModalStop').removeClass('is-active');
   $('#bwProcessing').addClass('is-hidden');
   setPauseButton();

--- a/app/ts/renderer/bw/wordlistinput.ts
+++ b/app/ts/renderer/bw/wordlistinput.ts
@@ -1,7 +1,11 @@
 import * as conversions from '../../common/conversions';
 import { settings } from '../../common/settings';
 
-import { ipcRenderer } from 'electron';
+const electron = (window as any).electron as {
+  send: (channel: string, ...args: any[]) => void;
+  invoke: (channel: string, ...args: any[]) => Promise<any>;
+  on: (channel: string, listener: (...args: any[]) => void) => void;
+};
 import { tableReset } from './auxiliary';
 import $ from 'jquery';
 
@@ -10,10 +14,10 @@ import { formatString } from '../../common/stringformat';
 let bwWordlistContents = ''; // Global wordlist input contents
 
 /*
-  ipcRenderer.on('bw:wordlistinput.confirmation', function() {...});
+  electron.on('bw:wordlistinput.confirmation', function() {...});
     Wordlist input, contents confirmation container
  */
-ipcRenderer.on('bw:wordlistinput.confirmation', function () {
+electron.on('bw:wordlistinput.confirmation', function () {
   const bwFileStats: Record<string, any> = {};
 
   bwWordlistContents = String($('#bwWordlistTextareaDomains').val() ?? '');
@@ -90,7 +94,7 @@ $(document).on('click', '#bwWordlistinputButtonCancel', function () {
  */
 $(document).on('click', '#bwWordlistinputButtonConfirm', function () {
   $('#bwWordlistinput').addClass('is-hidden');
-  ipcRenderer.send('bw:input.wordlist');
+  electron.send('bw:input.wordlist');
 
   return;
 });
@@ -125,7 +129,7 @@ $(document).on('click', '#bwWordlistconfirmButtonStart', function () {
   $('#bwWordlistconfirm').addClass('is-hidden');
   $('#bwProcessing').removeClass('is-hidden');
 
-  ipcRenderer.send('bw:lookup', bwDomainArray, bwTldsArray);
+  electron.send('bw:lookup', bwDomainArray, bwTldsArray);
 
   return;
 });

--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -5,20 +5,24 @@ import datatables from 'datatables';
 const dt = datatables();
 import $ from 'jquery';
 
-import { ipcRenderer } from 'electron';
+const electron = (window as any).electron as {
+  send: (channel: string, ...args: any[]) => void;
+  invoke: (channel: string, ...args: any[]) => Promise<any>;
+  on: (channel: string, listener: (...args: any[]) => void) => void;
+};
 
 import { formatString } from '../../common/stringformat';
 
 let bwaFileContents: any;
 
 /*
-  ipcRenderer.on('bwa:analyser.tablegen', function() {...});
+  electron.on('bwa:analyser.tablegen', function() {...});
     Generate analyser content table
   parameters
     event
     contents
  */
-ipcRenderer.on('bwa:analyser.tablegen', function (event, contents) {
+electron.on('bwa:analyser.tablegen', function (event, contents) {
   bwaFileContents = contents;
   showTable();
 
@@ -30,7 +34,7 @@ ipcRenderer.on('bwa:analyser.tablegen', function (event, contents) {
     Bulk whois analyser close button
  */
 $('#bwaAnalyserButtonClose').click(function () {
-  ipcRenderer.send('app:debug', '#bwaAnalyserButtonClose clicked');
+  electron.send('app:debug', '#bwaAnalyserButtonClose clicked');
   $('#bwaAnalyserModalClose').addClass('is-active');
 
   return;

--- a/app/ts/renderer/navigation.ts
+++ b/app/ts/renderer/navigation.ts
@@ -1,8 +1,13 @@
-import { ipcRenderer } from 'electron';
 import { formatString } from '../common/stringformat';
 import $ from 'jquery';
 import { populateInputs } from './options';
 import { settings } from '../common/settings';
+
+const electron = (window as any).electron as {
+  send: (channel: string, ...args: any[]) => void;
+  invoke: (channel: string, ...args: any[]) => Promise<any>;
+  on: (channel: string, listener: (...args: any[]) => void) => void;
+};
 
 /*
   $(document).on('drop', function(...) {...});
@@ -11,7 +16,7 @@ import { settings } from '../common/settings';
     event (object)
  */
 $(document).on('drop', function (event) {
-  ipcRenderer.send('app:debug', 'Preventing drag and drop redirect');
+  electron.send('app:debug', 'Preventing drag and drop redirect');
   event.preventDefault();
 
   return false;
@@ -34,8 +39,8 @@ $(document).on('dragover', function (event) {
     On click: Button toggle developer tools
  */
 $(document).on('click', '#navButtonDevtools', function () {
-  void ipcRenderer.invoke('app:toggleDevtools');
-  ipcRenderer.send('app:debug', '#navButtonDevtools was clicked');
+  void electron.invoke('app:toggleDevtools');
+  electron.send('app:debug', '#navButtonDevtools was clicked');
 
   return;
 });
@@ -57,7 +62,7 @@ $(document).on('click', 'section.tabs ul li', function () {
       populateInputs();
     }
   }
-  ipcRenderer.send('app:debug', formatString('#section.tabs switched to data tab, {0}', tabName));
+  electron.send('app:debug', formatString('#section.tabs switched to data tab, {0}', tabName));
 
   return;
 });
@@ -67,7 +72,7 @@ $(document).on('click', 'section.tabs ul li', function () {
     On click: Delete open notifications
  */
 $(document).on('click', '.delete', function () {
-  ipcRenderer.send('app:debug', '.delete (notifications) was clicked');
+  electron.send('app:debug', '.delete (notifications) was clicked');
   const notificationId = $(this).attr('data-notif');
 
   $('#' + notificationId).addClass('is-hidden');
@@ -81,7 +86,7 @@ $(document).on('click', '.delete', function () {
  */
 $(document).keyup(function (event) {
   if (event.keyCode === 27) {
-    ipcRenderer.send('app:debug', formatString('Hotkey, Used [ESC] key, {0}', event.keyCode));
+    electron.send('app:debug', formatString('Hotkey, Used [ESC] key, {0}', event.keyCode));
     if ($('#appModalExit').hasClass('is-active')) {
       $('#appModalExitButtonNo').click();
       return;
@@ -89,7 +94,7 @@ $(document).keyup(function (event) {
     switch (true) {
       // Single whois tab is active
       case $('#navButtonSinglewhois').hasClass('is-active'):
-        ipcRenderer.send('app:debug', 'Hotkey, Single whois tab is active');
+        electron.send('app:debug', 'Hotkey, Single whois tab is active');
         switch (true) {
           case $('#singlewhoisDomainCopied').hasClass('is-active'):
             $('#singlewhoisDomainCopiedClose').click();
@@ -114,7 +119,7 @@ $(document).keyup(function (event) {
 
       // Bulk whois tab is active
       case $('#navButtonBw').hasClass('is-active'):
-        ipcRenderer.send('app:debug', 'Hotkey, Bulk whois tab is active');
+        electron.send('app:debug', 'Hotkey, Bulk whois tab is active');
         switch (true) {
           // Bulk whois, is Stop dialog open
           case $('#bwProcessingModalStop').hasClass('is-active'):
@@ -133,7 +138,7 @@ $(document).keyup(function (event) {
     Button/Toggle special menu items
  */
 $(document).on('click', '#navButtonExtendedmenu', function () {
-  ipcRenderer.send('app:debug', '#navButtonExtendedmenu was clicked');
+  electron.send('app:debug', '#navButtonExtendedmenu was clicked');
   $('#navButtonExtendedmenu').toggleClass('is-active');
   $('.is-specialmenu').toggleClass('is-hidden');
 
@@ -145,8 +150,8 @@ $(document).on('click', '#navButtonExtendedmenu', function () {
     On click: Minimize window button
  */
 $(document).on('click', '#navButtonMinimize', function () {
-  ipcRenderer.send('app:debug', '#navButtonMinimize was clicked');
-  void ipcRenderer.invoke('app:minimize');
+  electron.send('app:debug', '#navButtonMinimize was clicked');
+  void electron.invoke('app:minimize');
 
   return;
 });
@@ -156,32 +161,32 @@ $(document).on('click', '#navButtonMinimize', function () {
     On click: Close main window button
  */
 $(document).on('click', '#navButtonExit', function () {
-  ipcRenderer.send('app:debug', '#navButtonExit was clicked');
+  electron.send('app:debug', '#navButtonExit was clicked');
   if (settings.ui?.confirmExit) {
     $('#appModalExit').addClass('is-active');
   } else {
-    void ipcRenderer.invoke('app:close');
+      void electron.invoke('app:close');
   }
 
   return;
 });
 
 $(document).on('click', '#appModalExitButtonYes', function () {
-  ipcRenderer.send('app:debug', '#appModalExitButtonYes was clicked');
+  electron.send('app:debug', '#appModalExitButtonYes was clicked');
   $('#appModalExit').removeClass('is-active');
-  ipcRenderer.send('app:exit-confirmed');
+  electron.send('app:exit-confirmed');
 });
 
 $(document).on('click', '#appModalExitButtonNo, #appModalExit .delete', function () {
-  ipcRenderer.send('app:debug', '#appModalExitButtonNo was clicked');
+  electron.send('app:debug', '#appModalExitButtonNo was clicked');
   $('#appModalExit').removeClass('is-active');
 });
 
-ipcRenderer.on('app:confirm-exit', function () {
+electron.on('app:confirm-exit', function () {
   if (settings.ui?.confirmExit) {
     $('#appModalExit').addClass('is-active');
   } else {
-    void ipcRenderer.invoke('app:close');
+      void electron.invoke('app:close');
   }
 });
 

--- a/app/ts/renderer/options.ts
+++ b/app/ts/renderer/options.ts
@@ -1,7 +1,12 @@
 import $ from 'jquery';
 import fs from 'fs';
 import path from 'path';
-import { shell, ipcRenderer } from 'electron';
+const electron = (window as any).electron as {
+  send: (channel: string, ...args: any[]) => void;
+  invoke: (channel: string, ...args: any[]) => Promise<any>;
+  on: (channel: string, listener: (...args: any[]) => void) => void;
+  openPath: (path: string) => Promise<string>;
+};
 import { Worker } from 'worker_threads';
 import chokidar from 'chokidar';
 import {
@@ -367,7 +372,7 @@ $(document).ready(() => {
 
   $('#openDataFolder').on('click', async () => {
     const dataDir = getUserDataPath();
-    const result = await shell.openPath(dataDir);
+    const result = await electron.openPath(dataDir);
     if (result) {
       showToast('Failed to open data directory', false);
     }
@@ -375,7 +380,7 @@ $(document).ready(() => {
 
   $('#reloadApp').on('click', async () => {
     try {
-      await ipcRenderer.invoke('app:reload');
+      await electron.invoke('app:reload');
     } catch {
       showToast('Failed to reload application', false);
     }

--- a/test/fileWatcher.test.ts
+++ b/test/fileWatcher.test.ts
@@ -35,6 +35,12 @@ jest.mock('electron', () => ({
 
 beforeAll(() => {
   (window as any).$ = (window as any).jQuery = jQuery;
+  (window as any).electron = {
+    on: (channel: string, listener: (...args: any[]) => void) => ipc.on(channel, listener),
+    send: ipc.send,
+    invoke: jest.fn(),
+    openPath: jest.fn()
+  };
 });
 
 beforeEach(() => {

--- a/test/rendererOptions.test.ts
+++ b/test/rendererOptions.test.ts
@@ -5,11 +5,6 @@ let settingsModule: any;
 const invokeMock = jest.fn();
 const openPathMock = jest.fn();
 
-jest.mock('electron', () => ({
-  ipcRenderer: { invoke: invokeMock },
-  shell: { openPath: openPathMock }
-}));
-
 jest.mock('worker_threads', () => ({
   Worker: jest.fn().mockImplementation(() => ({
     on: jest.fn(),
@@ -43,6 +38,12 @@ beforeEach(() => {
     <input id="opSearch" />
     <div id="opSearchNoResults"></div>
   `;
+  (window as any).electron = {
+    invoke: invokeMock,
+    openPath: openPathMock,
+    send: jest.fn(),
+    on: jest.fn()
+  };
   invokeMock.mockClear();
   openPathMock.mockClear();
   saveSettingsMock.mockClear();

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -156,6 +156,12 @@ declare global {
   interface Window {
     $: any;
     jQuery: any;
+    electron: {
+      send: (channel: string, ...args: any[]) => void;
+      invoke: (channel: string, ...args: any[]) => Promise<any>;
+      on: (channel: string, listener: (...args: any[]) => void) => void;
+      openPath: (path: string) => Promise<string>;
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
- expose ipc wrappers via new preload script
- wire preload into BrowserWindow
- refactor renderer code to use exposed API
- update tests for window-based electron API

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685ccc25da6c83259991df4b10d988d9