### PR TITLE
fix: avoid duplicate CI triggers

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,11 +2,13 @@ name: Node.js CI
 
 on:
   push:
-    branches: ['**']
+    branches:
+      - master
+    tags:
+      - '*'
   pull_request:
-    branches: ['**']
-  pull_request_target:
-    branches: ['**']
+    branches:
+      - master
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- limit workflow triggers to push on `master` branch and tags
- remove `pull_request_target` trigger

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685cd306e8d4832584e53325789154cd