### PR TITLE
Add browser log checks in e2e test

### DIFF
--- a/test/e2e/run.js
+++ b/test/e2e/run.js
@@ -41,6 +41,13 @@ const debug = require('debug')('test:e2e');
 
     await browser.pause(2000);
 
+    const logs =
+      typeof browser.getRenderProcessLogs === 'function'
+        ? await browser.getRenderProcessLogs()
+        : await browser.getLogs('browser');
+    const errorLogs = logs.filter((l) => l.level === 'SEVERE' || /Error/.test(l.message));
+    assert.strictEqual(errorLogs.length, 0, 'Console errors: ' + JSON.stringify(errorLogs));
+
     const handles = await browser.getWindowHandles();
     assert.ok(handles.length > 0, 'No windows were created');
 


### PR DESCRIPTION
## Summary
- ensure the e2e test fails on console errors
- format the updated test file

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685cd5cf3a088325a3f995575387f1a0