### PR TITLE
docs: clarify e2e test requirement

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -98,6 +98,7 @@ To merge a PR, the following must be true:
 - ✅ Code passes **ESLint** (`npm run lint`)
 - ✅ Code passes **Prettier** formatting (`npm run format`)
 - ✅ All unit tests pass (`npm test`)
+- ✅ End-to-end tests pass (`npm run test:e2e`) and confirm the app launches without console errors
 - ✅ New logic includes test coverage
 - ✅ No production `console.log`s or `debugger` statements
 - ✅ PR follows conventional commits (`feat:`, `fix:`, `refactor:`)


### PR DESCRIPTION
## Summary
- document that end-to-end tests must pass before merging

## Testing
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: `xvfb-run` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cd5da1f808325a241f1923e67b1d6