### PR TITLE
docs: require E2E tests

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -99,6 +99,7 @@ To merge a PR, the following must be true:
 - ✅ Code passes **Prettier** formatting (`npm run format`)
 - ✅ All unit tests pass (`npm test`)
 - ✅ New logic includes test coverage
+- ✅ E2E tests pass and the app loads without console errors (`npm run test:e2e`)
 - ✅ No production `console.log`s or `debugger` statements
 - ✅ PR follows conventional commits (`feat:`, `fix:`, `refactor:`)
 - ✅ Public-facing changes must be reflected in the README when relevant


### PR DESCRIPTION
## Summary
- document E2E testing as part of PR requirements

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`
- `npm test`
- `npm run test:e2e` *(fails: xvfb-run not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cd82d9eb483259fdf74f264bc37e8