### PR TITLE
fix: run prebuild before jest tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test:e2e": "xvfb-run -a node test/e2e/run.js",
     "prebuild": "node scripts/prebuild.js",
     "prepare": "husky install",
-    "clean": "rimraf dist release_builds app/compiled-templates"
+    "clean": "rimraf dist release_builds app/compiled-templates",
+    "pretest": "node scripts/prebuild.js"
   },
   "author": "supermarsx",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- ensure Jest runs after running the prebuild step

## Testing
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: `xvfb-run` not found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685cdc4f92c8832595452febaad78ea9