### PR TITLE
Add command line interface

### DIFF
--- a/app/ts/cli.ts
+++ b/app/ts/cli.ts
@@ -1,0 +1,125 @@
+import fs from 'fs';
+import path from 'path';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import JSZip from 'jszip';
+import { lookup as whoisLookup } from './common/lookup';
+import { settings } from './common/settings';
+import { isDomainAvailable, getDomainParameters, WhoisResult } from './common/availability';
+import { toJSON } from './common/parser';
+import { generateFilename } from './main/bw/export';
+
+export interface CliOptions {
+  domains: string[];
+  wordlist?: string;
+  tlds: string[];
+  proxy?: string;
+  format: 'csv' | 'txt' | 'zip';
+  out?: string;
+}
+
+export function parseArgs(argv: string[]): CliOptions {
+  const args = yargs(argv)
+    .option('domain', { type: 'string', array: true })
+    .option('wordlist', { type: 'string' })
+    .option('tlds', { type: 'string', array: true, default: ['com'] })
+    .option('proxy', { type: 'string' })
+    .option('format', { choices: ['csv', 'txt', 'zip'] as const, default: 'txt' })
+    .option('out', { type: 'string' })
+    .parseSync();
+  return {
+    domains: args.domain ?? [],
+    wordlist: args.wordlist,
+    tlds: args.tlds as string[],
+    proxy: args.proxy,
+    format: args.format as 'csv' | 'txt' | 'zip',
+    out: args.out
+  };
+}
+
+export async function lookupDomains(opts: CliOptions): Promise<WhoisResult[]> {
+  if (opts.proxy) {
+    settings.lookupProxy.enable = true;
+    settings.lookupProxy.mode = 'single';
+    settings.lookupProxy.single = opts.proxy;
+  }
+
+  let domains: string[] = opts.domains;
+  if (opts.wordlist) {
+    const contents = await fs.promises.readFile(opts.wordlist, 'utf8');
+    const words = contents.split(/\r?\n/).filter((l) => l.trim() !== '');
+    const combos: string[] = [];
+    for (const tld of opts.tlds) {
+      combos.push(...words.map((w) => `${w}${opts.tlds.length > 0 ? '.' : ''}${tld}`));
+    }
+    domains = domains.concat(combos);
+  }
+
+  const results: WhoisResult[] = [];
+  for (const domain of domains) {
+    const data = await whoisLookup(domain);
+    const json = toJSON(data) as Record<string, unknown>;
+    const status = isDomainAvailable(data);
+    const params = getDomainParameters(domain, status, data, json);
+    results.push(params);
+  }
+  return results;
+}
+
+export async function exportResults(results: WhoisResult[], opts: CliOptions): Promise<string> {
+  const { lookupExport } = settings;
+  const file = opts.out ?? generateFilename(`.${opts.format}`);
+
+  switch (opts.format) {
+    case 'csv': {
+      const header = [
+        'Domain',
+        'Status',
+        'Registrar',
+        'Company',
+        'CreationDate',
+        'UpdateDate',
+        'ExpiryDate'
+      ];
+      const lines = results.map((r) =>
+        [r.domain, r.status, r.registrar, r.company, r.creationDate, r.updateDate, r.expiryDate]
+          .map(
+            (v) =>
+              `${lookupExport.enclosure}${(v ?? '').toString().replace(/"/g, '""')}${
+                lookupExport.enclosure
+              }`
+          )
+          .join(lookupExport.separator)
+      );
+      const content = [header.join(lookupExport.separator), ...lines].join(lookupExport.linebreak);
+      await fs.promises.writeFile(file, content);
+      return file;
+    }
+    case 'zip': {
+      const zip = new JSZip();
+      for (const r of results) {
+        if (r.domain && r.whoisreply)
+          zip.file(`${r.domain}${lookupExport.filetypeText}`, r.whoisreply);
+      }
+      const data = await zip.generateAsync({ type: 'uint8array' });
+      await fs.promises.writeFile(file, data);
+      return file;
+    }
+    default: {
+      const content = results
+        .map((r) => `==== ${r.domain} ====` + lookupExport.linebreak + (r.whoisreply ?? ''))
+        .join(lookupExport.linebreak + lookupExport.linebreak);
+      await fs.promises.writeFile(file, content);
+      return file;
+    }
+  }
+}
+
+if (require.main === module) {
+  (async () => {
+    const opts = parseArgs(hideBin(process.argv));
+    const results = await lookupDomains(opts);
+    const outPath = await exportResults(results, opts);
+    console.log(`Results written to ${path.resolve(outPath)}`);
+  })();
+}

--- a/readme.md
+++ b/readme.md
@@ -166,6 +166,21 @@ When choosing export options, you can decide what domain status to export, if yo
 
 Exporting as text will only export raw replies for each domain in a zip file, as a csv you're able to see both both basic information and whois replies (in text, inline csv or separate csv inside a zip file).
 
+### CLI usage
+
+After building the project you can run lookups from the command line:
+
+```bash
+# single domain
+node dist/app/ts/cli.js --domain example.com
+
+# bulk search using a wordlist
+node dist/app/ts/cli.js --wordlist words.txt --tlds com net --format csv --out results.csv
+
+# using a proxy
+node dist/app/ts/cli.js --domain example.com --proxy 127.0.0.1:9050
+```
+
 ### Notes on errors
 
 Errors during bulk lookups are pretty common due to sheer request volume, this means that you'll have requests periodically getting blocked, rejected, throttled or delayed (might result in false negatives, false positives in rare cases or errors). Errors may and usually signal that a domain is already registered, at times you can assume that but take into account the domain name, tld and probability of it being registered. Whoisdigger includes assumptions settings that you can tweak for specific scenarios, see assumptions below for more.

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,49 @@
+import './electronMainMock';
+import fs from 'fs';
+import path from 'path';
+import { parseArgs, lookupDomains, exportResults, CliOptions } from '../app/ts/cli';
+import { lookup as whoisLookup } from '../app/ts/common/lookup';
+
+jest.mock('../app/ts/common/lookup', () => ({ lookup: jest.fn() }));
+
+const mockLookup = whoisLookup as jest.Mock;
+
+describe('cli utility', () => {
+  test('parseArgs extracts options', () => {
+    const opts = parseArgs(['--domain', 'example.com', '--format', 'csv']);
+    expect(opts.domains).toEqual(['example.com']);
+    expect(opts.format).toBe('csv');
+  });
+
+  test('lookupDomains uses whois module', async () => {
+    mockLookup.mockResolvedValueOnce('data');
+    const opts: CliOptions = { domains: ['example.com'], tlds: ['com'], format: 'txt' };
+    const results = await lookupDomains(opts);
+    expect(results[0].domain).toBe('example.com');
+    expect(results[0].whoisreply).toBe('data');
+  });
+
+  test('exportResults writes csv output', async () => {
+    const file = path.join(__dirname, 'out.csv');
+    const opts: CliOptions = { domains: [], tlds: ['com'], format: 'csv', out: file };
+    await exportResults(
+      [
+        {
+          domain: 'example.com',
+          status: 'available',
+          registrar: 'reg',
+          company: 'comp',
+          creationDate: 'c',
+          updateDate: 'u',
+          expiryDate: 'e',
+          whoisreply: 'r',
+          whoisJson: {}
+        }
+      ],
+      opts
+    );
+    const content = await fs.promises.readFile(file, 'utf8');
+    expect(content).toContain('example.com');
+    fs.unlinkSync(file);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `cli.ts` entry for running lookups outside the GUI
- support arguments for domains, wordlists, proxies, and output format
- document CLI usage in the README
- add unit tests covering argument parsing and CSV export

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: xvfb-run not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cde5bcba48325a6448cf2409d3850