### PR TITLE
fix: handle missing context isolation in preload

### DIFF
--- a/app/ts/preload.ts
+++ b/app/ts/preload.ts
@@ -1,10 +1,16 @@
 import { contextBridge, ipcRenderer, shell } from 'electron';
 
-contextBridge.exposeInMainWorld('electron', {
+const api = {
   send: (channel: string, ...args: unknown[]) => ipcRenderer.send(channel, ...args),
   invoke: (channel: string, ...args: unknown[]) => ipcRenderer.invoke(channel, ...args),
   on: (channel: string, listener: (...args: unknown[]) => void) => {
     ipcRenderer.on(channel, (_event, ...args) => listener(...args));
   },
   openPath: (path: string) => shell.openPath(path)
-});
+};
+
+if (process.contextIsolated) {
+  contextBridge.exposeInMainWorld('electron', api);
+} else {
+  (window as any).electron = api;
+}


### PR DESCRIPTION
## Summary
- avoid contextBridge error when contextIsolation is disabled

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm test` *(fails: Cannot find module 'debug')*
- `npm run test:e2e` *(fails: xvfb-run not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce2411bdc8325b4d333d5de697436