### PR TITLE
Enforce BrowserWindow context isolation

### DIFF
--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -142,12 +142,19 @@ function watchConfig(): void {
       const parsed = JSON.parse(raw) as Partial<Settings>;
       try {
         settings = mergeDefaults(parsed);
+        if ((settings as any).appWindowWebPreferences) {
+          // Always enforce context isolation when reloading settings
+          (settings as any).appWindowWebPreferences.contextIsolation = true;
+        }
         debug(`Reloaded custom configuration at ${cfg}`);
         if (typeof window !== 'undefined' && settings.ui?.liveReload) {
           window.dispatchEvent(new Event('settings-reloaded'));
         }
       } catch (mergeError) {
         settings = JSON.parse(JSON.stringify(defaultSettings));
+        if ((settings as any).appWindowWebPreferences) {
+          (settings as any).appWindowWebPreferences.contextIsolation = true;
+        }
         debug(`Failed to merge configuration with error: ${mergeError}`);
         if (typeof window !== 'undefined' && settings.ui?.liveReload) {
           window.dispatchEvent(new Event('settings-reloaded'));
@@ -177,26 +184,43 @@ export async function load(): Promise<Settings> {
         const parsed = JSON.parse(raw) as Partial<Settings>;
         try {
           settings = mergeDefaults(parsed);
+          if ((settings as any).appWindowWebPreferences) {
+            // Enforce context isolation when loading configuration
+            (settings as any).appWindowWebPreferences.contextIsolation = true;
+          }
           customSettingsLoaded = true;
           debug(`Loaded custom configuration at ${filePath}`);
         } catch (mergeError) {
           settings = JSON.parse(JSON.stringify(defaultSettings));
+          if ((settings as any).appWindowWebPreferences) {
+            (settings as any).appWindowWebPreferences.contextIsolation = true;
+          }
           customSettingsLoaded = false;
           debug(`Failed to merge custom configuration with error: ${mergeError}`);
         }
       } catch (parseError) {
         customSettingsLoaded = false;
+        if ((settings as any).appWindowWebPreferences) {
+          (settings as any).appWindowWebPreferences.contextIsolation = true;
+        }
         debug(`Failed to parse custom configuration with error: ${parseError}`);
       }
     } catch (e) {
       debug(`Failed to load custom configuration with error: ${e}`);
       customSettingsLoaded = false;
+      if ((settings as any).appWindowWebPreferences) {
+        (settings as any).appWindowWebPreferences.contextIsolation = true;
+      }
       // Silently ignore loading errors
     }
   }
 
   watchConfig();
   if (!customSettingsLoaded) customSettingsLoaded = false;
+  if ((settings as any).appWindowWebPreferences) {
+    // Enforce context isolation regardless of loaded configuration
+    (settings as any).appWindowWebPreferences.contextIsolation = true;
+  }
   return settings;
 }
 

--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -32,7 +32,7 @@ interface AppWindowSettings {
   fullscreenable: boolean;
   kiosk: boolean;
   darkTheme: boolean;
-  thickFrame: boolean;
+    thickFrame: boolean;
 }
 
 interface WebPreferencesSettings {
@@ -109,7 +109,7 @@ app.on('ready', async function () {
     thickFrame: appWindow.thickFrame, // Use WS_THICKFRAME style for frameless windows on Windows, which adds standard window frame. Setting it to false will remove window shadow and window animations.
     webPreferences: {
       nodeIntegration: webPreferences.nodeIntegration, // Enable node integration
-      contextIsolation: webPreferences.contextIsolation, // Context isolation
+      contextIsolation: true, // Enforce context isolation for security
       zoomFactor: webPreferences.zoomFactor, // Page zoom factor
       images: webPreferences.images, // Image support
       experimentalFeatures: webPreferences.experimentalFeatures, // Enable Chromium experimental features

--- a/readme.md
+++ b/readme.md
@@ -208,6 +208,8 @@ Run `npm run format -- --write` before committing to apply Prettier formatting. 
 
 Whoisdigger uses a settings file that rules how the application behaves overall, this can be achieved by either using the preload settings file or change the `appsettings.ts` inside `js`.
 
+Context isolation is always enabled for security purposes and cannot be disabled in configuration.
+
 ### Theme
 
 The options screen provides a **Follow system theme** toggle. When enabled the application automatically switches between dark and light modes according to your operating system preference. This behaviour is controlled by the `theme.followSystem` setting which can be set to `true` or `false` in the configuration file.


### PR DESCRIPTION
## Summary
- override `contextIsolation` setting when creating `BrowserWindow`
- force loaded settings to keep `contextIsolation` enabled
- document requirement for context isolation in README

## Testing
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: xvfb-run not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce376e1d4832597e05ce76c72fd28