### PR TITLE
fix: add missing eslint js package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
       "devDependencies": {
         "@babel/core": "^7.27.4",
         "@babel/preset-env": "^7.27.2",
+        "@eslint/js": "^9.29.0",
         "@types/better-sqlite3": "^7.6.13",
         "@types/jest": "^30.0.0",
         "@types/jquery": "^3.5.32",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "electronmon": "^2.0.3",
     "eslint": "^9.29.0",
     "eslint-config-prettier": "^8.10.0",
+    "@eslint/js": "^9.29.0",
     "husky": "^9.1.7",
     "jest": "^30.0.2",
     "jest-environment-jsdom": "^30.0.2",


### PR DESCRIPTION
## Summary
- install `@eslint/js` to satisfy config requirement

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`
- `npm test`
- `npm run test:e2e` *(fails: `xvfb-run` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce406a3f48325899541101a3d4233