### PR TITLE
fix: support module startup script

### DIFF
--- a/app/html/startup.js
+++ b/app/html/startup.js
@@ -1,4 +1,4 @@
-const { registerPartials } = require('../ts/renderer/registerPartials.js');
+import { registerPartials } from '../ts/renderer/registerPartials.js';
 registerPartials();
 
-require('../ts/mainPanel.js');
+import '../ts/mainPanel.js';

--- a/app/html/templates/mainPanel.hbs
+++ b/app/html/templates/mainPanel.hbs
@@ -15,7 +15,7 @@
     <link href="../css/style.css" rel="stylesheet" />
     <link href="../css/tables.css" rel="stylesheet" />
     <!--<link href="../css/fontawesome/all.min.css" rel="stylesheet">-->
-    <script src="./startup.js"></script>
+    <script type="module" src="./startup.js"></script>
   </head>
 
   <body>


### PR DESCRIPTION
## Summary
- fix startup script to use ES module syntax
- update main panel template to load startup script as module

## Testing
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run build`
- `npm run test:e2e` *(fails: `xvfb-run: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685ce6a111008325a34498d2710b31a2