### PR TITLE
Fix E2E context isolation issues

### DIFF
--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -207,6 +207,14 @@ ipcMain.handle('app:minimize', function () {
 });
 
 /*
+  ipcMain.handle('app:isMinimized', function() {...});
+    Return whether the window is currently minimized
+ */
+ipcMain.handle('app:isMinimized', function () {
+  return mainWindow.isMinimized();
+});
+
+/*
   ipcMain.handle('app:close', function() {...});
     Close the application window
  */

--- a/test/e2e/run.js
+++ b/test/e2e/run.js
@@ -8,7 +8,7 @@ const debug = require('debug')('test:e2e');
 
 (async () => {
   const electronPath = require('electron');
-  const appPath = path.join(__dirname, '..', '..', 'dist', 'app', 'ts', 'main.js');
+  const appPath = path.resolve(__dirname, '..', '..', 'dist', 'app', 'ts', 'main.js');
 
   const artifactsDir = path.join(__dirname, 'artifacts');
   fs.mkdirSync(artifactsDir, { recursive: true });
@@ -52,14 +52,12 @@ const debug = require('debug')('test:e2e');
     assert.ok(handles.length > 0, 'No windows were created');
 
     await browser.execute(() => {
-      const { ipcRenderer } = require('electron');
-      ipcRenderer.send('app:minimize');
+      window.electron?.send('app:minimize');
     });
     await browser.pause(500);
 
-    const minimized = await browser.execute(() => {
-      const remote = require('@electron/remote');
-      return remote.BrowserWindow.getFocusedWindow().isMinimized();
+    const minimized = await browser.executeAsync((done) => {
+      window.electron?.invoke('app:isMinimized').then((res) => done(res));
     });
     assert.ok(minimized, 'Window did not minimize via IPC');
 

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -33,6 +33,7 @@ declare module 'electron' {
 
   interface RendererToMainIpc {
     'app:minimize': [];
+    'app:isMinimized': [];
     'app:reload': [];
     'app:debug': [message: any];
     'bw:lookup': [string[], string[]];


### PR DESCRIPTION
## Summary
- add `app:isMinimized` IPC handler
- adjust e2e test to work with context isolation
- use absolute path for electron entry in e2e test

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: Electron prints usage output)*


------
https://chatgpt.com/codex/tasks/task_e_685cdd76b48083259df5a476fee2f2b4