### PR TITLE
fix: load partials module correctly

### DIFF
--- a/app/html/startup.js
+++ b/app/html/startup.js
@@ -1,4 +1,4 @@
-import { registerPartials } from '../ts/renderer/registerPartials.js';
-registerPartials();
+import registerPartialsModule from '../ts/renderer/registerPartials.js';
+registerPartialsModule.registerPartials();
 
 import '../ts/mainPanel.js';


### PR DESCRIPTION
## Summary
- update startup.js to correctly import compiled CommonJS module

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: `xvfb-run` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce9d3906883258b1e3ad4567b6709