### PR TITLE
feat: add AI configuration section

### DIFF
--- a/app/ts/appsettings.ts
+++ b/app/ts/appsettings.ts
@@ -177,6 +177,14 @@ const appSettings = {
       filetypeZip: '.zip', // Compressed file extension (default: '.zip')
       openAfterExport: false, // Open file after exporting (default: false)
       autoGenerateFilename: false // Suggest filename automatically (default: false)
+    },
+    ai: {
+      // AI domain availability configuration
+      enabled: false,
+      modelPath: 'model/availability.onnx',
+      dataPath: 'ai-data',
+      modelURL: '',
+      openai: { url: '', apiKey: '' }
     }
   }
 };
@@ -277,5 +285,11 @@ export const appSettingsDescriptions: Record<string, string> = {
   'lookupExport.filetypeCsv': 'CSV file extension',
   'lookupExport.filetypeZip': 'ZIP file extension',
   'lookupExport.openAfterExport': 'Open exported file automatically',
-  'lookupExport.autoGenerateFilename': 'Suggest export filename automatically'
+  'lookupExport.autoGenerateFilename': 'Suggest export filename automatically',
+  'ai.enabled': 'Enable AI features',
+  'ai.modelPath': 'Local ONNX model path',
+  'ai.dataPath': 'Directory for AI data',
+  'ai.modelURL': 'URL to download the ONNX model',
+  'ai.openai.url': 'Custom OpenAI API endpoint',
+  'ai.openai.apiKey': 'OpenAI API key'
 };

--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -54,6 +54,13 @@ export interface Settings {
   customConfiguration: { filepath: string; load: boolean; save: boolean };
   theme: { darkMode: boolean; followSystem: boolean };
   ui: { liveReload: boolean; confirmExit: boolean; language: string };
+  ai: {
+    enabled: boolean;
+    modelPath: string;
+    dataPath: string;
+    modelURL: string;
+    openai: { url: string; apiKey: string };
+  };
   [key: string]: any;
 }
 

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,7 @@ If you clone this repo please patch `node_modules\whois\index.js` and remove the
 - IDNA 2003/2008 (UTS46), Punycode, non-ASCII character filter support
 - Public Suffix List (PSL) and wildcard filtering
 - Basic bulk whois result analyser (csv import)
+- Experimental AI domain availability checks
 - Persistent settings through JSON file preload with live updates
 - Redesigned options interface with auto-save
 - Dark mode toggle
@@ -231,6 +232,16 @@ You can use assumptions (`lookup.assumptions` settings section) to make more rel
 `unparsable`, Assume a domain as available if reply is unparsable, it may help correcting malformed, unusual or unhandled whois replies, default: false
 
 `dnsFailureUnavailable`, Assume a domain is unavailable in a DNS sweep if request fails, this avoids having false positives on availability, default: true
+
+### AI
+
+Whoisdigger can optionally use a local ONNX model or OpenAI to predict domain availability.
+Configure these features in the `ai` section of `appsettings.ts`:
+
+- `ai.enabled` - toggle AI features
+- `ai.modelPath` and `ai.dataPath` - local model and data locations
+- `ai.modelURL` - remote URL to download the model
+- `ai.openai.url` and `ai.openai.apiKey` - OpenAI endpoint and API key
 
 ## Building
 


### PR DESCRIPTION
## Summary
- define default AI settings
- extend `Settings` interface with AI section
- document AI options and features

## Testing
- `npm run lint`
- `npx prettier app/ts/appsettings.ts app/ts/common/settings.ts readme.md --check`
- `npm test`
- `npm run test:e2e` *(fails: `xvfb-run: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685cebb7a1508325a4aed9845132746a