### PR TITLE
feat: add cache purge and clear commands

### DIFF
--- a/app/ts/main/cache.ts
+++ b/app/ts/main/cache.ts
@@ -1,0 +1,15 @@
+import { ipcMain } from 'electron';
+import debugModule from 'debug';
+import { purgeExpired, clearCache } from '../common/requestCache';
+
+const debug = debugModule('main.cache');
+
+ipcMain.handle('cache:purge', (_event, opts: { clear?: boolean } = {}) => {
+  if (opts.clear) {
+    clearCache();
+    debug('Cleared cache via IPC');
+  } else {
+    purgeExpired();
+    debug('Purged expired cache entries via IPC');
+  }
+});

--- a/app/ts/main/index.ts
+++ b/app/ts/main/index.ts
@@ -2,3 +2,4 @@ import './singlewhois';
 import './bw';
 import './bwa';
 import './to';
+import './cache';

--- a/readme.md
+++ b/readme.md
@@ -179,6 +179,12 @@ node dist/app/ts/cli.js --wordlist words.txt --tlds com net --format csv --out r
 
 # using a proxy
 node dist/app/ts/cli.js --domain example.com --proxy 127.0.0.1:9050
+
+# purge expired cache
+node dist/app/ts/cli.js --purge-cache
+
+# clear entire cache
+node dist/app/ts/cli.js --clear-cache
 ```
 
 ### Notes on errors

--- a/test/cacheCommand.test.ts
+++ b/test/cacheCommand.test.ts
@@ -1,0 +1,37 @@
+const ipcMainHandlers: Record<string, (...args: any[]) => any> = {};
+const purgeMock = jest.fn();
+const clearMock = jest.fn();
+
+jest.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, listener: (...args: any[]) => any) => {
+      ipcMainHandlers[channel] = listener;
+    }
+  },
+  dialog: {},
+  app: undefined,
+  BrowserWindow: class {},
+  Menu: {}
+}));
+
+jest.mock('../app/ts/common/requestCache', () => ({
+  purgeExpired: () => purgeMock(),
+  clearCache: () => clearMock()
+}));
+
+import '../app/ts/main/cache';
+
+describe('cache IPC handler', () => {
+  test('purges expired entries', () => {
+    const handler = ipcMainHandlers['cache:purge'];
+    handler({}, { clear: false });
+    expect(purgeMock).toHaveBeenCalled();
+    expect(clearMock).not.toHaveBeenCalled();
+  });
+
+  test('clears all entries when clear flag set', () => {
+    const handler = ipcMainHandlers['cache:purge'];
+    handler({}, { clear: true });
+    expect(clearMock).toHaveBeenCalled();
+  });
+});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -15,6 +15,12 @@ describe('cli utility', () => {
     expect(opts.format).toBe('csv');
   });
 
+  test('parseArgs recognizes cache flags', () => {
+    const opts = parseArgs(['--purge-cache', '--clear-cache']);
+    expect(opts.purgeCache).toBe(true);
+    expect(opts.clearCache).toBe(true);
+  });
+
   test('lookupDomains uses whois module', async () => {
     mockLookup.mockResolvedValueOnce('data');
     const opts: CliOptions = { domains: ['example.com'], tlds: ['com'], format: 'txt' };

--- a/test/requestCache.test.ts
+++ b/test/requestCache.test.ts
@@ -1,6 +1,12 @@
 import '../test/electronMock';
 import { settings, getUserDataPath } from '../app/ts/common/settings';
-import { getCached, setCached, closeCache } from '../app/ts/common/requestCache';
+import {
+  getCached,
+  setCached,
+  closeCache,
+  purgeExpired,
+  clearCache
+} from '../app/ts/common/requestCache';
 import fs from 'fs';
 import path from 'path';
 
@@ -46,5 +52,22 @@ describe('requestCache', () => {
   test('closeCache does not throw when cache disabled', () => {
     settings.requestCache.enabled = false;
     expect(() => closeCache()).not.toThrow();
+  });
+
+  test('purgeExpired removes outdated entries', async () => {
+    settings.requestCache.enabled = true;
+    setCached('whois', 'old.com', 'data');
+    await new Promise((r) => setTimeout(r, 1100));
+    purgeExpired();
+    const res = getCached('whois', 'old.com');
+    expect(res).toBeUndefined();
+  });
+
+  test('clearCache wipes all entries', () => {
+    setCached('whois', 'a.com', '1');
+    setCached('whois', 'b.com', '2');
+    clearCache();
+    expect(getCached('whois', 'a.com')).toBeUndefined();
+    expect(getCached('whois', 'b.com')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- add `purgeExpired` and `clearCache` functions
- expose cache maintenance via new IPC handler and CLI flags
- document CLI options in README
- cover cache clearing and purging with unit tests

## Testing
- `npm run format -- --write`
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:e2e` *(fails: xvfb-run not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cec814be483259b64190d55e71660