### PR TITLE
fix: import named partials correctly

### DIFF
--- a/app/html/startup.js
+++ b/app/html/startup.js
@@ -1,4 +1,4 @@
-import registerPartialsModule from '../ts/renderer/registerPartials.js';
-registerPartialsModule.registerPartials();
+import { registerPartials } from '../ts/renderer/registerPartials.js';
+registerPartials();
 
 import '../ts/mainPanel.js';


### PR DESCRIPTION
## Summary
- import `registerPartials` as a named export in `startup.js`

## Testing
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: xvfb-run not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d0e9220b4832597fef97f583733ed