### PR TITLE
Remove xvfb-run usage

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Run e2e tests
-        run: xvfb-run -a npm run test:e2e
+        run: npm run test:e2e
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint \"app/**/*.ts\" \"test/**/*.ts\"",
     "format": "prettier --ignore-path .prettierignore .",
     "test": "jest",
-    "test:e2e": "xvfb-run -a node test/e2e/run.js",
+    "test:e2e": "node test/e2e/run.js",
     "prebuild": "node scripts/prebuild.js",
     "prepare": "husky install",
     "clean": "rimraf dist release_builds app/compiled-templates",

--- a/test/e2e/run.js
+++ b/test/e2e/run.js
@@ -12,7 +12,6 @@ const debug = require('debug')('test:e2e');
 
   const artifactsDir = path.join(__dirname, 'artifacts');
   fs.mkdirSync(artifactsDir, { recursive: true });
-  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'whoisdigger-'));
 
   const chromedriverPath = path.join(__dirname, '..', '..', 'node_modules', '.bin', 'chromedriver');
   const chromedriver = spawn(chromedriverPath, ['--port=9515'], {
@@ -33,7 +32,8 @@ const debug = require('debug')('test:e2e');
             appPath,
             '--no-sandbox',
             '--disable-dev-shm-usage',
-            `--user-data-dir=${userDataDir}`
+            '--headless=new',
+            '--remote-debugging-port=9515'
           ]
         }
       }
@@ -130,6 +130,5 @@ const debug = require('debug')('test:e2e');
     process.exit(1);
   } finally {
     chromedriver.kill();
-    fs.rmSync(userDataDir, { recursive: true, force: true });
   }
 })();


### PR DESCRIPTION
## Summary
- eliminate use of `xvfb-run` in the e2e workflow
- adjust the npm `test:e2e` script
- run Electron headless in e2e tests

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_685d0ea62ebc83259e60004d206510c3