### PR TITLE
fix: default export for registerPartials

### DIFF
--- a/app/html/startup.js
+++ b/app/html/startup.js
@@ -1,4 +1,4 @@
-import { registerPartials } from '../ts/renderer/registerPartials.js';
+import registerPartials from '../ts/renderer/registerPartials.js';
 registerPartials();
 
 import '../ts/mainPanel.js';

--- a/app/ts/renderer/registerPartials.ts
+++ b/app/ts/renderer/registerPartials.ts
@@ -66,3 +66,5 @@ export function registerPartials(): void {
     Handlebars.registerPartial(name, template);
   }
 }
+
+export default registerPartials;


### PR DESCRIPTION
## Summary
- expose `registerPartials` as a default export
- update startup script to use the default

This fixes the startup crash when importing `registerPartials` as an ES module.

## Testing
- `npm run lint`
- `npm run format -- --check` *(fails: code style issues found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d1a985270832597c1e7f8dcdc3385