### PR TITLE
feat: add AI training script

### DIFF
--- a/docs/ai_training.md
+++ b/docs/ai_training.md
@@ -1,0 +1,27 @@
+# AI Model Training
+
+This document outlines how to create a local availability model from WHOIS replies.
+
+## Collecting data
+
+Use domain lists such as those under `sample_lists/` as input. Each domain will be queried and labelled using Whoisdigger's built‑in availability heuristics.
+
+## Running the trainer
+
+1. Build the project to compile TypeScript:
+
+```bash
+npm run build
+```
+
+2. Execute the training script. You can specify one or more `.list` files:
+
+```bash
+node dist/scripts/train-ai.js --lists sample_lists/3letter_alpha.list
+```
+
+When no list is supplied, every file in `sample_lists/` is processed. The script writes the resulting model to the path defined by `settings.ai.modelPath` under the user data directory (`settings.ai.dataPath`).
+
+## Updating the model
+
+After training completes, distribute the generated file to users or update `settings.ai.modelPath` to point to the new location.

--- a/scripts/train-ai.ts
+++ b/scripts/train-ai.ts
@@ -1,0 +1,119 @@
+import fs from 'fs';
+import path from 'path';
+import { parseArgs } from 'util';
+import { settings, getUserDataPath } from '../app/ts/common/settings';
+import { lookup } from '../app/ts/common/lookup';
+import { toJSON } from '../app/ts/common/parser';
+import { isDomainAvailable } from '../app/ts/common/availability';
+
+type Label = 'available' | 'unavailable';
+
+export interface TrainingSample {
+  text: string;
+  label: Label;
+}
+
+export interface Model {
+  vocabulary: string[];
+  classTotals: Record<Label, number>;
+  tokenTotals: Record<Label, number>;
+  tokenCounts: Record<Label, Record<string, number>>;
+}
+
+export function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+export function trainFromSamples(samples: TrainingSample[]): Model {
+  const vocabulary = new Set<string>();
+  const classTotals: Record<Label, number> = { available: 0, unavailable: 0 };
+  const tokenTotals: Record<Label, number> = { available: 0, unavailable: 0 };
+  const tokenCounts: Record<Label, Record<string, number>> = {
+    available: {},
+    unavailable: {}
+  };
+  for (const sample of samples) {
+    const tokens = tokenize(sample.text);
+    classTotals[sample.label]++;
+    tokenTotals[sample.label] += tokens.length;
+    for (const t of tokens) {
+      vocabulary.add(t);
+      tokenCounts[sample.label][t] = (tokenCounts[sample.label][t] || 0) + 1;
+    }
+  }
+  return {
+    vocabulary: Array.from(vocabulary),
+    classTotals,
+    tokenTotals,
+    tokenCounts
+  };
+}
+
+export function predict(model: Model, text: string): Label {
+  const tokens = tokenize(text);
+  const vocabSize = model.vocabulary.length;
+  const totalDocs = model.classTotals.available + model.classTotals.unavailable;
+  function score(label: Label): number {
+    let s = Math.log(model.classTotals[label] / totalDocs);
+    for (const t of tokens) {
+      const count = model.tokenCounts[label][t] || 0;
+      s += Math.log((count + 1) / (model.tokenTotals[label] + vocabSize));
+    }
+    return s;
+  }
+  return score('available') > score('unavailable') ? 'available' : 'unavailable';
+}
+
+async function trainDomains(domains: string[]): Promise<Model> {
+  const samples: TrainingSample[] = [];
+  for (const domain of domains) {
+    try {
+      const text = await lookup(domain);
+      const json = toJSON(text) as Record<string, unknown>;
+      const result = isDomainAvailable(text, json);
+      if (result === 'available' || result === 'unavailable') {
+        samples.push({ text, label: result });
+      }
+    } catch {
+      // Ignore lookup errors
+    }
+  }
+  if (!samples.length) throw new Error('no training data');
+  return trainFromSamples(samples);
+}
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    options: { lists: { type: 'string', multiple: true } }
+  });
+  let files: string[] = values.lists as string[];
+  if (!files || files.length === 0) {
+    files = fs.readdirSync('sample_lists').filter((f) => f.endsWith('.list'));
+  }
+  const domains: string[] = [];
+  for (const f of files) {
+    const lines = fs.readFileSync(f, 'utf8').split(/\r?\n/).filter(Boolean);
+    domains.push(...lines);
+  }
+  const model = await trainDomains(domains);
+  const baseDir = path.resolve(getUserDataPath(), settings.ai.dataPath);
+  const dest = path.resolve(baseDir, settings.ai.modelPath);
+  if (dest !== baseDir && !dest.startsWith(baseDir + path.sep)) {
+    throw new Error('Invalid model path');
+  }
+  await fs.promises.mkdir(path.dirname(dest), { recursive: true });
+  await fs.promises.writeFile(dest, JSON.stringify(model));
+  console.log(`Model written to ${dest}`);
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  });
+}

--- a/test/trainAi.test.ts
+++ b/test/trainAi.test.ts
@@ -1,0 +1,13 @@
+import { trainFromSamples, predict } from '../scripts/train-ai';
+
+describe('train-ai', () => {
+  test('predicts labels after training', () => {
+    const samples = [
+      { text: 'No match for domain example.com', label: 'available' },
+      { text: 'Domain Status:ok\nExpiry Date:2030-01-01', label: 'unavailable' }
+    ];
+    const model = trainFromSamples(samples);
+    expect(predict(model, 'Domain Status:ok')).toBe('unavailable');
+    expect(predict(model, 'No match for domain test')).toBe('available');
+  });
+});


### PR DESCRIPTION
## Summary
- add a script to train a simple AI model from WHOIS replies
- document how to collect data and run the training script
- cover new functionality with a unit test

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_685d1a59a1808325ae6caf4219936bb2