### PR TITLE
fix: support esnext modules

### DIFF
--- a/app/ts/main/bw/process.defaults.ts
+++ b/app/ts/main/bw/process.defaults.ts
@@ -69,4 +69,4 @@ const defaultBulkWhois: BulkWhois = {
   }
 };
 
-export = defaultBulkWhois;
+export default defaultBulkWhois;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2019",
-    "module": "commonjs",
+    "module": "esnext",
     "moduleResolution": "node",
     "allowJs": true,
     "noEmit": false,

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -134,7 +134,7 @@ declare module 'app/ts/main/bw/auxiliary' {
 
 declare module 'app/ts/main/bw/process.defaults' {
   const defaults: any;
-  export = defaults;
+  export default defaults;
 }
 
 declare module 'app/ts/common/resetObject' {


### PR DESCRIPTION
## Summary
- switch TypeScript module target to `esnext`
- export default bulk WHOIS defaults
- update custom type declaration

## Testing
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_685d481b9b3c83259e5eac9ccabd6fbf