### PR TITLE
feat: add cache override options

### DIFF
--- a/app/ts/common/lookup.ts
+++ b/app/ts/common/lookup.ts
@@ -4,7 +4,7 @@ import uts46 from 'idna-uts46';
 import whois from 'whois';
 import debugModule from 'debug';
 import { settings, Settings } from './settings';
-import { getCached, setCached } from './requestCache';
+import { getCached, setCached, CacheOptions } from './requestCache';
 import { getProxy } from './proxy';
 
 const debug = debugModule('common.whoisWrapper');
@@ -23,11 +23,15 @@ const lookupPromise = (...args: unknown[]): Promise<string> => {
   });
 };
 
-export async function lookup(domain: string, options = getWhoisOptions()): Promise<string> {
+export async function lookup(
+  domain: string,
+  options = getWhoisOptions(),
+  cacheOpts: CacheOptions = {}
+): Promise<string> {
   const { lookupConversion: conversion, lookupGeneral: general } = getSettings();
   let domainResults: string;
 
-  const cached = getCached('whois', domain);
+  const cached = getCached('whois', domain, cacheOpts);
   if (cached !== undefined) {
     return cached;
   }
@@ -45,7 +49,7 @@ export async function lookup(domain: string, options = getWhoisOptions()): Promi
     domainResults = `Whois lookup error, ${e}`;
   }
 
-  setCached('whois', domain, domainResults);
+  setCached('whois', domain, domainResults, cacheOpts);
 
   return domainResults;
 }

--- a/test/cacheOverride.test.ts
+++ b/test/cacheOverride.test.ts
@@ -1,0 +1,62 @@
+import '../test/electronMock';
+import fs from 'fs';
+import path from 'path';
+import whois from 'whois';
+import dns from 'dns/promises';
+import { lookup } from '../app/ts/common/lookup';
+import { nsLookup } from '../app/ts/common/dnsLookup';
+import { settings, getUserDataPath } from '../app/ts/common/settings';
+
+describe('cache override', () => {
+  const dbFile = 'override-cache.sqlite';
+
+  beforeAll(() => {
+    settings.requestCache.enabled = true;
+    settings.requestCache.database = dbFile;
+    settings.requestCache.ttl = 60;
+  });
+
+  afterAll(() => {
+    const dbPath = path.resolve(getUserDataPath(), dbFile);
+    if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+    settings.requestCache.enabled = false;
+  });
+
+  test('whois lookup bypasses cache when disabled', async () => {
+    const spy = jest.spyOn(whois, 'lookup').mockImplementation((...args: any[]) => {
+      const cb = args[args.length - 1] as Function;
+      cb(null, 'DATA');
+    });
+    await lookup('example.com', undefined, { enabled: false });
+    await lookup('example.com', undefined, { enabled: false });
+    expect(spy).toHaveBeenCalledTimes(2);
+    spy.mockRestore();
+  });
+
+  test('dns lookup bypasses cache when disabled', async () => {
+    const spy = jest.spyOn(dns, 'resolve').mockResolvedValue(['ns1']);
+    await nsLookup('example.com', { enabled: false });
+    await nsLookup('example.com', { enabled: false });
+    expect(spy).toHaveBeenCalledTimes(2);
+    spy.mockRestore();
+  });
+
+  test('whois lookup ttl override forces refresh', async () => {
+    const spy = jest.spyOn(whois, 'lookup').mockImplementation((...args: any[]) => {
+      const cb = args[args.length - 1] as Function;
+      cb(null, 'DATA');
+    });
+    await lookup('ttl.com', undefined, { ttl: 0 });
+    await lookup('ttl.com', undefined, { ttl: 0 });
+    expect(spy).toHaveBeenCalledTimes(2);
+    spy.mockRestore();
+  });
+
+  test('dns lookup ttl override forces refresh', async () => {
+    const spy = jest.spyOn(dns, 'resolve').mockResolvedValue(['ns1']);
+    await nsLookup('ttl.com', { ttl: 0 });
+    await nsLookup('ttl.com', { ttl: 0 });
+    expect(spy).toHaveBeenCalledTimes(2);
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add `CacheOptions` allowing per-call overrides
- update whois and DNS lookup functions to accept cache options
- honor overrides within cache helpers
- test cache overrides for whois and dns lookups

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: session not created due to Chrome user data directory)*

------
https://chatgpt.com/codex/tasks/task_e_685d4b5c207c83259b1ea5b2e63e1f19