### PR TITLE
feat: integrate ai availability model

### DIFF
--- a/app/ts/ai/availabilityModel.ts
+++ b/app/ts/ai/availabilityModel.ts
@@ -1,0 +1,58 @@
+import fs from 'fs';
+import path from 'path';
+import debugModule from 'debug';
+import { settings, getUserDataPath } from '../common/settings';
+
+const debug = debugModule('ai.availabilityModel');
+
+export type Label = 'available' | 'unavailable';
+
+export interface Model {
+  vocabulary: string[];
+  classTotals: Record<Label, number>;
+  tokenTotals: Record<Label, number>;
+  tokenCounts: Record<Label, Record<string, number>>;
+}
+
+let model: Model | undefined;
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+export async function loadModel(modelPath: string = settings.ai.modelPath): Promise<void> {
+  const baseDir = path.resolve(getUserDataPath(), settings.ai.dataPath);
+  const dest = path.resolve(baseDir, modelPath);
+  if (dest !== baseDir && !dest.startsWith(baseDir + path.sep)) {
+    throw new Error('Invalid model path');
+  }
+  const data = await fs.promises.readFile(dest, 'utf8');
+  model = JSON.parse(data) as Model;
+  debug('Model loaded');
+}
+
+export function predict(text: string): 'available' | 'unavailable' | 'error' {
+  if (!model) return 'error';
+  try {
+    const tokens = tokenize(text);
+    const vocabSize = model.vocabulary.length;
+    const totalDocs = model.classTotals.available + model.classTotals.unavailable;
+    function score(label: Label): number {
+      let s = Math.log(model.classTotals[label] / totalDocs);
+      for (const t of tokens) {
+        const count = model.tokenCounts[label][t] || 0;
+        s += Math.log((count + 1) / (model.tokenTotals[label] + vocabSize));
+      }
+      return s;
+    }
+    return score('available') > score('unavailable') ? 'available' : 'unavailable';
+  } catch (e) {
+    debug(`Prediction failed: ${e}`);
+    return 'error';
+  }
+}

--- a/app/ts/common/availability.ts
+++ b/app/ts/common/availability.ts
@@ -3,6 +3,7 @@ import { getDate } from './conversions';
 import { toJSON } from './parser';
 import { settings as appSettings, Settings } from './settings';
 import { checkPatterns } from './whoiswrapper/patterns';
+import { predict as aiPredict } from '../ai/availabilityModel';
 
 const debug = debugModule('common.whoisWrapper');
 let settings: Settings = appSettings;
@@ -135,6 +136,15 @@ export function isDomainAvailable(
   resultsJSON?: Record<string, unknown>
 ): string {
   const { lookupAssumptions: assumptions } = settings;
+
+  if (settings.ai.enabled) {
+    try {
+      const aiRes = aiPredict(resultsText);
+      if (aiRes === 'available' || aiRes === 'unavailable') return aiRes;
+    } catch (e) {
+      debug(`AI prediction failed: ${e}`);
+    }
+  }
 
   const patternResult = checkPatterns(resultsText, resultsJSON);
   const defaultResult = assumptions.unparsable ? 'available' : 'error:unparsable';

--- a/test/availabilityModel.test.ts
+++ b/test/availabilityModel.test.ts
@@ -1,0 +1,35 @@
+import fs from 'fs';
+import path from 'path';
+import '../test/electronMock';
+import { loadModel, predict } from '../app/ts/ai/availabilityModel';
+import { settings, getUserDataPath } from '../app/ts/common/settings';
+import { trainFromSamples } from '../scripts/train-ai';
+
+const modelDir = 'ai-test-model';
+
+describe('availabilityModel', () => {
+  beforeEach(() => {
+    settings.ai.dataPath = modelDir;
+    settings.ai.modelPath = 'model.json';
+    fs.rmSync(path.join(getUserDataPath(), modelDir), { recursive: true, force: true });
+  });
+
+  test('loadModel rejects on missing file', async () => {
+    await expect(loadModel(settings.ai.modelPath)).rejects.toThrow();
+  });
+
+  test('predict returns loaded result', async () => {
+    const base = path.join(getUserDataPath(), modelDir);
+    const dest = path.join(base, settings.ai.modelPath);
+    const model = trainFromSamples([
+      { text: 'Domain Status:ok', label: 'available' },
+      { text: 'No match', label: 'unavailable' }
+    ]);
+    await fs.promises.mkdir(path.dirname(dest), { recursive: true });
+    await fs.promises.writeFile(dest, JSON.stringify(model));
+
+    await loadModel(settings.ai.modelPath);
+    const res = predict('Domain Status:ok');
+    expect(res).toBe('available');
+  });
+});

--- a/test/isDomainAvailableAi.test.ts
+++ b/test/isDomainAvailableAi.test.ts
@@ -1,0 +1,36 @@
+import fs from 'fs';
+import path from 'path';
+import '../test/electronMock';
+import { settings, getUserDataPath } from '../app/ts/common/settings';
+import { loadModel } from '../app/ts/ai/availabilityModel';
+import { trainFromSamples } from '../scripts/train-ai';
+import { isDomainAvailable } from '../app/ts/common/availability';
+
+describe('isDomainAvailable with AI', () => {
+  const dir = 'ai-int';
+
+  beforeAll(async () => {
+    settings.ai.enabled = true;
+    settings.ai.dataPath = dir;
+    settings.ai.modelPath = 'model.json';
+    const base = path.join(getUserDataPath(), dir);
+    const dest = path.join(base, 'model.json');
+    const model = trainFromSamples([
+      { text: 'Domain Status:ok', label: 'available' },
+      { text: 'No match', label: 'unavailable' }
+    ]);
+    await fs.promises.mkdir(path.dirname(dest), { recursive: true });
+    await fs.promises.writeFile(dest, JSON.stringify(model));
+    await loadModel(settings.ai.modelPath);
+  });
+
+  afterAll(() => {
+    settings.ai.enabled = false;
+    fs.rmSync(path.join(getUserDataPath(), dir), { recursive: true, force: true });
+  });
+
+  test('returns ai prediction when enabled', () => {
+    const res = isDomainAvailable('Domain Status:ok');
+    expect(res).toBe('available');
+  });
+});


### PR DESCRIPTION
## Summary
- add AI availability model loader/predictor
- use AI predictions in `isDomainAvailable`
- test AI model loading and prediction integration

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: session not created: probably user data directory is already in use)*

------
https://chatgpt.com/codex/tasks/task_e_685d4b7e26ec832582f5c86d6bf853b2