### PR TITLE
fix: ensure esm modules load

### DIFF
--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -5,7 +5,10 @@ import { loadSettings, settings as store } from './common/settings';
 import type { Settings as BaseSettings } from './common/settings';
 import { formatString } from './common/stringformat';
 import { closeCache } from './common/requestCache';
-import { initialize as initializeRemote, enable as enableRemote } from '@electron/remote/main';
+import {
+  initialize as initializeRemote,
+  enable as enableRemote
+} from '@electron/remote/main/index.js';
 import type { IpcMainEvent } from 'electron';
 
 const debug = debugModule('main');
@@ -32,7 +35,7 @@ interface AppWindowSettings {
   fullscreenable: boolean;
   kiosk: boolean;
   darkTheme: boolean;
-    thickFrame: boolean;
+  thickFrame: boolean;
 }
 
 interface WebPreferencesSettings {

--- a/app/ts/main/index.ts
+++ b/app/ts/main/index.ts
@@ -1,7 +1,7 @@
-import './singlewhois';
-import './bw';
-import './bwa';
-import './to';
-import './cache';
-import './ai';
-import './history';
+import './singlewhois.js';
+import './bw.js';
+import './bwa.js';
+import './to.js';
+import './cache.js';
+import './ai.js';
+import './history.js';

--- a/app/ts/renderer/bw.ts
+++ b/app/ts/renderer/bw.ts
@@ -1,5 +1,5 @@
 /* Bulk whois handling */
-import './bw/wordlistinput'; // Bulk whois by wordlist input
-import './bw/fileinput'; // Bulk whois by file input
-import './bw/process'; // Bulk whois requests processing
-import './bw/export'; // Export processing
+import './bw/wordlistinput.js'; // Bulk whois by wordlist input
+import './bw/fileinput.js'; // Bulk whois by file input
+import './bw/process.js'; // Bulk whois requests processing
+import './bw/export.js'; // Export processing

--- a/app/ts/renderer/bwa.ts
+++ b/app/ts/renderer/bwa.ts
@@ -1,3 +1,3 @@
 /* Bulk whois analyser handling */
-import './bwa/fileinput';
-import './bwa/analyser';
+import './bwa/fileinput.js';
+import './bwa/analyser.js';

--- a/app/ts/renderer/index.ts
+++ b/app/ts/renderer/index.ts
@@ -1,7 +1,7 @@
-import './singlewhois';
-import './bw';
-import './bwa';
-import './darkmode';
-import './options';
-import './to';
-import './history';
+import './singlewhois.js';
+import './bw.js';
+import './bwa.js';
+import './darkmode.js';
+import './options.js';
+import './to.js';
+import './history.js';

--- a/scripts/create-esm-links.cjs
+++ b/scripts/create-esm-links.cjs
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+
+const distDir = path.join(__dirname, '..', 'dist', 'app', 'ts');
+
+function processDir(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      processDir(full);
+    } else if (entry.isFile() && entry.name.endsWith('.js')) {
+      const base = full.slice(0, -3);
+      if (!fs.existsSync(base)) {
+        fs.symlinkSync(entry.name, base); // relative link within same dir
+      }
+    }
+  }
+}
+
+processDir(distDir);

--- a/scripts/postbuild.cjs
+++ b/scripts/postbuild.cjs
@@ -57,3 +57,6 @@ const htmlOut = mainTemplate({});
 const outPath = path.join(distDir, 'html', 'mainPanel.html');
 fs.rmSync(outPath, { force: true });
 fs.writeFileSync(outPath, htmlOut);
+
+// Create extensionless symlinks for Node ESM
+require('./create-esm-links.cjs');


### PR DESCRIPTION
## Summary
- allow Electron remote to import with full path
- load entry modules using `.js` suffix
- symlink extensionless builds for Node ESM

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d524556ac8325be14600e637d5f7d