### PR TITLE
Fix availability model prediction and start scripts

### DIFF
--- a/app/ts/ai/availabilityModel.ts
+++ b/app/ts/ai/availabilityModel.ts
@@ -38,15 +38,16 @@ export async function loadModel(modelPath: string = settings.ai.modelPath): Prom
 
 export function predict(text: string): 'available' | 'unavailable' | 'error' {
   if (!model) return 'error';
+  const m = model as Model;
   try {
     const tokens = tokenize(text);
-    const vocabSize = model.vocabulary.length;
-    const totalDocs = model.classTotals.available + model.classTotals.unavailable;
+    const vocabSize = m.vocabulary.length;
+    const totalDocs = m.classTotals.available + m.classTotals.unavailable;
     function score(label: Label): number {
-      let s = Math.log(model.classTotals[label] / totalDocs);
+      let s = Math.log(m.classTotals[label] / totalDocs);
       for (const t of tokens) {
-        const count = model.tokenCounts[label][t] || 0;
-        s += Math.log((count + 1) / (model.tokenTotals[label] + vocabSize));
+        const count = m.tokenCounts[label][t] || 0;
+        s += Math.log((count + 1) / (m.tokenTotals[label] + vocabSize));
       }
       return s;
     }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Bulk whois lookup tool",
   "main": "./dist/app/ts/main.js",
   "scripts": {
-    "start": "npm run build && npm run postbuild && electron .",
+    "start": "npm run build && npm run postbuild && cross-env NODE_OPTIONS=--experimental-specifier-resolution=node electron .",
     "debug-powershell": "@powershell -Command $env:DEBUG='*';npm start;",
     "debug-cmd": "set DEBUG=* & npm start",
     "debug": "cross-env DEBUG=* npm start",
@@ -18,7 +18,7 @@
     "build:css": "postcss app/css/*.css -d dist/app/css --no-map",
     "watch": "cross-env DEBUG=* tsc -w",
     "watch-assets": "node scripts/watch-assets.cjs",
-    "dev": "npm run build && concurrently \"npm:watch\" \"npm:watch-assets\" \"electronmon .\"",
+    "dev": "npm run build && concurrently \"npm:watch\" \"npm:watch-assets\" \"cross-env NODE_OPTIONS=--experimental-specifier-resolution=node electronmon .\"",
     "lint": "eslint \"app/**/*.ts\" \"test/**/*.ts\"",
     "format": "prettier --write --ignore-path .prettierignore .",
     "format:check": "prettier --check --ignore-path .prettierignore .",


### PR DESCRIPTION
## Summary
- guard availability model null references
- ensure Electron runs with Node's specifier resolution

## Testing
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_685d53423eb88325906badfbb5b4c0de