### PR TITLE
Fix dynamic requires for ESM

### DIFF
--- a/app/ts/common/lookup.ts
+++ b/app/ts/common/lookup.ts
@@ -1,5 +1,8 @@
 import psl from 'psl';
-import puny from 'punycode';
+import { createRequire as nodeCreateRequire } from 'module';
+const moduleRequire =
+  typeof require === 'undefined' ? nodeCreateRequire(eval('import.meta.url')) : require;
+const puny = moduleRequire('punycode/') as typeof import('punycode');
 import uts46 from 'idna-uts46';
 import whois from 'whois';
 import debugModule from 'debug';

--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -1,10 +1,13 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as electron from 'electron';
+import { createRequire as nodeCreateRequire } from 'module';
+const moduleRequire =
+  typeof require === 'undefined' ? nodeCreateRequire(eval('import.meta.url')) : require;
 let remote: typeof import('@electron/remote') | undefined;
 try {
   // Dynamically require to avoid issues when Electron bindings are unavailable
-  remote = require('@electron/remote');
+  remote = moduleRequire('@electron/remote');
 } catch {
   remote = (electron as any).remote;
 }
@@ -65,8 +68,8 @@ export interface Settings {
 }
 
 const rawModule = fs.existsSync('./appsettings')
-  ? require('./appsettings')
-  : require('../appsettings');
+  ? moduleRequire('./appsettings')
+  : moduleRequire('../appsettings');
 const settingsModule: { settings: Settings } = rawModule.settings ? rawModule : rawModule.default;
 let { settings } = settingsModule;
 const defaultSettings: Settings = JSON.parse(JSON.stringify(settings));


### PR DESCRIPTION
## Summary
- load remote module via `createRequire` that works in both CommonJS and ESM
- load punycode via userland module to avoid deprecation warning

## Testing
- `npm test`
- `npm run lint`
- `npm run format` *(files were already formatted)*
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_685d6684de2c832590e1717fa4ce498f