### PR TITLE
Fix typecheck imports for compiled templates

### DIFF
--- a/types/compiled-templates.d.ts
+++ b/types/compiled-templates.d.ts
@@ -1,1 +1,2 @@
 declare module 'app/compiled-templates/*.cjs';
+declare module '../../compiled-templates/*.cjs';


### PR DESCRIPTION
## Summary
- expand `compiled-templates` type declarations to cover relative imports

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_685d7f62c5108325a0ceb3c7dc6ec1b4