### PR TITLE
Fix: load renderer via ESM

### DIFF
--- a/app/ts/mainPanel.ts
+++ b/app/ts/mainPanel.ts
@@ -1,15 +1,8 @@
-if (typeof module === 'object') {
-  (window as any).module = module;
-  // Prevent Electron from treating inline scripts as modules
-  (globalThis as any).module = undefined as any;
-}
-
-require('./common/fontawesome.js');
-
-(window as any).$ = (window as any).jQuery = require('jquery');
-if ((window as any).module) (globalThis as any).module = (window as any).module;
+import './common/fontawesome.js';
+import $ from 'jquery';
+(window as any).$ = (window as any).jQuery = $;
 
 // The main HTML file is precompiled and loaded directly, so loading
 // additional content at runtime is unnecessary.
-// require('./renderer/loadcontents.js');
-require('./renderer.js');
+// import './renderer/loadcontents.js';
+import './renderer.js';


### PR DESCRIPTION
## Summary
- migrate mainPanel.ts to ESM imports

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_685d807e86e083258027dd16093f8162