### PR TITLE
feat: add dirname compatibility helper

### DIFF
--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { fileURLToPath } from 'url';
+import { dirnameCompat } from '../utils/dirnameCompat';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const baseDir = dirnameCompat();
 import * as electron from 'electron';
 import { createRequire as nodeCreateRequire } from 'module';
 const moduleRequire =
@@ -97,7 +97,7 @@ const isMainProcess = ((): boolean => {
   }
 })();
 
-const userDataPath = path.join(__dirname, '..', '..', 'data');
+const userDataPath = path.join(baseDir, '..', '..', 'data');
 
 export function getUserDataPath(): string {
   return userDataPath;

--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -1,8 +1,8 @@
 import { app, BrowserWindow, Menu, ipcMain, dialog } from 'electron';
 import * as path from 'path';
-import { fileURLToPath } from 'url';
+import { dirnameCompat } from './utils/dirnameCompat';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const baseDir = dirnameCompat();
 import debugModule from 'debug';
 import { loadSettings, settings as store } from './common/settings';
 import type { Settings as BaseSettings } from './common/settings';
@@ -99,7 +99,7 @@ app.on('ready', async function () {
     show: appWindow.show, // Show app before load (default: false)
     height: appWindow.height, // Window height in pixels (default: 700)
     width: appWindow.width, // Window width in pixels (default: 1000)
-    icon: path.join(__dirname, appWindow.icon), // App icon path
+    icon: path.join(baseDir, appWindow.icon), // App icon path
     center: appWindow.center, // Center window
     minimizable: appWindow.minimizable, // Make window minimizable
     maximizable: appWindow.maximizable, // Make window maximizable
@@ -122,7 +122,7 @@ app.on('ready', async function () {
       backgroundThrottling: webPreferences.backgroundThrottling, // Whether to throttle animations and timers when the page becomes background
       offscreen: webPreferences.offscreen, // enable offscreen rendering for the browser window
       spellcheck: webPreferences.spellcheck, // Enable builtin spellchecker
-      preload: path.join(__dirname, 'preload.js')
+      preload: path.join(baseDir, 'preload.js')
     }
   });
 
@@ -131,7 +131,7 @@ app.on('ready', async function () {
   // mainWindow, Main window URL load
   const loadPath = path.isAbsolute(appUrl.pathname)
     ? path.normalize(appUrl.pathname)
-    : path.join(__dirname, appUrl.pathname);
+    : path.join(baseDir, appUrl.pathname);
   mainWindow.loadFile(loadPath);
 
   // Some more debugging messages

--- a/app/ts/renderer/i18n.ts
+++ b/app/ts/renderer/i18n.ts
@@ -1,14 +1,14 @@
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { dirnameCompat } from '../utils/dirnameCompat';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const baseDir = dirnameCompat();
 import Handlebars from 'handlebars/runtime';
 
 let translations: Record<string, string> = {};
 
 export async function loadTranslations(lang: string): Promise<void> {
-  const file = path.join(__dirname, '..', 'locales', `${lang}.json`);
+  const file = path.join(baseDir, '..', 'locales', `${lang}.json`);
   try {
     const raw = await fs.promises.readFile(file, 'utf8');
     translations = JSON.parse(raw);

--- a/app/ts/renderer/options.ts
+++ b/app/ts/renderer/options.ts
@@ -1,9 +1,9 @@
 import $ from 'jquery';
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { dirnameCompat } from '../utils/dirnameCompat';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const baseDir = dirnameCompat();
 const electron = (window as any).electron as {
   send: (channel: string, ...args: any[]) => void;
   invoke: (channel: string, ...args: any[]) => Promise<any>;
@@ -128,7 +128,7 @@ function startStatsWorker(): void {
       workerPath = new URL('./renderer/workers/statsWorker.js', eval('import.meta.url')).pathname;
     } catch {
       // Fallback for CommonJS environments like Jest
-      workerPath = path.join(__dirname, 'renderer', 'workers', 'statsWorker.js');
+      workerPath = path.join(baseDir, 'renderer', 'workers', 'statsWorker.js');
     }
     statsWorker = new Worker(workerPath, {
       workerData: {

--- a/app/ts/utils/dirnameCompat.ts
+++ b/app/ts/utils/dirnameCompat.ts
@@ -1,0 +1,8 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+export function dirnameCompat(): string {
+  return typeof __filename !== 'undefined'
+    ? path.dirname(__filename)
+    : path.dirname(fileURLToPath(import.meta.url));
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ export default {
   testEnvironment: 'node',
   testMatch: ['**/test/**/*.test.ts'],
   transform: {
-    '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.json', diagnostics: false }],
+    '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.json', diagnostics: false, useESM: true }],
     '^.+\\.m?js$': 'babel-jest'
   },
   transformIgnorePatterns: ['node_modules/(?!(change-case|html-entities)/)'],

--- a/readme.md
+++ b/readme.md
@@ -217,6 +217,20 @@ Use `npm run dev` to watch source files and automatically reload the application
 
 Run `npm run format` before committing to apply Prettier formatting. CI will verify formatting with `npm run format:check`.
 
+### Resolving paths
+
+Modules within Whoisdigger may execute in both CommonJS and ESM contexts. Use
+`dirnameCompat()` from `app/ts/utils/dirnameCompat.ts` to obtain a directory
+name that works in either environment:
+
+```ts
+import { dirnameCompat } from './utils/dirnameCompat';
+const __dirname = dirnameCompat();
+```
+
+The helper checks for `__filename` in CommonJS and falls back to
+`fileURLToPath(import.meta.url)` when running as an ES module.
+
 ## Settings
 
 Whoisdigger uses a settings file that rules how the application behaves overall, this can be achieved by either using the preload settings file or change the `appsettings.ts` inside `js`.

--- a/scripts/create-esm-links.js
+++ b/scripts/create-esm-links.js
@@ -1,10 +1,9 @@
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { dirnameCompat } from './dirnameCompat.js';
+const baseDir = dirnameCompat();
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-const distDir = path.join(__dirname, '..', 'dist', 'app', 'ts');
+const distDir = path.join(baseDir, '..', 'dist', 'app', 'ts');
 
 function processDir(dir) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {

--- a/scripts/dirnameCompat.js
+++ b/scripts/dirnameCompat.js
@@ -1,0 +1,8 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+export function dirnameCompat() {
+  return typeof __filename !== 'undefined'
+    ? path.dirname(__filename)
+    : path.dirname(fileURLToPath(import.meta.url));
+}

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -4,15 +4,16 @@ import { spawnSync } from 'child_process';
 import { copyRecursiveSync } from './copyRecursive.js';
 import { precompileTemplates } from './precompileTemplates.js';
 import debugModule from 'debug';
+import { dirnameCompat } from './dirnameCompat.js';
 import { fileURLToPath } from 'url';
 import Handlebars from 'handlebars/runtime.js';
 import './create-esm-links.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const baseDir = dirnameCompat();
 const debug = debugModule('postbuild');
 
 const folders = ['html', 'html/templates', 'fonts', 'icons', 'compiled-templates', 'locales'];
-const rootDir = path.join(__dirname, '..');
+const rootDir = path.join(baseDir, '..');
 const appDir = path.join(rootDir, 'app');
 const distDir = path.join(rootDir, 'dist', 'app');
 

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -3,12 +3,13 @@ import path from 'path';
 import { spawnSync } from 'child_process';
 import debugModule from 'debug';
 import { precompileTemplates } from './precompileTemplates.js';
+import { dirnameCompat } from './dirnameCompat.js';
 import { fileURLToPath } from 'url';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const baseDir = dirnameCompat();
 const debug = debugModule('prebuild');
 
-const rootDir = path.join(__dirname, '..');
+const rootDir = path.join(baseDir, '..');
 const modulesPath = path.join(rootDir, 'node_modules');
 
 if (!fs.existsSync(modulesPath)) {

--- a/scripts/precompileTemplates.js
+++ b/scripts/precompileTemplates.js
@@ -1,24 +1,18 @@
 import fs from 'fs';
 import path from 'path';
 import { spawnSync } from 'child_process';
+import { dirnameCompat } from './dirnameCompat.js';
 import { fileURLToPath } from 'url';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const baseDir = dirnameCompat();
 
 export function precompileTemplates(
-  outputDir = path.join(__dirname, '..', 'app', 'compiled-templates')
+  outputDir = path.join(baseDir, '..', 'app', 'compiled-templates')
 ) {
-  const templatesDir = path.join(__dirname, '..', 'app', 'html', 'templates');
+  const templatesDir = path.join(baseDir, '..', 'app', 'html', 'templates');
   fs.mkdirSync(outputDir, { recursive: true });
 
-  const handlebarBin = path.join(
-    __dirname,
-    '..',
-    'node_modules',
-    'handlebars',
-    'bin',
-    'handlebars'
-  );
+  const handlebarBin = path.join(baseDir, '..', 'node_modules', 'handlebars', 'bin', 'handlebars');
 
   for (const file of fs.readdirSync(templatesDir)) {
     if (path.extname(file) !== '.hbs') continue;

--- a/test/e2e/run.js
+++ b/test/e2e/run.js
@@ -6,22 +6,22 @@ import { spawn } from 'child_process';
 import net from 'net';
 import { remote } from 'webdriverio';
 import debugModule from 'debug';
-import { fileURLToPath } from 'url';
+import { dirnameCompat } from '../../scripts/dirnameCompat.js';
 import electron from 'electron';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const baseDir = dirnameCompat();
 const debug = debugModule('test:e2e');
 
 (async () => {
   const electronPath = electron;
-  const appPath = path.resolve(__dirname, '..', '..', 'dist', 'app', 'ts', 'main.js');
+  const appPath = path.resolve(baseDir, '..', '..', 'dist', 'app', 'ts', 'main.js');
 
-  const artifactsDir = path.join(__dirname, 'artifacts');
+  const artifactsDir = path.join(baseDir, 'artifacts');
   fs.mkdirSync(artifactsDir, { recursive: true });
   const userDataDir = path.join(os.tmpdir(), `whoisdigger-test-${Date.now()}`);
   fs.mkdirSync(userDataDir, { recursive: true });
 
-  const chromedriverPath = path.join(__dirname, '..', '..', 'node_modules', '.bin', 'chromedriver');
+  const chromedriverPath = path.join(baseDir, '..', '..', 'node_modules', '.bin', 'chromedriver');
 
   const findPort = async (port) => {
     return new Promise((resolve) => {


### PR DESCRIPTION
## Summary
- add `dirnameCompat` utility for use in both CJS and ESM
- replace direct `fileURLToPath(import.meta.url)` calls
- document path helper in README
- adjust Jest config to compile modules as ESM

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Cannot use 'import.meta' outside a module)*
- `npm run test:e2e` *(fails: chromedriver ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_685d8df75df48325b2a113f5b6e1b75c