### PR TITLE
Fix build errors with explicit Express types

### DIFF
--- a/app/ts/server/index.ts
+++ b/app/ts/server/index.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { Request, Response } from 'express';
 import { lookup } from '../common/lookup';
 import { lookupDomains, CliOptions } from '../cli';
 import { fileURLToPath } from 'url';
@@ -7,7 +7,7 @@ export function createServer() {
   const app = express();
   app.use(express.json());
 
-  app.post('/lookup', async (req, res) => {
+  app.post('/lookup', async (req: Request, res: Response) => {
     const domain = req.body?.domain;
     if (!domain || typeof domain !== 'string') {
       res.status(400).json({ error: 'domain required' });
@@ -21,7 +21,7 @@ export function createServer() {
     }
   });
 
-  app.post('/bulk-lookup', async (req, res) => {
+  app.post('/bulk-lookup', async (req: Request, res: Response) => {
     const body = req.body ?? {};
     const opts: CliOptions = {
       domains: Array.isArray(body.domains) ? body.domains : [],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "strict": true,
     "skipLibCheck": true,
     "moduleDetection": "force",
-    "types": ["node", "jest", "better-sqlite3"],
+    "types": ["node", "jest", "better-sqlite3", "express"],
     "typeRoots": [
       "./node_modules/@types",
       "./types",


### PR DESCRIPTION
## Summary
- include `express` type definitions in `tsconfig.json`
- annotate Express handler parameters in the server

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*
- `npm run test:e2e` *(fails: chromedriver ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6860567163808325a5e7cd314782ed85