### PR TITLE
fix: handle esm import urls safely

### DIFF
--- a/app/ts/server/index.ts
+++ b/app/ts/server/index.ts
@@ -40,7 +40,15 @@ export function createServer() {
   return app;
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+let moduleUrl: string | undefined;
+try {
+  // Avoid syntax errors in CommonJS environments
+  moduleUrl = eval('import.meta.url') as string;
+} catch {
+  moduleUrl = undefined;
+}
+
+if (moduleUrl && process.argv[1] === fileURLToPath(moduleUrl)) {
   const port = Number(process.env.PORT) || 3000;
   createServer().listen(port, () => {
     console.log(`Server listening on port ${port}`);

--- a/app/ts/utils/dirnameCompat.ts
+++ b/app/ts/utils/dirnameCompat.ts
@@ -2,7 +2,17 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 export function dirnameCompat(): string {
-  return typeof __filename !== 'undefined'
-    ? path.dirname(__filename)
-    : path.dirname(fileURLToPath(import.meta.url));
+  if (typeof __dirname !== 'undefined') {
+    return __dirname;
+  }
+
+  try {
+    // `import.meta.url` is only available in ESM environments. Using
+    // `eval` avoids a syntax error when the code is executed as CommonJS.
+    const metaUrl = eval('import.meta.url') as string;
+    return path.dirname(fileURLToPath(metaUrl));
+  } catch {
+    // Fallback to current working directory as a last resort.
+    return process.cwd();
+  }
 }


### PR DESCRIPTION
## Summary
- use `eval('import.meta.url')` in `dirnameCompat` to avoid syntax error when run in CJS
- guard server startup check against `import.meta.url`

## Testing
- `npm test`
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm run test:e2e` *(fails: chromedriver ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68605a0c02d8832591c986e74a2ab2b5