### PR TITLE
Fix import.meta issue with ESM build

### DIFF
--- a/app/ts/ai/availabilityModel.ts
+++ b/app/ts/ai/availabilityModel.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import debugModule from 'debug';
-import { settings, getUserDataPath } from '../common/settings';
+import { settings, getUserDataPath } from '../common/settings.js';
 
 const debug = debugModule('ai.availabilityModel');
 

--- a/app/ts/ai/modelDownloader.ts
+++ b/app/ts/ai/modelDownloader.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import https from 'https';
 import debugModule from 'debug';
-import { settings, getUserDataPath } from '../common/settings';
+import { settings, getUserDataPath } from '../common/settings.js';
 
 const debug = debugModule('ai.modelDownloader');
 

--- a/app/ts/ai/openaiSuggest.ts
+++ b/app/ts/ai/openaiSuggest.ts
@@ -1,5 +1,5 @@
 import debugModule from 'debug';
-import { settings } from '../common/settings';
+import { settings } from '../common/settings.js';
 
 const debug = debugModule('ai.openaiSuggest');
 

--- a/app/ts/cli.ts
+++ b/app/ts/cli.ts
@@ -3,14 +3,14 @@ import path from 'path';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import JSZip from 'jszip';
-import { lookup as whoisLookup } from './common/lookup';
-import { settings } from './common/settings';
-import { purgeExpired, clearCache } from './common/requestCache';
-import { isDomainAvailable, getDomainParameters, WhoisResult } from './common/availability';
-import { toJSON } from './common/parser';
-import { generateFilename } from './main/bw/export';
-import { downloadModel } from './ai/modelDownloader';
-import { suggestWords } from './ai/openaiSuggest';
+import { lookup as whoisLookup } from './common/lookup.js';
+import { settings } from './common/settings.js';
+import { purgeExpired, clearCache } from './common/requestCache.js';
+import { isDomainAvailable, getDomainParameters, WhoisResult } from './common/availability.js';
+import { toJSON } from './common/parser.js';
+import { generateFilename } from './main/bw/export.js';
+import { downloadModel } from './ai/modelDownloader.js';
+import { suggestWords } from './ai/openaiSuggest.js';
 
 export interface CliOptions {
   domains: string[];

--- a/app/ts/common/availability.ts
+++ b/app/ts/common/availability.ts
@@ -1,9 +1,9 @@
 import debugModule from 'debug';
-import { getDate } from './conversions';
-import { toJSON } from './parser';
-import { settings as appSettings, Settings } from './settings';
-import { checkPatterns } from './whoiswrapper/patterns';
-import { predict as aiPredict } from '../ai/availabilityModel';
+import { getDate } from './conversions.js';
+import { toJSON } from './parser.js';
+import { settings as appSettings, Settings } from './settings.js';
+import { checkPatterns } from './whoiswrapper/patterns.js';
+import { predict as aiPredict } from '../ai/availabilityModel.js';
 
 const debug = debugModule('common.whoisWrapper');
 let settings: Settings = appSettings;

--- a/app/ts/common/dnsLookup.ts
+++ b/app/ts/common/dnsLookup.ts
@@ -1,10 +1,10 @@
 import dns from 'dns/promises';
 import psl from 'psl';
 import debugModule from 'debug';
-import { convertDomain } from './lookup';
-import { settings, Settings } from './settings';
-import { getCached, setCached, CacheOptions } from './requestCache';
-import { DnsLookupError, Result } from './errors';
+import { convertDomain } from './lookup.js';
+import { settings, Settings } from './settings.js';
+import { getCached, setCached, CacheOptions } from './requestCache.js';
+import { DnsLookupError, Result } from './errors.js';
 
 const debug = debugModule('common.dnsLookup');
 

--- a/app/ts/common/history.ts
+++ b/app/ts/common/history.ts
@@ -2,7 +2,7 @@ import Database from 'better-sqlite3';
 import type { Database as DatabaseType } from 'better-sqlite3';
 import fs from 'fs';
 import path from 'path';
-import { getUserDataPath } from './settings';
+import { getUserDataPath } from './settings.js';
 import debugModule from 'debug';
 
 const debug = debugModule('common.history');

--- a/app/ts/common/index.ts
+++ b/app/ts/common/index.ts
@@ -1,11 +1,11 @@
-import * as Conversions from './conversions';
-import LineHelper from './lineHelper';
-import { formatString } from './stringformat';
-import { parseRawData as ParseRawData } from './parser';
-import { lookup as WhoisLookup } from './lookup';
-import DnsLookup from './dnsLookup';
-import WordlistTools from './wordlist';
-import { getProxy } from './proxy';
+import * as Conversions from './conversions.js';
+import LineHelper from './lineHelper.js';
+import { formatString } from './stringformat.js';
+import { parseRawData as ParseRawData } from './parser.js';
+import { lookup as WhoisLookup } from './lookup.js';
+import DnsLookup from './dnsLookup.js';
+import WordlistTools from './wordlist.js';
+import { getProxy } from './proxy.js';
 
 export {
   Conversions,

--- a/app/ts/common/lookup.ts
+++ b/app/ts/common/lookup.ts
@@ -6,9 +6,9 @@ const puny = moduleRequire('punycode/') as typeof import('punycode');
 import uts46 from 'idna-uts46';
 import whois from 'whois';
 import debugModule from 'debug';
-import { settings, Settings } from './settings';
-import { getCached, setCached, CacheOptions } from './requestCache';
-import { getProxy } from './proxy';
+import { settings, Settings } from './settings.js';
+import { getCached, setCached, CacheOptions } from './requestCache.js';
+import { getProxy } from './proxy.js';
 
 const debug = debugModule('common.whoisWrapper');
 

--- a/app/ts/common/proxy.ts
+++ b/app/ts/common/proxy.ts
@@ -1,4 +1,4 @@
-import { settings } from './settings';
+import { settings } from './settings.js';
 import { isIP } from 'net';
 
 export interface ProxyInfo {

--- a/app/ts/common/requestCache.ts
+++ b/app/ts/common/requestCache.ts
@@ -2,7 +2,7 @@ import Database from 'better-sqlite3';
 import type { Database as DatabaseType } from 'better-sqlite3';
 import fs from 'fs';
 import path from 'path';
-import { settings, getUserDataPath } from './settings';
+import { settings, getUserDataPath } from './settings.js';
 import debugModule from 'debug';
 
 const debug = debugModule('common.requestCache');

--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { dirnameCompat } from '../utils/dirnameCompat';
+import { dirnameCompat } from '../utils/dirnameCompat.js';
 
 const baseDir = dirnameCompat();
 import * as electron from 'electron';

--- a/app/ts/common/tools.ts
+++ b/app/ts/common/tools.ts
@@ -1,4 +1,4 @@
-import * as WordlistTools from './wordlist';
+import * as WordlistTools from './wordlist.js';
 
 export interface ProcessOptions {
   prefix?: string;

--- a/app/ts/common/whoiswrapper/patterns.ts
+++ b/app/ts/common/whoiswrapper/patterns.ts
@@ -1,7 +1,7 @@
-import { settings as appSettings, Settings } from '../settings';
-import { toJSON } from '../parser';
-import { getDomainParameters, WhoisResult } from '../availability';
-import { getDate } from '../conversions';
+import { settings as appSettings, Settings } from '../settings.js';
+import { toJSON } from '../parser.js';
+import { getDomainParameters, WhoisResult } from '../availability.js';
+import { getDate } from '../conversions.js';
 
 export interface PatternFunction {
   (context: PatternContext): boolean;

--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -1,13 +1,13 @@
 import { app, BrowserWindow, Menu, ipcMain, dialog } from 'electron';
 import * as path from 'path';
-import { dirnameCompat } from './utils/dirnameCompat';
+import { dirnameCompat } from './utils/dirnameCompat.js';
 
 const baseDir = dirnameCompat();
 import debugModule from 'debug';
-import { loadSettings, settings as store } from './common/settings';
-import type { Settings as BaseSettings } from './common/settings';
-import { formatString } from './common/stringformat';
-import { closeCache } from './common/requestCache';
+import { loadSettings, settings as store } from './common/settings.js';
+import type { Settings as BaseSettings } from './common/settings.js';
+import { formatString } from './common/stringformat.js';
+import { closeCache } from './common/requestCache.js';
 import {
   initialize as initializeRemote,
   enable as enableRemote

--- a/app/ts/main/ai.ts
+++ b/app/ts/main/ai.ts
@@ -1,8 +1,8 @@
 import { ipcMain } from 'electron';
 import debugModule from 'debug';
-import { settings } from '../common/settings';
-import { downloadModel } from '../ai/modelDownloader';
-import { suggestWords } from '../ai/openaiSuggest';
+import { settings } from '../common/settings.js';
+import { downloadModel } from '../ai/modelDownloader.js';
+import { suggestWords } from '../ai/openaiSuggest.js';
 
 const debug = debugModule('main.ai');
 

--- a/app/ts/main/bw/export.ts
+++ b/app/ts/main/bw/export.ts
@@ -1,15 +1,15 @@
 import electron from 'electron';
 import fs from 'fs';
 import path from 'path';
-import * as conversions from '../../common/conversions';
+import * as conversions from '../../common/conversions.js';
 import debugModule from 'debug';
 const debug = debugModule('main.bw.export');
 import JSZip from 'jszip';
-import { formatString } from '../../common/stringformat';
+import { formatString } from '../../common/stringformat.js';
 
 const { app, BrowserWindow, Menu, ipcMain, dialog, remote, shell } = electron;
 
-import { getSettings } from '../../common/settings';
+import { getSettings } from '../../common/settings.js';
 
 export function generateFilename(ext: string): string {
   function pad(n: number): string {

--- a/app/ts/main/bw/fileinput.ts
+++ b/app/ts/main/bw/fileinput.ts
@@ -3,9 +3,9 @@ import debugModule from 'debug';
 const debug = debugModule('main.bw.fileinput');
 
 const { app, BrowserWindow, Menu, ipcMain, dialog } = electron;
-import { formatString } from '../../common/stringformat';
+import { formatString } from '../../common/stringformat.js';
 
-import { getSettings } from '../../common/settings';
+import { getSettings } from '../../common/settings.js';
 
 /*
   ipcMain.on('bw:input.file', function(...) {...});

--- a/app/ts/main/bw/process.defaults.ts
+++ b/app/ts/main/bw/process.defaults.ts
@@ -1,4 +1,4 @@
-import type { BulkWhois } from './types';
+import type { BulkWhois } from './types.js';
 
 const defaultFirstValue = null, // Default that is equivalent or similar to null value: null, undefined, false..
   defaultSecondValue = 0, // Default numeric starting value

--- a/app/ts/main/bw/process.ts
+++ b/app/ts/main/bw/process.ts
@@ -2,18 +2,18 @@ import electron from 'electron';
 import type { IpcMainEvent } from 'electron';
 import debugModule from 'debug';
 const debug = debugModule('main.bw.process');
-import defaultBulkWhois from './process.defaults';
+import defaultBulkWhois from './process.defaults.js';
 
-import type { BulkWhois, DomainSetup } from './types';
-import { compileQueue, getDomainSetup } from './queue';
-import { processDomain, counter } from './scheduler';
-import { resetObject } from '../../common/resetObject';
-import { resetUiCounters } from './auxiliary';
+import type { BulkWhois, DomainSetup } from './types.js';
+import { compileQueue, getDomainSetup } from './queue.js';
+import { processDomain, counter } from './scheduler.js';
+import { resetObject } from '../../common/resetObject.js';
+import { resetUiCounters } from './auxiliary.js';
 
-import { getSettings } from '../../common/settings';
+import { getSettings } from '../../common/settings.js';
 
 const { app, BrowserWindow, Menu, ipcMain, dialog, remote } = electron;
-import { formatString } from '../../common/stringformat';
+import { formatString } from '../../common/stringformat.js';
 
 let bulkWhois: BulkWhois; // BulkWhois object
 let reqtime: number[] = [];
@@ -232,4 +232,4 @@ ipcMain.on('bw:lookup.stop', function (event: IpcMainEvent) {
 });
 
 // Re-export for consumers that imported from this module previously
-export { getDomainSetup } from './queue';
+export { getDomainSetup } from './queue.js';

--- a/app/ts/main/bw/queue.ts
+++ b/app/ts/main/bw/queue.ts
@@ -1,7 +1,7 @@
 import debugModule from 'debug';
-import { formatString } from '../../common/stringformat';
-import type { Settings } from '../../common/settings';
-import type { DomainSetup } from './types';
+import { formatString } from '../../common/stringformat.js';
+import type { Settings } from '../../common/settings.js';
+import type { DomainSetup } from './types.js';
 
 const debug = debugModule('main.bw.queue');
 

--- a/app/ts/main/bw/resultHandler.ts
+++ b/app/ts/main/bw/resultHandler.ts
@@ -1,14 +1,14 @@
 import debugModule from 'debug';
-import { isDomainAvailable, getDomainParameters } from '../../common/availability';
-import { toJSON } from '../../common/parser';
+import { isDomainAvailable, getDomainParameters } from '../../common/availability.js';
+import { toJSON } from '../../common/parser.js';
 import { performance } from 'perf_hooks';
-import { getSettings } from '../../common/settings';
-import { formatString } from '../../common/stringformat';
-import type { BulkWhois, ProcessedResult } from './types';
-import * as dns from '../../common/dnsLookup';
-import { Result, DnsLookupError } from '../../common/errors';
+import { getSettings } from '../../common/settings.js';
+import { formatString } from '../../common/stringformat.js';
+import type { BulkWhois, ProcessedResult } from './types.js';
+import * as dns from '../../common/dnsLookup.js';
+import { Result, DnsLookupError } from '../../common/errors.js';
 import type { IpcMainEvent } from 'electron';
-import { addEntry as addHistoryEntry } from '../../common/history';
+import { addEntry as addHistoryEntry } from '../../common/history.js';
 
 const debug = debugModule('main.bw.resultHandler');
 

--- a/app/ts/main/bw/scheduler.ts
+++ b/app/ts/main/bw/scheduler.ts
@@ -1,13 +1,13 @@
 import debugModule from 'debug';
 import { performance } from 'perf_hooks';
-import { lookup as whoisLookup } from '../../common/lookup';
-import * as dns from '../../common/dnsLookup';
-import { Result, DnsLookupError } from '../../common/errors';
-import { formatString } from '../../common/stringformat';
-import { msToHumanTime } from '../../common/conversions';
-import { getSettings } from '../../common/settings';
-import type { BulkWhois, DomainSetup } from './types';
-import { processData } from './resultHandler';
+import { lookup as whoisLookup } from '../../common/lookup.js';
+import * as dns from '../../common/dnsLookup.js';
+import { Result, DnsLookupError } from '../../common/errors.js';
+import { formatString } from '../../common/stringformat.js';
+import { msToHumanTime } from '../../common/conversions.js';
+import { getSettings } from '../../common/settings.js';
+import type { BulkWhois, DomainSetup } from './types.js';
+import { processData } from './resultHandler.js';
 import type { IpcMainEvent } from 'electron';
 
 const debug = debugModule('main.bw.scheduler');

--- a/app/ts/main/bwa/fileinput.ts
+++ b/app/ts/main/bwa/fileinput.ts
@@ -3,7 +3,7 @@ import debugModule from 'debug';
 const debug = debugModule('main.bwa.fileinput');
 
 const { app, BrowserWindow, Menu, ipcMain, dialog } = electron;
-import { formatString } from '../../common/stringformat';
+import { formatString } from '../../common/stringformat.js';
 
 /*
   ipcMain.on('bwa:input.file', function(...) {...});

--- a/app/ts/main/cache.ts
+++ b/app/ts/main/cache.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron';
 import debugModule from 'debug';
-import { purgeExpired, clearCache } from '../common/requestCache';
+import { purgeExpired, clearCache } from '../common/requestCache.js';
 
 const debug = debugModule('main.cache');
 

--- a/app/ts/main/history.ts
+++ b/app/ts/main/history.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron';
 import debugModule from 'debug';
-import { getHistory, clearHistory } from '../common/history';
+import { getHistory, clearHistory } from '../common/history.js';
 
 const debug = debugModule('main.history');
 

--- a/app/ts/main/singlewhois.ts
+++ b/app/ts/main/singlewhois.ts
@@ -2,17 +2,17 @@ import electron from 'electron';
 import type { IpcMainEvent } from 'electron';
 import * as path from 'path';
 import * as url from 'url';
-import { lookup as whoisLookup } from '../common/lookup';
-import { isDomainAvailable } from '../common/availability';
-import { addEntry as addHistoryEntry } from '../common/history';
+import { lookup as whoisLookup } from '../common/lookup.js';
+import { isDomainAvailable } from '../common/availability.js';
+import { addEntry as addHistoryEntry } from '../common/history.js';
 import debugModule from 'debug';
 const debug = debugModule('main.singlewhois');
 
 const { app, Menu, ipcMain, dialog, remote, clipboard, shell } = electron;
-import { formatString } from '../common/stringformat';
+import { formatString } from '../common/stringformat.js';
 
-import { settings } from '../common/settings';
-import type { Settings } from '../common/settings';
+import { settings } from '../common/settings.js';
+import type { Settings } from '../common/settings.js';
 
 /*
   ipcMain.on('singlewhois:lookup', function(...) {...});

--- a/app/ts/main/to.ts
+++ b/app/ts/main/to.ts
@@ -1,7 +1,7 @@
 import electron from 'electron';
 import fs from 'fs';
 import debugModule from 'debug';
-import { processLines, ProcessOptions } from '../common/tools';
+import { processLines, ProcessOptions } from '../common/tools.js';
 
 const { ipcMain, dialog } = electron;
 const debug = debugModule('main.to');

--- a/app/ts/renderer.ts
+++ b/app/ts/renderer.ts
@@ -2,9 +2,9 @@
 import $ from 'jquery';
 
 import './renderer/index';
-import { loadSettings, settings, customSettingsLoaded } from './common/settings';
-import { loadTranslations, registerTranslationHelpers } from './renderer/i18n';
-import { formatString } from './common/stringformat';
+import { loadSettings, settings, customSettingsLoaded } from './common/settings.js';
+import { loadTranslations, registerTranslationHelpers } from './renderer/i18n.js';
+import { formatString } from './common/stringformat.js';
 
 const electron = (window as any).electron as {
   send: (channel: string, ...args: any[]) => void;
@@ -49,7 +49,7 @@ $(document).ready(async function () {
   sendDebug('Document is ready');
 
   startup();
-  void import('./renderer/navigation');
+  void import('./renderer/navigation.js');
 
   return;
 });

--- a/app/ts/renderer/bw/auxiliary.ts
+++ b/app/ts/renderer/bw/auxiliary.ts
@@ -1,4 +1,4 @@
-import { resetObject } from '../../common/resetObject';
+import { resetObject } from '../../common/resetObject.js';
 import $ from 'jquery';
 
 /*

--- a/app/ts/renderer/bw/export.ts
+++ b/app/ts/renderer/bw/export.ts
@@ -1,5 +1,5 @@
-import * as conversions from '../../common/conversions';
-import defaultExportOptions from './export.defaults';
+import * as conversions from '../../common/conversions.js';
+import defaultExportOptions from './export.defaults.js';
 import $ from 'jquery';
 
 const electron = (window as any).electron as {
@@ -7,10 +7,10 @@ const electron = (window as any).electron as {
   invoke: (channel: string, ...args: any[]) => Promise<any>;
   on: (channel: string, listener: (...args: any[]) => void) => void;
 };
-import { resetObject } from '../../common/resetObject';
-import { getExportOptions, setExportOptions, setExportOptionsEx } from './auxiliary';
+import { resetObject } from '../../common/resetObject.js';
+import { getExportOptions, setExportOptions, setExportOptionsEx } from './auxiliary.js';
 
-import { formatString } from '../../common/stringformat';
+import { formatString } from '../../common/stringformat.js';
 
 let results: any;
 let options: any;

--- a/app/ts/renderer/bw/fileinput.ts
+++ b/app/ts/renderer/bw/fileinput.ts
@@ -1,7 +1,7 @@
-import * as conversions from '../../common/conversions';
+import * as conversions from '../../common/conversions.js';
 import fs from 'fs';
 import path from 'path';
-import type { FileStats } from '../../common/fileStats';
+import type { FileStats } from '../../common/fileStats.js';
 import debugModule from 'debug';
 const debug = debugModule('renderer.bw.fileinput');
 
@@ -10,11 +10,11 @@ const electron = (window as any).electron as {
   invoke: (channel: string, ...args: any[]) => Promise<any>;
   on: (channel: string, listener: (...args: any[]) => void) => void;
 };
-import { tableReset } from './auxiliary';
+import { tableReset } from './auxiliary.js';
 import $ from 'jquery';
 
-import { formatString } from '../../common/stringformat';
-import { settings } from '../../common/settings';
+import { formatString } from '../../common/stringformat.js';
+import { settings } from '../../common/settings.js';
 
 let bwFileContents: Buffer;
 let bwFileWatcher: fs.FSWatcher | undefined;

--- a/app/ts/renderer/bw/process.ts
+++ b/app/ts/renderer/bw/process.ts
@@ -1,5 +1,5 @@
-import * as conversions from '../../common/conversions';
-import parseRawData from '../../common/parser';
+import * as conversions from '../../common/conversions.js';
+import parseRawData from '../../common/parser.js';
 const base = 10;
 
 const electron = (window as any).electron as {
@@ -9,7 +9,7 @@ const electron = (window as any).electron as {
 };
 import $ from 'jquery';
 
-import { formatString } from '../../common/stringformat';
+import { formatString } from '../../common/stringformat.js';
 
 /*
 // Receive whois lookup reply

--- a/app/ts/renderer/bw/wordlistinput.ts
+++ b/app/ts/renderer/bw/wordlistinput.ts
@@ -1,15 +1,15 @@
-import * as conversions from '../../common/conversions';
-import { settings } from '../../common/settings';
+import * as conversions from '../../common/conversions.js';
+import { settings } from '../../common/settings.js';
 
 const electron = (window as any).electron as {
   send: (channel: string, ...args: any[]) => void;
   invoke: (channel: string, ...args: any[]) => Promise<any>;
   on: (channel: string, listener: (...args: any[]) => void) => void;
 };
-import { tableReset } from './auxiliary';
+import { tableReset } from './auxiliary.js';
 import $ from 'jquery';
 
-import { formatString } from '../../common/stringformat';
+import { formatString } from '../../common/stringformat.js';
 
 let bwWordlistContents = ''; // Global wordlist input contents
 

--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -1,4 +1,4 @@
-import * as conversions from '../../common/conversions';
+import * as conversions from '../../common/conversions.js';
 import fs from 'fs';
 import Papa from 'papaparse';
 import datatables from 'datatables';
@@ -11,7 +11,7 @@ const electron = (window as any).electron as {
   on: (channel: string, listener: (...args: any[]) => void) => void;
 };
 
-import { formatString } from '../../common/stringformat';
+import { formatString } from '../../common/stringformat.js';
 
 let bwaFileContents: any;
 

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -1,11 +1,11 @@
-import * as conversions from '../../common/conversions';
+import * as conversions from '../../common/conversions.js';
 import fs from 'fs';
-import type { FileStats } from '../../common/fileStats';
+import type { FileStats } from '../../common/fileStats.js';
 import Papa from 'papaparse';
 import datatables from 'datatables';
 const dt = datatables();
 import path from 'path';
-import { settings } from '../../common/settings';
+import { settings } from '../../common/settings.js';
 
 const electron = (window as any).electron as {
   send: (channel: string, ...args: any[]) => void;
@@ -14,7 +14,7 @@ const electron = (window as any).electron as {
 };
 import $ from 'jquery';
 
-import { formatString } from '../../common/stringformat';
+import { formatString } from '../../common/stringformat.js';
 
 let bwaFileContents: any;
 let bwaFileWatcher: fs.FSWatcher | undefined;

--- a/app/ts/renderer/darkmode.ts
+++ b/app/ts/renderer/darkmode.ts
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import { settings, saveSettings } from '../common/settings';
+import { settings, saveSettings } from '../common/settings.js';
 
 function applyDarkMode(enabled: boolean): void {
   const html = document.documentElement;

--- a/app/ts/renderer/i18n.ts
+++ b/app/ts/renderer/i18n.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { dirnameCompat } from '../utils/dirnameCompat';
+import { dirnameCompat } from '../utils/dirnameCompat.js';
 
 const baseDir = dirnameCompat();
 import Handlebars from 'handlebars/runtime';

--- a/app/ts/renderer/navigation.ts
+++ b/app/ts/renderer/navigation.ts
@@ -1,7 +1,7 @@
-import { formatString } from '../common/stringformat';
+import { formatString } from '../common/stringformat.js';
 import $ from 'jquery';
-import { populateInputs } from './options';
-import { settings } from '../common/settings';
+import { populateInputs } from './options.js';
+import { settings } from '../common/settings.js';
 
 const electron = (window as any).electron as {
   send: (channel: string, ...args: any[]) => void;

--- a/app/ts/renderer/options.ts
+++ b/app/ts/renderer/options.ts
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import fs from 'fs';
 import path from 'path';
-import { dirnameCompat } from '../utils/dirnameCompat';
+import { dirnameCompat } from '../utils/dirnameCompat.js';
 
 const baseDir = dirnameCompat();
 const electron = (window as any).electron as {
@@ -19,9 +19,9 @@ import {
   loadSettings,
   customSettingsLoaded,
   getUserDataPath
-} from '../common/settings';
-import { byteToHumanFileSize } from '../common/conversions';
-import appDefaults, { appSettingsDescriptions } from '../appsettings';
+} from '../common/settings.js';
+import { byteToHumanFileSize } from '../common/conversions.js';
+import appDefaults, { appSettingsDescriptions } from '../appsettings.js';
 
 function getValue(path: string): any {
   return path.split('.').reduce((obj: any, key: string) => (obj ? obj[key] : undefined), settings);

--- a/app/ts/renderer/singlewhois.ts
+++ b/app/ts/renderer/singlewhois.ts
@@ -1,13 +1,13 @@
-import { isDomainAvailable, getDomainParameters, WhoisResult } from '../common/availability';
-import { preStringStrip, toJSON } from '../common/parser';
+import { isDomainAvailable, getDomainParameters, WhoisResult } from '../common/availability.js';
+import { preStringStrip, toJSON } from '../common/parser.js';
 
-import { getDate } from '../common/conversions';
+import { getDate } from '../common/conversions.js';
 const electron = (window as any).electron as {
   send: (channel: string, ...args: any[]) => void;
   invoke: (channel: string, ...args: any[]) => Promise<any>;
   on: (channel: string, listener: (...args: any[]) => void) => void;
 };
-import { formatString } from '../common/stringformat';
+import { formatString } from '../common/stringformat.js';
 
 import $ from 'jquery';
 (window as any).$ = (window as any).jQuery = $;

--- a/app/ts/server/index.ts
+++ b/app/ts/server/index.ts
@@ -1,6 +1,6 @@
 import express, { Request, Response } from 'express';
-import { lookup } from '../common/lookup';
-import { lookupDomains, CliOptions } from '../cli';
+import { lookup } from '../common/lookup.js';
+import { lookupDomains, CliOptions } from '../cli.js';
 import { fileURLToPath } from 'url';
 
 export function createServer() {

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,9 @@ export default {
     '^.+\\.m?js$': 'babel-jest'
   },
   transformIgnorePatterns: ['node_modules/(?!(change-case|html-entities)/)'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  },
   setupFiles: ['<rootDir>/test/jest.setup.ts'],
   collectCoverage: true,
   coverageDirectory: 'coverage'

--- a/scripts/train-ai.ts
+++ b/scripts/train-ai.ts
@@ -1,10 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 import { parseArgs } from 'util';
-import { settings, getUserDataPath } from '../app/ts/common/settings';
-import { lookup } from '../app/ts/common/lookup';
-import { toJSON } from '../app/ts/common/parser';
-import { isDomainAvailable } from '../app/ts/common/availability';
+import { settings, getUserDataPath } from '../app/ts/common/settings.js';
+import { lookup } from '../app/ts/common/lookup.js';
+import { toJSON } from '../app/ts/common/parser.js';
+import { isDomainAvailable } from '../app/ts/common/availability.js';
 
 type Label = 'available' | 'unavailable';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,16 @@
 {
   "compilerOptions": {
-    "target": "ES2019",
-    "module": "esnext",
-    "moduleResolution": "node",
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "allowJs": true,
     "noEmit": false,
-    "rootDir": "app",
+    "rootDir": ".",
     "outDir": "dist/app",
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
     "moduleDetection": "force",
     "types": ["node", "jest", "better-sqlite3", "express"],
     "typeRoots": [
@@ -20,8 +21,9 @@
     ],
     "noImplicitAny": true,
     "strictNullChecks": true,
-    "noImplicitThis": true
+    "noImplicitThis": true,
+    "resolveJsonModule": true
   },
-  "include": ["app/ts/**/*.ts", "app/ts/server/**/*.ts", "**/*.d.ts"],
+  "include": ["app/ts/**/*.ts", "app/ts/server/**/*.ts", "scripts/**/*.ts", "**/*.d.ts"],
   "exclude": ["test", "app/compiled-templates"]
 }


### PR DESCRIPTION
## Summary
- compile TS using `NodeNext` modules
- map `.js` imports for Jest
- update internal imports to include `.js` extension

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: chromedriver ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68606bcb97b48325b894a2c1142e1128