### PR TITLE
Fix build output path

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "allowJs": true,
     "noEmit": false,
     "rootDir": ".",
-    "outDir": "dist/app",
+    "outDir": "dist",
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- ensure TypeScript output goes to `dist`

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: spawn ...chromedriver ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68607372cf408325bd0562467cbb99c9