### PR TITLE
fix appsettings module path

### DIFF
--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -70,9 +70,11 @@ export interface Settings {
   [key: string]: any;
 }
 
-const rawModule = fs.existsSync('./appsettings')
-  ? moduleRequire('./appsettings')
-  : moduleRequire('../appsettings');
+const localAppSettings = path.join(baseDir, 'appsettings');
+const parentAppSettings = path.join(baseDir, '..', 'appsettings');
+const rawModule = fs.existsSync(`${localAppSettings}.js`)
+  ? moduleRequire(localAppSettings)
+  : moduleRequire(parentAppSettings);
 const settingsModule: { settings: Settings } = rawModule.settings ? rawModule : rawModule.default;
 let { settings } = settingsModule;
 const defaultSettings: Settings = JSON.parse(JSON.stringify(settings));


### PR DESCRIPTION
## Summary
- fix settings.ts to load appsettings relative to module directory

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: spawn chromedriver ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68607706777483259f10586d85c9569d