### PR TITLE
test: add stats worker integration

### DIFF
--- a/test/statsWorker.test.ts
+++ b/test/statsWorker.test.ts
@@ -1,0 +1,66 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { execSync } from 'child_process';
+import { Worker } from 'worker_threads';
+
+const workerPath = path.join(
+  process.cwd(),
+  'dist',
+  'app',
+  'ts',
+  'renderer',
+  'workers',
+  'statsWorker.js'
+);
+
+beforeAll(() => {
+  if (!fs.existsSync(workerPath)) {
+    execSync('npx tsc', { stdio: 'inherit' });
+  }
+});
+
+test('statsWorker reports stats and updates on file changes', async () => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'stats-'));
+  const dataDir = path.join(tmpRoot, 'data');
+  fs.mkdirSync(dataDir);
+  const configPath = path.join(tmpRoot, 'config.json');
+  fs.writeFileSync(configPath, 'initial');
+
+  const workerPath = path.join(
+    process.cwd(),
+    'dist',
+    'app',
+    'ts',
+    'renderer',
+    'workers',
+    'statsWorker.js'
+  );
+  const worker = new Worker(workerPath, {
+    workerData: { configPath, dataDir }
+  });
+
+  const first: any = await new Promise((resolve) => worker.once('message', resolve));
+
+  expect(first).toEqual(
+    expect.objectContaining({
+      loaded: true,
+      configPath,
+      dataPath: dataDir
+    })
+  );
+  expect(typeof first.size).toBe('number');
+  expect(typeof first.configSize).toBe('number');
+  expect(typeof first.mtime).toBe('number');
+  expect(first.readWrite).toBe(true);
+
+  fs.writeFileSync(path.join(dataDir, 'file.txt'), 'hello');
+  const second: any = await new Promise((resolve) => worker.once('message', resolve));
+  expect(second.size).toBeGreaterThan(first.size);
+
+  fs.writeFileSync(configPath, 'changed!!!!');
+  const third: any = await new Promise((resolve) => worker.once('message', resolve));
+  expect(third.configSize).toBeGreaterThan(first.configSize);
+
+  await worker.terminate();
+});


### PR DESCRIPTION
## Summary
- create `statsWorker.test.ts` to spawn the compiled stats worker
- verify emitted stats fields
- check updates when files change

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: chromedriver ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68610a910f08832584f07d3975dbf589