### PR TITLE
Add dirnameCompat tests

### DIFF
--- a/test/dirnameCompat.test.ts
+++ b/test/dirnameCompat.test.ts
@@ -1,0 +1,37 @@
+import { dirnameCompat } from '../app/ts/utils/dirnameCompat';
+
+describe('dirnameCompat', () => {
+  const originalDirname = (global as any).__dirname;
+  const originalEval = global.eval;
+
+  afterEach(() => {
+    if (originalDirname === undefined) {
+      delete (global as any).__dirname;
+    } else {
+      (global as any).__dirname = originalDirname;
+    }
+    global.eval = originalEval;
+  });
+
+  test('returns __dirname when defined', () => {
+    (global as any).__dirname = '/tmp/dir';
+    const result = dirnameCompat();
+    expect(result).toBe('/tmp/dir');
+  });
+
+  test('uses import.meta.url when __dirname is undefined', () => {
+    delete (global as any).__dirname;
+    global.eval = jest.fn(() => 'file:///some/place/file.js');
+    const result = dirnameCompat();
+    expect(result).toBe('/some/place');
+  });
+
+  test('falls back to process.cwd()', () => {
+    delete (global as any).__dirname;
+    global.eval = jest.fn(() => {
+      throw new Error('fail');
+    });
+    const result = dirnameCompat();
+    expect(result).toBe(process.cwd());
+  });
+});


### PR DESCRIPTION
## Summary
- cover dirnameCompat fallback logic

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Jest failed to parse settings.ts)*
- `npm run test:e2e` *(fails: chromedriver ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6861134332ac832589d4b36b0039dc7e