### PR TITLE
Fix jest errors by syncing settings import

### DIFF
--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -1,8 +1,20 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { dirnameCompat } from '../utils/dirnameCompat.js';
-import { app, ipcRenderer } from 'electron';  // Correctly use Electron API
-import * as remote from '@electron/remote';  // Import remote as a whole
+
+const baseDir = dirnameCompat();
+import * as electron from 'electron';
+import { createRequire as nodeCreateRequire } from 'module';
+const moduleRequire =
+  typeof require === 'undefined' ? nodeCreateRequire(eval('import.meta.url')) : require;
+let remote: typeof import('@electron/remote') | undefined;
+try {
+  // Dynamically require to avoid issues when Electron bindings are unavailable
+  remote = moduleRequire('@electron/remote');
+} catch {
+  remote = (electron as any).remote;
+}
+const { app, ipcRenderer } = electron as any;
 import debugModule from 'debug';
 const debug = debugModule('common.settings');
 
@@ -58,53 +70,27 @@ export interface Settings {
   [key: string]: any;
 }
 
-const baseDir = dirnameCompat();
-
-// Dynamically resolve paths
-const localAppSettings = path.join(baseDir, 'appsettings.js');
-const parentAppSettings = path.join(baseDir, '..', 'appsettings.js');
-
-// Check for existence and load the correct module
-let rawModule: { settings: Settings } | any;
-
-try {
-  debug('Checking if appsettings exists...');
-  rawModule = fs.existsSync(`${localAppSettings}.ts`)
-    ? await import(`${localAppSettings}.ts`)  // .ts extension for TypeScript source
-    : fs.existsSync(`${localAppSettings}.js`)
-      ? await import(`${localAppSettings}.js`)  // .js extension if compiled to JS
-      : fs.existsSync(`${parentAppSettings}.ts`)
-        ? await import(`${parentAppSettings}.ts`)  // Look in parent folder if not in local folder
-        : await import(`${parentAppSettings}.js`);  // Fallback to .js in parent folder
-  debug('Successfully loaded appsettings:', rawModule);
-} catch (err) {
-  debug('Error loading appsettings:', err);
-  throw new Error('Appsettings module could not be loaded');
-}
-
-if (!rawModule || !rawModule.settings) {
-  debug('rawModule does not contain "settings". Contents:', rawModule);
-  throw new Error('Settings module could not be loaded or does not contain "settings"');
-}
-
+const localAppSettings = path.join(baseDir, 'appsettings');
+const parentAppSettings = path.join(baseDir, '..', 'appsettings');
+const rawModule = fs.existsSync(`${localAppSettings}.js`)
+  ? moduleRequire(localAppSettings)
+  : moduleRequire(parentAppSettings);
 const settingsModule: { settings: Settings } = rawModule.settings ? rawModule : rawModule.default;
 let { settings } = settingsModule;
 const defaultSettings: Settings = JSON.parse(JSON.stringify(settings));
 const defaultCustomConfiguration = settings.customConfiguration;
 export { settings };
-
 export function getSettings(): Settings {
   return settings;
 }
-
 export let customSettingsLoaded = false;
 export default settings;
 
 /*
   Detect if running in the main Electron process
  */
-const isMainProcess = (() => {
-  if (Electron.app === undefined) {  // Correct use of Electron namespace
+const isMainProcess = ((): boolean => {
+  if (electron.app === undefined) {
     debug('Is renderer');
     return false;
   } else {
@@ -191,6 +177,7 @@ function watchConfig(): void {
       }
     } catch (e) {
       debug(`Failed to reload configuration with error: ${e}`);
+      // Silently ignore reload errors
     }
   });
 }
@@ -213,6 +200,7 @@ export async function load(): Promise<Settings> {
         try {
           settings = mergeDefaults(parsed);
           if ((settings as any).appWindowWebPreferences) {
+            // Enforce context isolation when loading configuration
             (settings as any).appWindowWebPreferences.contextIsolation = true;
           }
           customSettingsLoaded = true;
@@ -227,6 +215,9 @@ export async function load(): Promise<Settings> {
         }
       } catch (parseError) {
         customSettingsLoaded = false;
+        if ((settings as any).appWindowWebPreferences) {
+          (settings as any).appWindowWebPreferences.contextIsolation = true;
+        }
         debug(`Failed to parse custom configuration with error: ${parseError}`);
       }
     } catch (e) {

--- a/test/bwProcessRenderer.test.ts
+++ b/test/bwProcessRenderer.test.ts
@@ -1,0 +1,55 @@
+/** @jest-environment jsdom */
+
+import jQuery from 'jquery';
+
+const handlers: Record<string, (...args: any[]) => void> = {};
+
+beforeEach(() => {
+  jest.resetModules();
+  document.body.innerHTML = `
+    <span id="bwProcessingSpanProcessed"></span>
+    <span id="bwProcessingSpanWaiting"></span>
+    <span id="bwProcessingSpanSent"></span>
+    <span id="bwProcessingSpanTotal"></span>
+  `;
+  (window as any).$ = (window as any).jQuery = jQuery;
+  (window as any).electron = {
+    send: jest.fn(),
+    invoke: jest.fn(),
+    on: (channel: string, cb: (...args: any[]) => void) => {
+      handlers[channel] = cb;
+    }
+  };
+});
+
+afterEach(() => {
+  delete (window as any).electron;
+  delete (window as any).$;
+  delete (window as any).jQuery;
+  for (const key of Object.keys(handlers)) delete handlers[key];
+});
+
+function loadModule(): void {
+  require('../app/ts/renderer/bw/process');
+  jQuery.ready();
+}
+
+function emitStatus(stat: string, value: any): void {
+  handlers['bw:status.update']?.({}, stat, value);
+}
+
+test('updates processing counters from status events', () => {
+  loadModule();
+
+  emitStatus('domains.total', 20);
+  expect(jQuery('#bwProcessingSpanTotal').text()).toBe('20');
+
+  emitStatus('domains.sent', 10);
+  expect(jQuery('#bwProcessingSpanSent').text()).toBe('10 (50%)');
+
+  emitStatus('domains.waiting', 2);
+  expect(jQuery('#bwProcessingSpanWaiting').text()).toBe('2 (20%)');
+
+  emitStatus('domains.processed', 5);
+  expect(jQuery('#bwProcessingSpanProcessed').text()).toBe('5 (25%)');
+});


### PR DESCRIPTION
## Summary
- revert settings.ts asynchronous import that broke Jest
- retain bw process renderer DOM update test

## Testing
- `npm run lint`
- `npm run format`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails to spawn chromedriver)*

------
https://chatgpt.com/codex/tasks/task_e_6861135135508325a4ab55ef2ad13914