### PR TITLE
Add compiled_templates to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ settings.json
 reload.json
 .DS_Store
 app/compiled-templates/
+compiled_templates/
 test/e2e/artifacts/
 app/data/history.sqlite


### PR DESCRIPTION
## Summary
- ignore the `compiled_templates/` directory

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: statsWorker test timeout)*
- `npm run test:e2e` *(fails: cannot spawn chromedriver)*

------
https://chatgpt.com/codex/tasks/task_e_686127d9288c8325921206bd29d250ac