### PR TITLE
Add history module tests

### DIFF
--- a/test/historyMain.test.ts
+++ b/test/historyMain.test.ts
@@ -1,0 +1,37 @@
+const ipcMainHandlers: Record<string, (...args: any[]) => any> = {};
+const getMock = jest.fn();
+const clearMock = jest.fn();
+
+jest.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, listener: (...args: any[]) => any) => {
+      ipcMainHandlers[channel] = listener;
+    }
+  },
+  dialog: {},
+  app: undefined,
+  BrowserWindow: class {},
+  Menu: {}
+}));
+
+jest.mock('../app/ts/common/history', () => ({
+  getHistory: (...args: any[]) => getMock(...args),
+  clearHistory: (...args: any[]) => clearMock(...args)
+}));
+
+import '../app/ts/main/history';
+
+describe('history IPC handlers', () => {
+  test('history:get returns history entries', () => {
+    const entries = [{ domain: 'test.com', status: 'ok', timestamp: 1 }];
+    getMock.mockReturnValue(entries);
+    const result = ipcMainHandlers['history:get']();
+    expect(getMock).toHaveBeenCalled();
+    expect(result).toBe(entries);
+  });
+
+  test('history:clear invokes clearHistory', () => {
+    ipcMainHandlers['history:clear']();
+    expect(clearMock).toHaveBeenCalled();
+  });
+});

--- a/test/historyRenderer.test.ts
+++ b/test/historyRenderer.test.ts
@@ -1,0 +1,44 @@
+/** @jest-environment jsdom */
+
+import jQuery from 'jquery';
+
+let invokeMock: jest.Mock;
+
+beforeEach(() => {
+  jest.resetModules();
+  document.body.innerHTML = `
+    <table id="historyTable"><tbody></tbody></table>
+    <div id="historyEmpty" class="is-hidden"></div>
+  `;
+  invokeMock = jest.fn();
+  (window as any).electron = { invoke: invokeMock };
+  (window as any).$ = (window as any).jQuery = jQuery;
+});
+
+afterEach(() => {
+  delete (window as any).electron;
+  delete (window as any).$;
+  delete (window as any).jQuery;
+});
+
+test('loadHistory displays entries in table', async () => {
+  invokeMock.mockResolvedValue([
+    { domain: 'a.com', status: 'ok', timestamp: 1 },
+    { domain: 'b.com', status: 'error', timestamp: 2 }
+  ]);
+  const { _test } = require('../app/ts/renderer/history');
+  await _test.loadHistory();
+  await Promise.resolve();
+  expect(invokeMock).toHaveBeenCalledWith('history:get');
+  expect(jQuery('#historyEmpty').hasClass('is-hidden')).toBe(true);
+  expect(jQuery('#historyTable tbody tr').length).toBe(2);
+});
+
+test('loadHistory shows empty message when no entries', async () => {
+  invokeMock.mockResolvedValue([]);
+  const { _test } = require('../app/ts/renderer/history');
+  await _test.loadHistory();
+  await Promise.resolve();
+  expect(jQuery('#historyEmpty').hasClass('is-hidden')).toBe(false);
+  expect(jQuery('#historyTable tbody tr').length).toBe(0);
+});


### PR DESCRIPTION
## Summary
- test IPC handlers for history in main process
- test renderer history loader functionality

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: chromedriver ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_686126bf78888325a90f603cd50ebc0b