### PR TITLE
Add tests for wordlist tools IPC and UI

### DIFF
--- a/test/toMain.test.ts
+++ b/test/toMain.test.ts
@@ -1,0 +1,60 @@
+const ipcMainHandlers: Record<string, (...args: any[]) => any> = {};
+const showDialogMock = jest.fn();
+
+jest.mock('electron', () => ({
+  ipcMain: {
+    on: (channel: string, listener: (...args: any[]) => void) => {
+      ipcMainHandlers[channel] = listener;
+    },
+    handle: (channel: string, listener: (...args: any[]) => any) => {
+      ipcMainHandlers[channel] = listener;
+    }
+  },
+  dialog: { showOpenDialogSync: showDialogMock },
+  app: undefined,
+  BrowserWindow: class {},
+  Menu: {}
+}));
+
+const readFileMock = jest.fn();
+
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  promises: { readFile: (...args: any[]) => readFileMock(...args) }
+}));
+
+const processLinesMock = jest.fn();
+
+jest.mock('../app/ts/common/tools.js', () => ({
+  processLines: (...args: any[]) => processLinesMock(...args)
+}));
+import '../app/ts/main/to';
+
+const handler = () => ipcMainHandlers['to:process'];
+
+describe('to main handler', () => {
+  beforeEach(() => {
+    readFileMock.mockReset();
+    processLinesMock.mockReset();
+    showDialogMock.mockReset();
+  });
+
+  test('processes file and sends result', async () => {
+    readFileMock.mockResolvedValue('a\nb');
+    processLinesMock.mockReturnValue(['x', 'y']);
+    const send = jest.fn();
+    await handler()({ sender: { send } } as any, '/tmp/list.txt', { opt: 1 } as any);
+
+    expect(readFileMock).toHaveBeenCalledWith('/tmp/list.txt', 'utf8');
+    expect(processLinesMock).toHaveBeenCalledWith(['a', 'b'], { opt: 1 });
+    expect(send).toHaveBeenCalledWith('to:process.result', 'x\ny');
+  });
+
+  test('sends error when read fails', async () => {
+    readFileMock.mockRejectedValue(new Error('fail'));
+    const send = jest.fn();
+    await handler()({ sender: { send } } as any, '/tmp/list.txt', {});
+
+    expect(send).toHaveBeenCalledWith('to:process.error', 'fail');
+  });
+});

--- a/test/toRenderer.test.ts
+++ b/test/toRenderer.test.ts
@@ -1,0 +1,75 @@
+/** @jest-environment jsdom */
+
+import jQuery from 'jquery';
+
+const handlers: Record<string, (...args: any[]) => void> = {};
+const sendMock = jest.fn();
+const invokeMock = jest.fn();
+
+jest.mock('electron', () => ({
+  ipcRenderer: {
+    send: (...args: any[]) => sendMock(...args),
+    invoke: (...args: any[]) => invokeMock(...args),
+    on: (channel: string, cb: (...args: any[]) => void) => {
+      handlers[channel] = cb;
+    }
+  }
+}));
+
+beforeEach(() => {
+  jest.resetModules();
+  document.body.innerHTML = `
+    <button id="toButtonSelect"></button>
+    <button id="toButtonProcess"></button>
+    <span id="toFileSelected"></span>
+    <input id="toPrefix" />
+    <input id="toSuffix" />
+    <input id="toTrimSpaces" type="checkbox" />
+    <input id="toDeleteBlank" type="checkbox" />
+    <input id="toDedupe" type="checkbox" />
+    <input type="radio" name="toSort" value="asc" id="radioAsc" />
+    <div id="toOutput"></div>
+  `;
+  (window as any).$ = (window as any).jQuery = jQuery;
+  sendMock.mockClear();
+  invokeMock.mockReset();
+  require('../app/ts/renderer/to');
+  jQuery.ready();
+});
+
+afterEach(() => {
+  delete (window as any).electron;
+  delete (window as any).$;
+  delete (window as any).jQuery;
+  for (const key in handlers) delete handlers[key];
+});
+
+test('select and process file flow', async () => {
+  jQuery('#toButtonSelect').trigger('click');
+  expect(sendMock).toHaveBeenCalledWith('to:input.file');
+
+  handlers['to:fileinput.confirmation']?.({}, '/tmp/list.txt');
+  expect(jQuery('#toFileSelected').text()).toBe('/tmp/list.txt');
+
+  jQuery('#toPrefix').val('pre');
+  jQuery('#toSuffix').val('suf');
+  jQuery('#toTrimSpaces').prop('checked', true);
+  jQuery('#toDeleteBlank').prop('checked', true);
+  jQuery('#toDedupe').prop('checked', true);
+  jQuery('#radioAsc').prop('checked', true);
+
+  jQuery('#toButtonProcess').trigger('click');
+  await new Promise((r) => setTimeout(r, 0));
+
+  expect(invokeMock).toHaveBeenCalledWith('to:process', '/tmp/list.txt', {
+    prefix: 'pre',
+    suffix: 'suf',
+    trimSpaces: true,
+    deleteBlankLines: true,
+    dedupe: true,
+    sort: 'asc'
+  });
+
+  handlers['to:process.result']?.({}, 'ok');
+  expect(jQuery('#toOutput').text()).toBe('ok');
+});


### PR DESCRIPTION
## Summary
- add unit test for `to.ts` IPC handler
- test renderer flow for wordlist tools UI

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: spawn chromedriver ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68612c73004c83258bf8e62e481f8702