### PR TITLE
Fix dirnameCompat path resolution

### DIFF
--- a/app/ts/utils/dirnameCompat.ts
+++ b/app/ts/utils/dirnameCompat.ts
@@ -1,7 +1,18 @@
+import path from 'path';
+
 export function dirnameCompat(): string {
   const globalDir = (global as any).__dirname;
   if (typeof globalDir === 'string') {
     return globalDir;
+  }
+  if (typeof __dirname !== 'undefined') {
+    return __dirname;
+  }
+  if (typeof __filename !== 'undefined') {
+    return path.dirname(__filename);
+  }
+  if (process.argv[1]) {
+    return path.dirname(process.argv[1]);
   }
   return process.cwd();
 }

--- a/scripts/dirnameCompat.js
+++ b/scripts/dirnameCompat.js
@@ -5,8 +5,14 @@ export function dirnameCompat() {
   if (typeof globalDir === 'string') {
     return globalDir;
   }
+  if (typeof __dirname !== 'undefined') {
+    return __dirname;
+  }
   if (typeof __filename !== 'undefined') {
     return path.dirname(__filename);
+  }
+  if (process.argv[1]) {
+    return path.dirname(process.argv[1]);
   }
   return process.cwd();
 }

--- a/test/dirnameCompat.test.ts
+++ b/test/dirnameCompat.test.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { dirnameCompat } from '../app/ts/utils/dirnameCompat';
 
 describe('dirnameCompat', () => {
@@ -18,16 +19,10 @@ describe('dirnameCompat', () => {
     expect(result).toBe('/tmp/dir');
   });
 
-  test('uses process.cwd() when __dirname is undefined', () => {
+  test('uses module directory when global __dirname is undefined', () => {
     delete (global as any).__dirname;
+    const expected = path.resolve(__dirname, '../app/ts/utils');
     const result = dirnameCompat();
-    expect(result).toBe(process.cwd());
+    expect(result).toBe(expected);
   });
-
-  test('falls back to process.cwd()', () => {
-    delete (global as any).__dirname;
-    const result = dirnameCompat();
-    expect(result).toBe(process.cwd());
-  });
-
 });


### PR DESCRIPTION
## Summary
- avoid using `import.meta.url` in dirnameCompat
- ensure runtime resolves to the script directory under ESM
- update tests for new path handling

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: session not created, user data dir in use)*

------
https://chatgpt.com/codex/tasks/task_e_68612be9cc448325bf5d23624c73d5d1