### PR TITLE
chore: ignore husky hook script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ app/compiled-templates/
 compiled_templates/
 test/e2e/artifacts/
 app/data/history.sqlite
+.husky/_/husky.sh


### PR DESCRIPTION
## Summary
- update `.gitignore` to exclude husky hook script

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: statsWorker.test.ts timeout)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6861317736808325a5751953d41bccd0