### PR TITLE
fix: resolve preload and HTML paths

### DIFF
--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -122,7 +122,7 @@ app.on('ready', async function () {
       backgroundThrottling: webPreferences.backgroundThrottling, // Whether to throttle animations and timers when the page becomes background
       offscreen: webPreferences.offscreen, // enable offscreen rendering for the browser window
       spellcheck: webPreferences.spellcheck, // Enable builtin spellchecker
-      preload: path.join(baseDir, 'preload.js')
+      preload: path.resolve(baseDir, 'preload.js')
     }
   });
 
@@ -131,7 +131,7 @@ app.on('ready', async function () {
   // mainWindow, Main window URL load
   const loadPath = path.isAbsolute(appUrl.pathname)
     ? path.normalize(appUrl.pathname)
-    : path.join(baseDir, appUrl.pathname);
+    : path.resolve(baseDir, appUrl.pathname);
   mainWindow.loadFile(loadPath);
 
   // Some more debugging messages


### PR DESCRIPTION
## Summary
- ensure BrowserWindow paths are absolute using `path.resolve`

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format:check`
- `CHOKIDAR_USEPOLLING=1 npm test -- --runInBand`
- `CHOKIDAR_USEPOLLING=1 npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68614587c97c8325afae86702749319b