### PR TITLE
fix: robust dirname detection for esm

### DIFF
--- a/app/ts/utils/dirnameCompat.ts
+++ b/app/ts/utils/dirnameCompat.ts
@@ -1,12 +1,31 @@
 import path from 'path';
+import { fileURLToPath } from 'url';
 
-export function dirnameCompat(): string {
+export function dirnameCompat(metaUrl?: string): string {
   const globalDir = (global as any).__dirname;
   if (typeof globalDir === 'string') {
     return globalDir;
   }
   if (typeof __dirname !== 'undefined') {
     return __dirname;
+  }
+  // Support ESM by using import.meta.url when available
+  let url = metaUrl;
+  if (!url) {
+    try {
+      url = Function(
+        'return typeof import!=="undefined" && import.meta && import.meta.url ? import.meta.url : undefined'
+      )();
+    } catch {
+      url = undefined;
+    }
+  }
+  if (typeof url === 'string') {
+    try {
+      return path.dirname(fileURLToPath(url));
+    } catch {
+      /* ignore */
+    }
   }
   if (typeof __filename !== 'undefined') {
     return path.dirname(__filename);

--- a/scripts/dirnameCompat.js
+++ b/scripts/dirnameCompat.js
@@ -1,12 +1,31 @@
 import path from 'path';
+import { fileURLToPath } from 'url';
 
-export function dirnameCompat() {
+export function dirnameCompat(metaUrl) {
   const globalDir = global.__dirname;
   if (typeof globalDir === 'string') {
     return globalDir;
   }
   if (typeof __dirname !== 'undefined') {
     return __dirname;
+  }
+  // Support ESM by using import.meta.url when available
+  let url = metaUrl;
+  if (!url) {
+    try {
+      url = Function(
+        'return typeof import!=="undefined" && import.meta && import.meta.url ? import.meta.url : undefined'
+      )();
+    } catch {
+      url = undefined;
+    }
+  }
+  if (typeof url === 'string') {
+    try {
+      return path.dirname(fileURLToPath(url));
+    } catch {
+      /* ignore */
+    }
   }
   if (typeof __filename !== 'undefined') {
     return path.dirname(__filename);


### PR DESCRIPTION
## Summary
- handle import.meta.url safely for CommonJS and ESM

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: statsWorker test timeout)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68614979390883258749f9e44edb9e8c