### PR TITLE
fix: improve dirname resolution under esm

### DIFF
--- a/app/ts/utils/dirnameCompat.ts
+++ b/app/ts/utils/dirnameCompat.ts
@@ -1,10 +1,17 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-export function dirnameCompat(metaUrl?: string): string {
+export function dirnameCompat(metaUrl?: string | URL): string {
   const globalDir = (global as any).__dirname;
   if (typeof globalDir === 'string') {
     return globalDir;
+  }
+  if (metaUrl) {
+    try {
+      return path.dirname(fileURLToPath(metaUrl));
+    } catch {
+      /* ignore */
+    }
   }
   if (typeof __dirname !== 'undefined') {
     return __dirname;

--- a/readme.md
+++ b/readme.md
@@ -220,16 +220,18 @@ Run `npm run format` before committing to apply Prettier formatting. CI will ver
 
 Modules within Whoisdigger may execute in both CommonJS and ESM contexts. Use
 `dirnameCompat()` from `app/ts/utils/dirnameCompat.ts` to obtain a directory
-name that works in either environment:
+name that works in either environment. Pass `import.meta.url` when calling from
+an ES module:
 
 ```ts
 import { dirnameCompat } from './utils/dirnameCompat';
-const __dirname = dirnameCompat();
+const __dirname = dirnameCompat(import.meta.url);
 ```
 
-The helper checks for a globally defined `__dirname` or the module
-`__dirname`, then tries `__filename`, `process.mainModule?.filename` or
-`process.argv[1]` before falling back to `process.cwd()`.
+The helper checks for a globally defined `__dirname`, falls back to the provided
+`import.meta.url` (or the current module's `__dirname` in CommonJS), then tries
+`__filename`, `process.mainModule?.filename` or `process.argv[1]` before
+falling back to `process.cwd()`.
 
 ## Settings
 

--- a/scripts/dirnameCompat.js
+++ b/scripts/dirnameCompat.js
@@ -6,6 +6,13 @@ export function dirnameCompat(metaUrl) {
   if (typeof globalDir === 'string') {
     return globalDir;
   }
+  if (metaUrl) {
+    try {
+      return path.dirname(fileURLToPath(metaUrl));
+    } catch {
+      /* ignore */
+    }
+  }
   if (typeof __dirname !== 'undefined') {
     return __dirname;
   }

--- a/test/dirnameCompat.test.ts
+++ b/test/dirnameCompat.test.ts
@@ -25,4 +25,9 @@ describe('dirnameCompat', () => {
     const result = dirnameCompat();
     expect(result).toBe(expected);
   });
+
+  test('resolves using provided metaUrl when in ESM context', () => {
+    const result = dirnameCompat('file:///tmp/foo/bar.js');
+    expect(result).toBe('/tmp/foo');
+  });
 });


### PR DESCRIPTION
## Summary
- update dirnameCompat to handle `import.meta.url`
- sync runtime script version
- document new usage in README
- expand dirnameCompat tests for ESM

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npx jest --runInBand`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68614ecbad6883259ea87f69bf43ca49