### PR TITLE
Fix ESM path resolution for renderer preload

### DIFF
--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -1,8 +1,9 @@
 import { app, BrowserWindow, Menu, ipcMain, dialog } from 'electron';
 import * as path from 'path';
-import { dirnameCompat } from './utils/dirnameCompat.js';
+import { fileURLToPath } from 'url';
 
-const baseDir = dirnameCompat();
+const __filename = fileURLToPath(import.meta.url);
+const baseDir = path.dirname(__filename);
 import debugModule from 'debug';
 import { loadSettings, settings as store } from './common/settings.js';
 import type { Settings as BaseSettings } from './common/settings.js';


### PR DESCRIPTION
## Summary
- compute `baseDir` from `import.meta.url`
- ensure preload and HTML paths resolve correctly

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68615bc8d3c883259f19fa4a3ba06ed3