### PR TITLE
refactor: use structuredClone for resetObj

### DIFF
--- a/app/ts/common/resetObject.ts
+++ b/app/ts/common/resetObject.ts
@@ -8,7 +8,7 @@ const defaultValue = {};
     defaultObject (object) - default object
  */
 export function resetObj<T>(defaultObject: T = defaultValue as T): T {
-  return JSON.parse(JSON.stringify(defaultObject));
+  return structuredClone(defaultObject);
 }
 
 export const resetObject = resetObj; // extended function alias

--- a/test/resetObject.test.ts
+++ b/test/resetObject.test.ts
@@ -16,4 +16,11 @@ describe('resetObj', () => {
     expect(second).toEqual({});
     expect(second).not.toBe(first);
   });
+
+  test('preserves Date instances', () => {
+    const original = { d: new Date('2020-01-01T00:00:00Z') };
+    const copy = resetObj(original);
+    expect(copy).toEqual(original);
+    expect(Object.prototype.toString.call(copy.d)).toBe('[object Date]');
+  });
 });


### PR DESCRIPTION
## Summary
- use `structuredClone` for object resets
- update `resetObj` unit tests for new cloning behavior

## Testing
- `npm run lint`
- `npm run format`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68615c801df8832584ca1cc029098e81