### PR TITLE
Fix handlebars runtime import

### DIFF
--- a/app/html/templates/mainPanel.hbs
+++ b/app/html/templates/mainPanel.hbs
@@ -15,6 +15,13 @@
     <link href="../css/style.css" rel="stylesheet" />
     <link href="../css/tables.css" rel="stylesheet" />
     <!--<link href="../css/fontawesome/all.min.css" rel="stylesheet">-->
+    <script type="importmap">
+      {
+        "imports": {
+          "handlebars/runtime": "../../../node_modules/handlebars/runtime.js"
+        }
+      }
+    </script>
     <script type="module" src="./startup.js"></script>
   </head>
 


### PR DESCRIPTION
## Summary
- reference `handlebars/runtime` via import map so the renderer can resolve the module

## Testing
- `npm run lint`
- `npm run format`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68615dafcaac83259f2d24dcd028e428