### PR TITLE
fix: trim bulk file tld input

### DIFF
--- a/app/ts/renderer/bw/fileinput.ts
+++ b/app/ts/renderer/bw/fileinput.ts
@@ -243,11 +243,10 @@ $(document).on('click', '#bwFileButtonConfirm', function () {
     .toString()
     .split('\n')
     .map(Function.prototype.call, String.prototype.trim);
-  const bwTldsArray = (
-    ($('#bwFileInputTlds').val() as string | number | string[] | undefined) || ''
-  )
-    .toString()
-    .split(',');
+  const bwTldsArray = (($('#bwFileInputTlds').val() as string) || '')
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean);
 
   tableReset(bwDomainArray.length, bwTldsArray.length);
   $('#bwFileinputconfirm').addClass('is-hidden');


### PR DESCRIPTION
## Summary
- trim and filter TLD list for bulk file input

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: statsWorker.test.ts timeout)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68615c5b740083259a2b93a473d02eaf