### PR TITLE
Handle CLI whois errors

### DIFF
--- a/app/ts/cli.ts
+++ b/app/ts/cli.ts
@@ -75,11 +75,15 @@ export async function lookupDomains(opts: CliOptions): Promise<WhoisResult[]> {
 
   const results: WhoisResult[] = [];
   for (const domain of domains) {
-    const data = await whoisLookup(domain);
-    const json = toJSON(data) as Record<string, unknown>;
-    const status = isDomainAvailable(data);
-    const params = getDomainParameters(domain, status, data, json);
-    results.push(params);
+    try {
+      const data = await whoisLookup(domain);
+      const json = toJSON(data) as Record<string, unknown>;
+      const status = isDomainAvailable(data);
+      const params = getDomainParameters(domain, status, data, json);
+      results.push(params);
+    } catch {
+      results.push({ domain, status: 'error', whoisreply: '' });
+    }
   }
   return results;
 }

--- a/readme.md
+++ b/readme.md
@@ -193,6 +193,9 @@ node dist/app/ts/cli.js --download-model
 node dist/app/ts/cli.js --suggest "short tech names" --suggest-count 5
 ```
 
+If a lookup fails, the result for that domain is still included with
+`status` set to `error` and an empty `whoisreply` field.
+
 ### Notes on errors
 
 Errors during bulk lookups are pretty common due to sheer request volume, this means that you'll have requests periodically getting blocked, rejected, throttled or delayed (might result in false negatives, false positives in rare cases or errors). Errors may and usually signal that a domain is already registered, at times you can assume that but take into account the domain name, tld and probability of it being registered. Whoisdigger includes assumptions settings that you can tweak for specific scenarios, see assumptions below for more.

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -40,6 +40,13 @@ describe('cli utility', () => {
     expect(results[0].whoisreply).toBe('data');
   });
 
+  test('lookupDomains handles lookup errors', async () => {
+    mockLookup.mockRejectedValueOnce(new Error('fail'));
+    const opts: CliOptions = { domains: ['bad.com'], tlds: ['com'], format: 'txt' };
+    const results = await lookupDomains(opts);
+    expect(results).toEqual([{ domain: 'bad.com', status: 'error', whoisreply: '' }]);
+  });
+
   test('exportResults writes csv output', async () => {
     const file = path.join(__dirname, 'out.csv');
     const opts: CliOptions = { domains: [], tlds: ['com'], format: 'csv', out: file };


### PR DESCRIPTION
## Summary
- catch lookup errors when running the CLI
- note error entries in README
- test CLI error handling

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68615c3792fc8325bd98aa9bf4aadb10