### PR TITLE
fix: resolve Handlebars runtime in renderer

### DIFF
--- a/app/ts/renderer/i18n.ts
+++ b/app/ts/renderer/i18n.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { dirnameCompat } from '../utils/dirnameCompat.js';
 
 const baseDir = dirnameCompat();
-import Handlebars from 'handlebars/runtime';
+import Handlebars from 'handlebars/runtime.js';
 
 let translations: Record<string, string> = {};
 

--- a/app/ts/renderer/registerPartials.ts
+++ b/app/ts/renderer/registerPartials.ts
@@ -1,4 +1,4 @@
-import Handlebars from 'handlebars/runtime';
+import Handlebars from 'handlebars/runtime.js';
 
 import bwEntry from '../../compiled-templates/bwEntry.js';
 import bwExport from '../../compiled-templates/bwExport.js';

--- a/app/ts/renderer/templateLoader.ts
+++ b/app/ts/renderer/templateLoader.ts
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import Handlebars from 'handlebars/runtime';
+import Handlebars from 'handlebars/runtime.js';
 
 export async function loadTemplate(
   selector: string,

--- a/test/i18n.test.ts
+++ b/test/i18n.test.ts
@@ -4,7 +4,7 @@ jest.mock('fs', () => ({
   promises: { readFile: jest.fn() }
 }));
 
-import Handlebars from 'handlebars/runtime';
+import Handlebars from 'handlebars/runtime.js';
 
 const readFileMock = require('fs').promises.readFile as jest.Mock;
 

--- a/test/registerPartials.test.ts
+++ b/test/registerPartials.test.ts
@@ -22,7 +22,7 @@ const partialNames = [
   'modals'
 ];
 
-jest.mock('handlebars/runtime', () => {
+jest.mock('handlebars/runtime.js', () => {
   const template = jest.fn((pre: any) => `compiled-${pre.name}`);
   const registerPartial = jest.fn();
   return { __esModule: true, default: { template, registerPartial } };
@@ -39,7 +39,7 @@ for (const name of partialNames) {
   );
 }
 
-const handlebars = require('handlebars/runtime').default;
+const handlebars = require('handlebars/runtime.js').default;
 const { registerPartials } = require('../app/ts/renderer/registerPartials');
 
 describe('registerPartials', () => {

--- a/test/templateLoader.test.ts
+++ b/test/templateLoader.test.ts
@@ -2,7 +2,7 @@
 
 import jQuery from 'jquery';
 
-jest.mock('handlebars/runtime', () => {
+jest.mock('handlebars/runtime.js', () => {
   const compiledFn = jest.fn((ctx: any) => `<span>${ctx.text}</span>`);
   const template = jest.fn(() => compiledFn);
   return { __esModule: true, default: { template } };
@@ -18,7 +18,7 @@ jest.mock(
 );
 
 import { loadTemplate } from '../app/ts/renderer/templateLoader';
-const handlebars = require('handlebars/runtime').default;
+const handlebars = require('handlebars/runtime.js').default;
 
 beforeAll(() => {
   (window as any).$ = (window as any).jQuery = jQuery;


### PR DESCRIPTION
## Summary
- update renderer to import `handlebars/runtime.js`
- adjust Handlebars mocks in tests

## Testing
- `npm test --silent -- --runInBand`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68615dafcaac83259f2d24dcd028e428