### PR TITLE
fix: index patterns with numeric keys

### DIFF
--- a/app/ts/common/whoiswrapper/patterns.ts
+++ b/app/ts/common/whoiswrapper/patterns.ts
@@ -407,7 +407,7 @@ export function buildPatterns(): void {
   builtPatterns.error = [];
 
   for (const key of Object.keys(patterns.special).sort((a, b) => Number(a) - Number(b))) {
-    const spec = patterns.special[key as keyof typeof patterns.special];
+    const spec = patterns.special[Number(key) as keyof typeof patterns.special];
     const res =
       typeof spec !== 'string' && !Array.isArray(spec) && spec.result !== undefined
         ? spec.result
@@ -419,14 +419,14 @@ export function buildPatterns(): void {
   for (const cat of ['notfound', 'nomatch', 'available', 'unique'] as const) {
     const group = avail[cat];
     for (const key of Object.keys(group).sort((a, b) => Number(a) - Number(b))) {
-      const spec = group[key as keyof typeof group];
+      const spec = group[Number(key) as keyof typeof group];
       builtPatterns.available.push(compileSpec(spec, 'available'));
     }
   }
 
   const unav = patterns.unavailable;
   for (const key of Object.keys(unav).sort((a, b) => Number(a) - Number(b))) {
-    const spec = unav[key as keyof typeof unav];
+    const spec = unav[Number(key) as keyof typeof unav];
     builtPatterns.unavailable.push(compileSpec(spec, 'unavailable'));
   }
 
@@ -440,7 +440,7 @@ export function buildPatterns(): void {
     const group = err[groupKey as keyof typeof err];
     const res = errMap[groupKey];
     for (const key of Object.keys(group).sort((a, b) => Number(a) - Number(b))) {
-      const spec = group[key as keyof typeof group];
+      const spec = group[Number(key) as keyof typeof group];
       builtPatterns.error.push(compileSpec(spec, res));
     }
   }


### PR DESCRIPTION
## Summary
- resolve TypeScript type errors in pattern building

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68618375db608325aad40b952262ac9a