### PR TITLE
fix: cleanup failed model download

### DIFF
--- a/test/modelDownloader.test.ts
+++ b/test/modelDownloader.test.ts
@@ -46,4 +46,16 @@ describe('model downloader', () => {
     await expect(downloadModel('https://bad', dest)).rejects.toThrow('fail');
     expect(fs.existsSync(destPath)).toBe(false);
   });
+
+  test('rejects on non-2xx status and cleans up file', async () => {
+    const res = new PassThrough() as PassThrough & { statusCode?: number };
+    res.statusCode = 404;
+    res.resume = jest.fn();
+    getMock.mockImplementation((_url, cb) => {
+      cb(res);
+      return new EventEmitter();
+    });
+    await expect(downloadModel('https://example.com/model.onnx', dest)).rejects.toThrow('HTTP 404');
+    expect(fs.existsSync(destPath)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure model downloader rejects on non-2xx responses
- delete partially written files on any download failure
- test cleanup of failed downloads

## Testing
- `npm test`
- `npm run test:e2e` *(fails: WebDriverError session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68618602c238832586673e405b107c4d