### PR TITLE
Fix randomization for domain setup

### DIFF
--- a/app/ts/main/bw/queue.ts
+++ b/app/ts/main/bw/queue.ts
@@ -5,6 +5,13 @@ import type { DomainSetup } from './types.js';
 
 const debug = debugModule('main.bw.queue');
 
+function randomWithin(min: number, max: number): number {
+  if (min > max) {
+    [min, max] = [max, min];
+  }
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
 export function compileQueue(domains: string[], tlds: string[], separator: string): string[] {
   const queue: string[] = [];
   for (const tld of tlds) {
@@ -51,21 +58,21 @@ export function getDomainSetup(
 
   return {
     timebetween: isRandom.timeBetween
-      ? Math.floor(
-          Math.random() * settings.lookupRandomizeTimeBetween.maximum +
-            settings.lookupRandomizeTimeBetween.minimum
+      ? randomWithin(
+          settings.lookupRandomizeTimeBetween.minimum,
+          settings.lookupRandomizeTimeBetween.maximum
         )
       : settings.lookupGeneral.timeBetween,
     follow: isRandom.followDepth
-      ? Math.floor(
-          Math.random() * settings.lookupRandomizeFollow.maximumDepth +
-            settings.lookupRandomizeFollow.minimumDepth
+      ? randomWithin(
+          settings.lookupRandomizeFollow.minimumDepth,
+          settings.lookupRandomizeFollow.maximumDepth
         )
       : settings.lookupGeneral.follow,
     timeout: isRandom.timeout
-      ? Math.floor(
-          Math.random() * settings.lookupRandomizeTimeout.maximum +
-            settings.lookupRandomizeTimeout.minimum
+      ? randomWithin(
+          settings.lookupRandomizeTimeout.minimum,
+          settings.lookupRandomizeTimeout.maximum
         )
       : settings.lookupGeneral.timeout
   };

--- a/test/getDomainSetup.test.ts
+++ b/test/getDomainSetup.test.ts
@@ -25,19 +25,13 @@ describe('getDomainSetup', () => {
     });
 
     expect(result.timebetween).toBeGreaterThanOrEqual(settings.lookupRandomizeTimeBetween.minimum);
-    expect(result.timebetween).toBeLessThan(
-      settings.lookupRandomizeTimeBetween.minimum + settings.lookupRandomizeTimeBetween.maximum
-    );
+    expect(result.timebetween).toBeLessThanOrEqual(settings.lookupRandomizeTimeBetween.maximum);
 
     expect(result.follow).toBeGreaterThanOrEqual(settings.lookupRandomizeFollow.minimumDepth);
-    expect(result.follow).toBeLessThan(
-      settings.lookupRandomizeFollow.minimumDepth + settings.lookupRandomizeFollow.maximumDepth
-    );
+    expect(result.follow).toBeLessThanOrEqual(settings.lookupRandomizeFollow.maximumDepth);
 
     expect(result.timeout).toBeGreaterThanOrEqual(settings.lookupRandomizeTimeout.minimum);
-    expect(result.timeout).toBeLessThan(
-      settings.lookupRandomizeTimeout.minimum + settings.lookupRandomizeTimeout.maximum
-    );
+    expect(result.timeout).toBeLessThanOrEqual(settings.lookupRandomizeTimeout.maximum);
 
     Object.assign(settings.lookupRandomizeTimeBetween, backup.lookupRandomizeTimeBetween);
     Object.assign(settings.lookupRandomizeFollow, backup.lookupRandomizeFollow);


### PR DESCRIPTION
## Summary
- ensure minimum/maximum are validated in `getDomainSetup`
- return random values inclusive of the bounds
- update `getDomainSetup` test to check inclusive range

## Testing
- `npm run lint`
- `npm run format:check`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6861860bab7c8325a62c47782193dabb