### PR TITLE
feat: fallback to node-fetch

### DIFF
--- a/app/ts/ai/openaiSuggest.ts
+++ b/app/ts/ai/openaiSuggest.ts
@@ -3,7 +3,15 @@ import { settings } from '../common/settings.js';
 
 const debug = debugModule('ai.openaiSuggest');
 
+async function ensureFetch(): Promise<void> {
+  if (typeof globalThis.fetch === 'undefined') {
+    const { default: fetchImpl } = await import('node-fetch');
+    (globalThis as any).fetch = fetchImpl as unknown as typeof fetch;
+  }
+}
+
 export async function suggestWords(prompt: string, count: number): Promise<string[]> {
+  await ensureFetch();
   const { url, apiKey } = settings.ai.openai ?? {};
   if (!url || !apiKey) {
     debug('OpenAI API disabled');

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "idna-uts46": "^1.1.0",
         "jquery": "^3.7.1",
         "jszip": "^3.10.1",
+        "node-fetch": "^3.3.2",
         "papaparse": "^5.5.3",
         "psl": "^1.15.0",
         "punycode": "^2.3.1",
@@ -6599,7 +6600,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -8149,7 +8149,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
       "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8402,7 +8401,6 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fetch-blob": "^3.1.2"
@@ -11110,7 +11108,6 @@
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "deprecated": "Use your platform's native DOMException instead",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11130,7 +11127,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
@@ -14770,7 +14766,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "papaparse": "^5.5.3",
     "psl": "^1.15.0",
     "punycode": "^2.3.1",
-    "whois": "^2.14.2"
+    "whois": "^2.14.2",
+    "node-fetch": "^3.3.2"
   },
   "devDependencies": {
     "@babel/core": "^7.27.4",

--- a/test/openaiSuggest.test.ts
+++ b/test/openaiSuggest.test.ts
@@ -1,6 +1,9 @@
 import { suggestWords } from '../app/ts/ai/openaiSuggest';
 import { settings } from '../app/ts/common/settings';
 
+const nodeFetchMock = jest.fn();
+jest.mock('node-fetch', () => ({ __esModule: true, default: nodeFetchMock }), { virtual: true });
+
 describe('openai suggestions', () => {
   beforeEach(() => {
     (global as any).fetch = jest.fn();
@@ -24,5 +27,18 @@ describe('openai suggestions', () => {
     const res = await suggestWords('hi', 3);
     expect((fetch as jest.Mock).mock.calls.length).toBe(0);
     expect(res).toEqual([]);
+  });
+
+  test('falls back to node-fetch when fetch missing', async () => {
+    delete (global as any).fetch;
+    settings.ai.openai.url = 'https://api';
+    settings.ai.openai.apiKey = 'key';
+    nodeFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'alpha' } }] })
+    });
+    const res = await suggestWords('hello', 1);
+    expect(nodeFetchMock).toHaveBeenCalled();
+    expect(res).toEqual(['alpha']);
   });
 });


### PR DESCRIPTION
## Summary
- detect missing `fetch` in `openaiSuggest`
- fallback to dynamic `node-fetch` import when needed
- test `node-fetch` fallback path
- include `node-fetch` runtime dependency

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686185fc29508325a94f4cdb32ae0881