### PR TITLE
refactor: convert console logs to debug

### DIFF
--- a/app/ts/cli.ts
+++ b/app/ts/cli.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import JSZip from 'jszip';
+import debugModule from 'debug';
 import { lookup as whoisLookup } from './common/lookup.js';
 import { settings } from './common/settings.js';
 import { purgeExpired, clearCache } from './common/requestCache.js';
@@ -11,6 +12,8 @@ import { toJSON } from './common/parser.js';
 import { generateFilename } from './main/bw/export.js';
 import { downloadModel } from './ai/modelDownloader.js';
 import { suggestWords } from './ai/openaiSuggest.js';
+
+const debug = debugModule('cli');
 
 export interface CliOptions {
   domains: string[];
@@ -143,7 +146,8 @@ if (require.main === module) {
     if (opts.suggest) {
       const words = await suggestWords(opts.suggest, opts.suggestCount ?? 5);
       for (const w of words) {
-        console.log(w);
+        console.info(w);
+        debug(w);
       }
       return;
     }
@@ -154,21 +158,25 @@ if (require.main === module) {
         return;
       }
       await downloadModel(url, settings.ai.modelPath);
-      console.log('Model downloaded');
+      console.info('Model downloaded');
+      debug('Model downloaded');
       return;
     }
     if (opts.purgeCache || opts.clearCache) {
       if (opts.clearCache) {
         clearCache();
-        console.log('Cache cleared');
+        console.info('Cache cleared');
+        debug('Cache cleared');
       } else {
         const purged = purgeExpired();
-        console.log(`Purged ${purged} expired entries`);
+        console.info(`Purged ${purged} expired entries`);
+        debug(`Purged ${purged} expired entries`);
       }
       return;
     }
     const results = await lookupDomains(opts);
     const outPath = await exportResults(results, opts);
-    console.log(`Results written to ${path.resolve(outPath)}`);
+    console.info(`Results written to ${path.resolve(outPath)}`);
+    debug(`Results written to ${path.resolve(outPath)}`);
   })();
 }

--- a/app/ts/server/index.ts
+++ b/app/ts/server/index.ts
@@ -1,6 +1,9 @@
 import express, { Request, Response } from 'express';
 import { lookup } from '../common/lookup.js';
 import { lookupDomains, CliOptions } from '../cli.js';
+import debugModule from 'debug';
+
+const debug = debugModule('server');
 
 export function createServer() {
   const app = express();
@@ -42,6 +45,6 @@ export function createServer() {
 if (process.argv[1] && process.argv[1].endsWith('server/index.js')) {
   const port = Number(process.env.PORT) || 3000;
   createServer().listen(port, () => {
-    console.log(`Server listening on port ${port}`);
+    debug(`Server listening on port ${port}`);
   });
 }


### PR DESCRIPTION
## Summary
- switch CLI and server logging to `debug`
- keep user-facing output with `console.info`

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68618606dd18832591dafbda843bb0c6