### PR TITLE
fix handlebars runtime path

### DIFF
--- a/app/html/templates/mainPanel.hbs
+++ b/app/html/templates/mainPanel.hbs
@@ -15,6 +15,13 @@
     <link href="../css/style.css" rel="stylesheet" />
     <link href="../css/tables.css" rel="stylesheet" />
     <!--<link href="../css/fontawesome/all.min.css" rel="stylesheet">-->
+    <script type="importmap">
+      {
+        "imports": {
+          "handlebars/runtime.js": "../../../node_modules/handlebars/runtime.js"
+        }
+      }
+    </script>
     <script type="module" src="./startup.js"></script>
   </head>
 

--- a/app/ts/renderer/i18n.ts
+++ b/app/ts/renderer/i18n.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { dirnameCompat } from '../utils/dirnameCompat.js';
 
 const baseDir = dirnameCompat();
-import Handlebars from 'handlebars/runtime.js';
+const Handlebars = require('handlebars/runtime.js').default;
 
 let translations: Record<string, string> = {};
 

--- a/app/ts/renderer/registerPartials.ts
+++ b/app/ts/renderer/registerPartials.ts
@@ -1,4 +1,4 @@
-import Handlebars from 'handlebars/runtime.js';
+const Handlebars = require('handlebars/runtime.js').default;
 
 import bwEntry from '../../compiled-templates/bwEntry.js';
 import bwExport from '../../compiled-templates/bwExport.js';

--- a/app/ts/renderer/templateLoader.ts
+++ b/app/ts/renderer/templateLoader.ts
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import Handlebars from 'handlebars/runtime.js';
+const Handlebars = require('handlebars/runtime.js').default;
 
 export async function loadTemplate(
   selector: string,

--- a/types/handlebars-runtime.d.ts
+++ b/types/handlebars-runtime.d.ts
@@ -2,3 +2,8 @@ declare module 'handlebars/runtime.js' {
   import Handlebars from 'handlebars';
   export default Handlebars;
 }
+
+declare module '../../../node_modules/handlebars/runtime.js' {
+  import Handlebars from 'handlebars';
+  export default Handlebars;
+}


### PR DESCRIPTION
## Summary
- load Handlebars using `require` so Electron can resolve it
- map the module via import map
- extend TypeScript definitions for the new require path

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68618ccccde08325a0608e89d66db743