### PR TITLE
Fix debug import in renderer

### DIFF
--- a/app/ts/common/availability.ts
+++ b/app/ts/common/availability.ts
@@ -1,11 +1,11 @@
-import debugModule from 'debug';
+import { debugFactory } from './logger.js';
 import { getDate } from './conversions.js';
 import { toJSON } from './parser.js';
 import { settings as appSettings, Settings } from './settings.js';
 import { checkPatterns } from './whoiswrapper/patterns.js';
 import { predict as aiPredict } from '../ai/availabilityModel.js';
 
-const debug = debugModule('common.whoisWrapper');
+const debug = debugFactory('common.whoisWrapper');
 let settings: Settings = appSettings;
 
 export interface WhoisResult {

--- a/app/ts/common/logger.ts
+++ b/app/ts/common/logger.ts
@@ -1,0 +1,21 @@
+export function debugFactory(namespace: string) {
+  return (...args: unknown[]): void => {
+    const message = `[${namespace}] ${args.map(String).join(' ')}`;
+    if (typeof window !== 'undefined' && (window as any)?.electron) {
+      (window as any).electron.send('app:debug', message);
+    } else {
+      console.debug(message);
+    }
+  };
+}
+
+export function errorFactory(namespace: string) {
+  return (...args: unknown[]): void => {
+    const message = `[${namespace}] ${args.map(String).join(' ')}`;
+    if (typeof window !== 'undefined' && (window as any)?.electron) {
+      (window as any).electron.send('app:error', message);
+    } else {
+      console.error(message);
+    }
+  };
+}

--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -3,9 +3,9 @@ import * as path from 'path';
 import { dirnameCompat } from '../utils/dirnameCompat.js';
 import { app, ipcRenderer } from 'electron'; // Correctly use Electron API
 import * as remote from '@electron/remote'; // Import remote as a whole
-import debugModule from 'debug';
+import { debugFactory } from './logger.js';
 import appDefaults from '../appsettings.js';
-const debug = debugModule('common.settings');
+const debug = debugFactory('common.settings');
 
 let watcher: fs.FSWatcher | undefined;
 

--- a/app/ts/renderer.ts
+++ b/app/ts/renderer.ts
@@ -5,6 +5,7 @@ import './renderer/index';
 import { loadSettings, settings, customSettingsLoaded } from './common/settings.js';
 import { loadTranslations, registerTranslationHelpers } from './renderer/i18n.js';
 import { formatString } from './common/stringformat.js';
+import { sendDebug, sendError } from './renderer/logger.js';
 
 const electron = (window as any).electron as {
   send: (channel: string, ...args: any[]) => void;
@@ -14,26 +15,6 @@ const electron = (window as any).electron as {
 
 (window as any).$ = $;
 (window as any).jQuery = $;
-
-interface DebugMessage {
-  channel: 'app:debug';
-  message: string;
-}
-
-interface ErrorMessage {
-  channel: 'app:error';
-  message: string;
-}
-
-function sendDebug(message: string): void {
-  const payload: DebugMessage = { channel: 'app:debug', message };
-  electron.send(payload.channel, payload.message);
-}
-
-function sendError(message: string): void {
-  const payload: ErrorMessage = { channel: 'app:error', message };
-  electron.send(payload.channel, payload.message);
-}
 
 /*
   $(document).ready(function() {...});

--- a/app/ts/renderer/bw/fileinput.ts
+++ b/app/ts/renderer/bw/fileinput.ts
@@ -2,8 +2,8 @@ import * as conversions from '../../common/conversions.js';
 import fs from 'fs';
 import path from 'path';
 import type { FileStats } from '../../common/fileStats.js';
-import debugModule from 'debug';
-const debug = debugModule('renderer.bw.fileinput');
+import { debugFactory } from '../../common/logger.js';
+const debug = debugFactory('renderer.bw.fileinput');
 
 const electron = (window as any).electron as {
   send: (channel: string, ...args: any[]) => void;

--- a/app/ts/renderer/logger.ts
+++ b/app/ts/renderer/logger.ts
@@ -1,0 +1,11 @@
+const electron = (window as any).electron as {
+  send: (channel: string, ...args: any[]) => void;
+};
+
+export function sendDebug(message: string): void {
+  electron.send('app:debug', message);
+}
+
+export function sendError(message: string): void {
+  electron.send('app:error', message);
+}


### PR DESCRIPTION
## Summary
- replace `debug` imports in renderer-side modules
- add IPC-based logger helpers
- wire renderer scripts to use the new logger

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6861bc62db988325977652d7e62fbe9c