### PR TITLE
Potential fix for code scanning alert no. 36: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -83,6 +83,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
     steps:
       - uses: actions/setup-node@v4
         with:
@@ -140,6 +143,8 @@ jobs:
   docker-build:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Build Docker image


### PR DESCRIPTION
Potential fix for [https://github.com/supermarsx/whoisdigger/security/code-scanning/36](https://github.com/supermarsx/whoisdigger/security/code-scanning/36)

To fix the issue, we need to add an explicit `permissions` block to the workflow. This block should define the minimum permissions required for each job. For example:
- Jobs that only read repository contents should have `contents: read`.
- Jobs that upload artifacts or interact with pull requests may require specific write permissions, such as `contents: write` or `pull-requests: write`.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within individual jobs to tailor permissions to their specific needs. In this case, we will add permissions to each job individually to ensure the principle of least privilege is followed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
