### PR TITLE
feat: add fs IPC layer and preload wrappers

### DIFF
--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -74,7 +74,7 @@ interface MainSettings extends BaseSettings {
   [key: string]: any;
 }
 
-import './main/index.js';
+import './main/fsIpc.js';
 
 let settings: MainSettings;
 let mainWindow: BrowserWindow;

--- a/app/ts/main/fsIpc.ts
+++ b/app/ts/main/fsIpc.ts
@@ -1,0 +1,47 @@
+import { ipcMain } from 'electron';
+import fs from 'fs';
+
+const watchers = new Map<number, fs.FSWatcher>();
+let watcherId = 0;
+
+ipcMain.handle('fs:readFile', async (_e, p: string, opts?: any) => {
+  return fs.promises.readFile(p, opts);
+});
+
+ipcMain.handle('fs:stat', async (_e, p: string) => {
+  return fs.promises.stat(p);
+});
+
+ipcMain.handle('fs:readdir', async (_e, p: string, opts?: any) => {
+  return fs.promises.readdir(p, opts);
+});
+
+ipcMain.handle('fs:unlink', async (_e, p: string) => {
+  return fs.promises.unlink(p);
+});
+
+ipcMain.handle('fs:access', async (_e, p: string, mode?: number) => {
+  return fs.promises.access(p, mode);
+});
+
+ipcMain.handle('fs:exists', async (_e, p: string) => {
+  return fs.existsSync(p);
+});
+
+ipcMain.handle('fs:watch', (e, p: string, opts?: fs.WatchOptions) => {
+  const id = ++watcherId;
+  const sender = e.sender;
+  const watcher = fs.watch(p, opts || {}, (event) => {
+    sender.send(`fs:watch:${id}`, event);
+  });
+  watchers.set(id, watcher);
+  return id;
+});
+
+ipcMain.handle('fs:unwatch', (_e, id: number) => {
+  const watcher = watchers.get(id);
+  if (watcher) {
+    watcher.close();
+    watchers.delete(id);
+  }
+});

--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -1,5 +1,4 @@
 import * as conversions from '../../common/conversions.js';
-import fs from 'fs';
 import Papa from 'papaparse';
 import datatables from 'datatables';
 const dt = datatables();

--- a/app/ts/renderer/i18n.ts
+++ b/app/ts/renderer/i18n.ts
@@ -1,16 +1,18 @@
-import fs from 'fs';
-import path from 'path';
 import { dirnameCompat } from '../utils/dirnameCompat.js';
 
 const baseDir = dirnameCompat();
 import Handlebars from '../../vendor/handlebars.runtime.js';
 
+const electron = (window as any).electron as {
+  readFile: (p: string, enc?: any) => Promise<any>;
+  path: { join: (...args: string[]) => string };
+};
 let translations: Record<string, string> = {};
 
 export async function loadTranslations(lang: string): Promise<void> {
-  const file = path.join(baseDir, '..', 'locales', `${lang}.json`);
+  const file = electron.path.join(baseDir, '..', 'locales', `${lang}.json`);
   try {
-    const raw = await fs.promises.readFile(file, 'utf8');
+    const raw = await electron.readFile(file, 'utf8');
     translations = JSON.parse(raw);
   } catch {
     translations = {};

--- a/test/i18n.test.ts
+++ b/test/i18n.test.ts
@@ -11,6 +11,10 @@ const readFileMock = require('fs').promises.readFile as jest.Mock;
 describe('i18n loader', () => {
   beforeEach(() => {
     readFileMock.mockReset();
+    (window as any).electron = {
+      readFile: readFileMock,
+      path: { join: (...args: string[]) => require('path').join(...args) }
+    };
   });
 
   test('loads translations and registers helper', async () => {

--- a/test/rendererOptions.test.ts
+++ b/test/rendererOptions.test.ts
@@ -42,7 +42,14 @@ beforeEach(() => {
     invoke: invokeMock,
     openPath: openPathMock,
     send: jest.fn(),
-    on: jest.fn()
+    on: jest.fn(),
+    path: { join: (...args: string[]) => require('path').join(...args) },
+    readdir: jest.fn(async () => []),
+    stat: jest.fn(async () => ({ size: 0, mtime: new Date(), atime: new Date() })),
+    access: jest.fn(async () => {}),
+    exists: jest.fn(async () => false),
+    unlink: jest.fn(async () => {}),
+    watch: jest.fn(async () => ({ close: () => {} }))
   };
   invokeMock.mockClear();
   openPathMock.mockClear();


### PR DESCRIPTION
## Summary
- add fsIpc module to expose filesystem APIs
- register handlers on startup
- provide preload helpers for fs and path access
- update renderer files to use preload APIs
- adjust related unit tests

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: e2e due to WebDriverError)*

------
https://chatgpt.com/codex/tasks/task_e_6861ddd55d808325a6e61a8d747da22e