### PR TITLE
Add vendor regen script

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test": "jest",
     "test:e2e": "node test/e2e/run.js",
     "prebuild": "node scripts/prebuild.js",
+    "regen:vendor": "node scripts/regenerateVendor.js",
     "postinstall": "simple-git-hooks",
     "clean": "rimraf dist release_builds app/compiled-templates",
     "pretest": "node scripts/prebuild.js"

--- a/readme.md
+++ b/readme.md
@@ -285,6 +285,7 @@ If you need a fresh build, run `npm run clean` first to remove the `dist`, `rele
 which minifies files from `app/css` into `dist/app/css`.
 It also precompiles Handlebars templates and writes `dist/app/html/mainPanel.html`
 from `app/html/templates/mainPanel.hbs`.
+Use `npm run regen:vendor` to regenerate the scripts in `app/vendor` after updating dependencies.
 
 MacOS
 

--- a/scripts/regenerateVendor.js
+++ b/scripts/regenerateVendor.js
@@ -1,0 +1,54 @@
+import fs from 'fs';
+import path from 'path';
+import { dirnameCompat } from './dirnameCompat.js';
+
+const baseDir = dirnameCompat();
+const rootDir = path.join(baseDir, '..');
+const modulesDir = path.join(rootDir, 'node_modules');
+const vendorDir = path.join(rootDir, 'app', 'vendor');
+
+function copyFile(src, dest) {
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.copyFileSync(src, dest);
+}
+
+function writeFile(dest, content) {
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.writeFileSync(dest, content);
+}
+
+copyFile(
+  path.join(modulesDir, 'handlebars', 'dist', 'handlebars.runtime.js'),
+  path.join(vendorDir, 'handlebars.runtime.js')
+);
+writeFile(
+  path.join(vendorDir, 'handlebars.runtime.d.ts'),
+  "import Handlebars from 'handlebars';\nexport default Handlebars;\n"
+);
+
+copyFile(path.join(modulesDir, 'jquery', 'dist', 'jquery.js'), path.join(vendorDir, 'jquery.js'));
+writeFile(
+  path.join(vendorDir, 'jquery.d.ts'),
+  "import jQuery from 'jquery';\nexport default jQuery;\n"
+);
+
+copyFile(
+  path.join(modulesDir, 'change-case', 'dist', 'index.js'),
+  path.join(vendorDir, 'change-case.js')
+);
+writeFile(path.join(vendorDir, 'change-case.d.ts'), "export * from 'change-case';\n");
+
+const htmlSrcDir = path.join(modulesDir, 'html-entities', 'dist', 'esm');
+const htmlDestDir = path.join(vendorDir, 'html-entities');
+fs.mkdirSync(htmlDestDir, { recursive: true });
+for (const file of [
+  'index.js',
+  'index.d.ts',
+  'named-references.js',
+  'numeric-unicode-map.js',
+  'surrogate-pairs.js'
+]) {
+  copyFile(path.join(htmlSrcDir, file), path.join(htmlDestDir, file));
+}
+
+console.log('Vendor scripts regenerated.');


### PR DESCRIPTION
## Summary
- add `regenerateVendor.js` helper
- expose `npm run regen:vendor` script
- document vendor regeneration step

## Testing
- `npm run lint`
- `npm run format`
- `npx tsc --noEmit`
- `npm test -- -w=1`


------
https://chatgpt.com/codex/tasks/task_e_6862b88717588325a579118ba7e249f9