### PR TITLE
refactor(cli): isolate export helpers

### DIFF
--- a/app/ts/cli.ts
+++ b/app/ts/cli.ts
@@ -9,14 +9,13 @@ import { settings } from './common/settings.js';
 import { RequestCache } from './common/requestCache.js';
 import { isDomainAvailable, getDomainParameters, WhoisResult } from './common/availability.js';
 import { toJSON } from './common/parser.js';
-import { generateFilename } from './main/bw/export.js';
+import { generateFilename } from './cli/export.js';
 import { downloadModel } from './ai/modelDownloader.js';
 import { suggestWords } from './ai/openaiSuggest.js';
 
 const requestCache = new RequestCache();
 
 const debug = debugModule('cli');
-
 
 export interface CliOptions {
   domains: string[];

--- a/app/ts/cli/export.ts
+++ b/app/ts/cli/export.ts
@@ -1,0 +1,17 @@
+export function generateFilename(ext: string): string {
+  function pad(n: number): string {
+    return String(n).padStart(2, '0');
+  }
+  const d = new Date();
+  const datetime =
+    d.getFullYear().toString() +
+    pad(d.getMonth() + 1) +
+    pad(d.getDate()) +
+    pad(d.getHours()) +
+    pad(d.getMinutes()) +
+    pad(d.getSeconds());
+  const hex = Math.floor(Math.random() * 0xffffff)
+    .toString(16)
+    .padStart(6, '0');
+  return `bulkwhois-export-${datetime}-${hex}${ext}`;
+}

--- a/app/ts/main/bw/export.ts
+++ b/app/ts/main/bw/export.ts
@@ -10,24 +10,7 @@ import { formatString } from '../../common/stringformat.js';
 const { app, BrowserWindow, Menu, ipcMain, dialog, remote, shell } = electron;
 
 import { getSettings } from '../../common/settings.js';
-
-export function generateFilename(ext: string): string {
-  function pad(n: number): string {
-    return String(n).padStart(2, '0');
-  }
-  const d = new Date();
-  const datetime =
-    d.getFullYear().toString() +
-    pad(d.getMonth() + 1) +
-    pad(d.getDate()) +
-    pad(d.getHours()) +
-    pad(d.getMinutes()) +
-    pad(d.getSeconds());
-  const hex = Math.floor(Math.random() * 0xffffff)
-    .toString(16)
-    .padStart(6, '0');
-  return `bulkwhois-export-${datetime}-${hex}${ext}`;
-}
+import { generateFilename } from '../../cli/export.js';
 
 /*
   ipcMain.on('bw:export', function(...) {...});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,4 +1,3 @@
-import './electronMainMock';
 import fs from 'fs';
 import path from 'path';
 import { parseArgs, lookupDomains, exportResults, CliOptions } from '../app/ts/cli';

--- a/test/generateFilename.test.ts
+++ b/test/generateFilename.test.ts
@@ -1,5 +1,4 @@
-import './electronMainMock';
-import { generateFilename } from '../app/ts/main/bw/export';
+import { generateFilename } from '../app/ts/cli/export';
 
 describe('generateFilename', () => {
   const RealDate = Date;


### PR DESCRIPTION
## Summary
- extract CLI file-export helpers into new `app/ts/cli/export.ts`
- update CLI and main export module to use the new helper
- drop electron mocks from CLI tests
- adjust generateFilename tests

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6862bc018ce48325bfae24ee71a696a3