### PR TITLE
build: output main and renderer to dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "type": "module",
   "description": "Bulk whois lookup tool",
-  "main": "./dist/app/ts/main.js",
+  "main": "./dist/main/main.js",
   "scripts": {
     "start": "npm run build && npm run postbuild && cross-env NODE_OPTIONS=--experimental-specifier-resolution=node electron .",
     "debug-powershell": "@powershell -Command $env:DEBUG='*';npm start;",

--- a/scripts/create-esm-links.js
+++ b/scripts/create-esm-links.js
@@ -3,7 +3,11 @@ import path from 'path';
 import { dirnameCompat } from './dirnameCompat.js';
 const baseDir = dirnameCompat();
 
-const distDir = path.join(baseDir, '..', 'dist', 'app', 'ts');
+const distDirs = [
+  path.join(baseDir, '..', 'dist', 'app', 'ts'),
+  path.join(baseDir, '..', 'dist', 'main'),
+  path.join(baseDir, '..', 'dist', 'renderer')
+];
 
 function processDir(dir) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -19,4 +23,8 @@ function processDir(dir) {
   }
 }
 
-processDir(distDir);
+for (const dir of distDirs) {
+  if (fs.existsSync(dir)) {
+    processDir(dir);
+  }
+}

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -24,6 +24,7 @@ const folders = [
 const rootDir = path.join(baseDir, '..');
 const appDir = path.join(rootDir, 'app');
 const distDir = path.join(rootDir, 'dist', 'app');
+const distRoot = path.join(rootDir, 'dist');
 
 for (const folder of folders) {
   const src = path.join(appDir, folder);
@@ -46,6 +47,26 @@ const bulmaSrc = path.join(rootDir, 'node_modules', 'bulma', 'css');
 const bulmaDest = path.join(distDir, 'css', 'bulma', 'css');
 if (fs.existsSync(bulmaSrc)) {
   copyRecursiveSync(bulmaSrc, bulmaDest);
+}
+
+// Move compiled TypeScript outputs to top-level dist folders
+const builtMain = path.join(distDir, 'ts', 'main');
+const builtRenderer = path.join(distDir, 'ts', 'renderer');
+const finalMain = path.join(distRoot, 'main');
+const finalRenderer = path.join(distRoot, 'renderer');
+const builtMainFile = path.join(distDir, 'ts', 'main.js');
+const finalMainFile = path.join(finalMain, 'main.js');
+fs.rmSync(finalMain, { recursive: true, force: true });
+fs.rmSync(finalRenderer, { recursive: true, force: true });
+if (fs.existsSync(builtMain)) {
+  fs.renameSync(builtMain, finalMain);
+}
+if (fs.existsSync(builtRenderer)) {
+  fs.renameSync(builtRenderer, finalRenderer);
+}
+if (fs.existsSync(builtMainFile)) {
+  fs.mkdirSync(finalMain, { recursive: true });
+  fs.renameSync(builtMainFile, finalMainFile);
 }
 
 // Precompile Handlebars templates into dist/app/compiled-templates

--- a/test/e2e/run.js
+++ b/test/e2e/run.js
@@ -14,7 +14,7 @@ const debug = debugModule('test:e2e');
 
 (async () => {
   const electronPath = electron;
-  const appPath = path.resolve(baseDir, '..', '..', 'dist', 'app', 'ts', 'main.js');
+  const appPath = path.resolve(baseDir, '..', '..', 'dist', 'main', 'main.js');
 
   const artifactsDir = path.join(baseDir, 'artifacts');
   fs.mkdirSync(artifactsDir, { recursive: true });

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "allowJs": false,
+    "noEmit": false,
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleDetection": "force",
+    "types": ["node", "jest", "better-sqlite3", "express"],
+    "typeRoots": [
+      "./node_modules/@types",
+      "./types",
+      "./types/fontawesome-free.d.ts",
+      "./types/compiled-templates.d.ts"
+    ],
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "resolveJsonModule": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,29 +1,9 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "allowJs": true,
-    "noEmit": false,
     "rootDir": ".",
-    "outDir": "dist",
-    "esModuleInterop": true,
-    "strict": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "moduleDetection": "force",
-    "types": ["node", "jest", "better-sqlite3", "express"],
-    "typeRoots": [
-      "./node_modules/@types",
-      "./types",
-      "./types/fontawesome-free.d.ts",
-      "./types/compiled-templates.d.ts"
-    ],
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "resolveJsonModule": true
+    "outDir": "dist"
   },
-  "include": ["app/ts/**/*.ts", "app/ts/server/**/*.ts", "scripts/**/*.ts", "**/*.d.ts"],
+  "include": ["app/ts/**/*.ts", "scripts/**/*.ts", "**/*.d.ts"],
   "exclude": ["test", "app/compiled-templates"]
 }


### PR DESCRIPTION
## Summary
- move main build output to `dist/main` and renderer to `dist/renderer`
- rename entry path in `package.json`
- adjust postbuild step to relocate compiled files
- handle new locations in helper scripts and tests

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format:check`
- `npm test` *(fails: fileWatcher and statsWorker tests)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6862bf298b188325a895a64883b1f6ab