### PR TITLE
refactor(ipc): invoke-based bulk ops

### DIFF
--- a/app/ts/common/ipcChannels.ts
+++ b/app/ts/common/ipcChannels.ts
@@ -1,0 +1,8 @@
+export enum IpcChannel {
+  BwLookup = 'bw:lookup',
+  BwLookupPause = 'bw:lookup.pause',
+  BwLookupContinue = 'bw:lookup.continue',
+  BwLookupStop = 'bw:lookup.stop',
+  BwInputFile = 'bw:input.file',
+  BwInputWordlist = 'bw:input.wordlist'
+}

--- a/app/ts/main/bw/fileinput.ts
+++ b/app/ts/main/bw/fileinput.ts
@@ -4,16 +4,15 @@ const debug = debugModule('main.bw.fileinput');
 
 const { app, BrowserWindow, Menu, ipcMain, dialog } = electron;
 import { formatString } from '../../common/stringformat.js';
+import { IpcChannel } from '../../common/ipcChannels.js';
 
 import { getSettings } from '../settings-main.js';
 
 /*
-  ipcMain.on('bw:input.file', function(...) {...});
-    On event: Bulk whois input file, select file dialog
-  parameters
-    event (object) - renderer object
- */
-ipcMain.on('bw:input.file', function (event) {
+  ipcMain.handle('bw:input.file', function() {...});
+    Open file dialog for bulk whois input
+*/
+ipcMain.handle(IpcChannel.BwInputFile, async () => {
   debug('Waiting for file selection');
   const filePath = dialog.showOpenDialogSync({
     title: 'Select wordlist file',
@@ -21,10 +20,8 @@ ipcMain.on('bw:input.file', function (event) {
     properties: ['openFile', 'showHiddenFiles']
   });
 
-  const { sender } = event;
-
   debug(formatString('Using selected file at {0}', filePath));
-  sender.send('bw:fileinput.confirmation', filePath);
+  return filePath;
 });
 
 /*

--- a/app/ts/main/bw/wordlistinput.ts
+++ b/app/ts/main/bw/wordlistinput.ts
@@ -3,16 +3,13 @@ import debugModule from 'debug';
 const debug = debugModule('main.bw.wordlistinput');
 
 const { app, BrowserWindow, Menu, ipcMain, dialog, remote } = electron;
+import { IpcChannel } from '../../common/ipcChannels.js';
 
 /*
-  ipcMain.on('bw:input.wordlist', function(...) {...});
-    On event: Bulk domain, wordlist input
-  parameters
-    event (object) - renderer object
- */
-ipcMain.on('bw:input.wordlist', function (event) {
-  const { sender } = event;
-
+  ipcMain.handle('bw:input.wordlist', function() {...});
+    Renderer requests wordlist mode
+*/
+ipcMain.handle(IpcChannel.BwInputWordlist, async () => {
   debug('Using wordlist input');
-  sender.send('bw:wordlistinput.confirmation');
+  return;
 });

--- a/app/ts/renderer/bw/fileinput.ts
+++ b/app/ts/renderer/bw/fileinput.ts
@@ -17,6 +17,7 @@ import $ from '../../../vendor/jquery.js';
 
 import { formatString } from '../../common/stringformat.js';
 import { settings } from '../settings-renderer.js';
+import { IpcChannel } from '../../common/ipcChannels.js';
 
 let bwFileContents: Buffer;
 let bwFileWatcher: { close: () => void } | undefined;
@@ -75,6 +76,126 @@ async function refreshBwFile(pathToFile: string): Promise<void> {
   }
 }
 
+async function handleFileConfirmation(
+  filePath: string | string[] | null = null,
+  isDragDrop = false
+): Promise<void> {
+  let bwFileStats: FileStats; // File stats, size, last changed, etc
+  const misc = settings.lookupMisc;
+  const lookup = {
+    randomize: {
+      timeBetween: settings.lookupRandomizeTimeBetween
+    }
+  };
+
+  if (bwFileWatcher) {
+    bwFileWatcher.close();
+    bwFileWatcher = undefined;
+  }
+
+  const chosenPath = Array.isArray(filePath)
+    ? filePath
+      ? (filePath as string[])[0]
+      : null
+    : (filePath as string | null);
+
+  debug(filePath);
+  if (filePath === undefined || filePath == '' || filePath === null) {
+    debug(filePath);
+    $('#bwFileinputloading').addClass('is-hidden');
+    $('#bwEntry').removeClass('is-hidden');
+  } else {
+    $('#bwLoadingInfo').text('Loading file stats...');
+    if (isDragDrop === true) {
+      $('#bwEntry').addClass('is-hidden');
+      $('#bwFileinputloading').removeClass('is-hidden');
+      try {
+        bwFileStats = (await electron.stat(filePath as string)) as FileStats;
+        bwFileStats.filename = electron.path.basename(filePath as string);
+        bwFileStats.humansize = conversions.byteToHumanFileSize(
+          bwFileStats.size,
+          misc.useStandardSize
+        );
+        $('#bwFileSpanInfo').text('Loading file contents...');
+        bwFileContents = await electron.readFile(filePath as string);
+      } catch (e) {
+        electron.send('app:error', `Failed to read file: ${e}`);
+        $('#bwFileSpanInfo').text('Failed to load file');
+        return;
+      }
+    } else {
+      try {
+        bwFileStats = (await electron.stat((filePath as string[])[0])) as FileStats;
+        bwFileStats.filename = electron.path.basename((filePath as string[])[0]);
+        bwFileStats.humansize = conversions.byteToHumanFileSize(
+          bwFileStats.size,
+          misc.useStandardSize
+        );
+        $('#bwFileSpanInfo').text('Loading file contents...');
+        bwFileContents = await electron.readFile((filePath as string[])[0]);
+      } catch (e) {
+        electron.send('app:error', `Failed to read file: ${e}`);
+        $('#bwFileSpanInfo').text('Failed to load file');
+        return;
+      }
+    }
+    $('#bwFileSpanInfo').text('Getting line count...');
+    bwFileStats.linecount = bwFileContents.toString().split('\n').length;
+
+    if (lookup.randomize.timeBetween.randomize === true) {
+      bwFileStats.minestimate = conversions.msToHumanTime(
+        bwFileStats.linecount! * lookup.randomize.timeBetween.minimum
+      );
+      bwFileStats.maxestimate = conversions.msToHumanTime(
+        bwFileStats.linecount! * lookup.randomize.timeBetween.maximum
+      );
+
+      $('#bwFileSpanTimebetweenmin').text(
+        formatString('{0}ms ', lookup.randomize.timeBetween.minimum)
+      );
+      $('#bwFileSpanTimebetweenmax').text(
+        formatString('/ {0}ms', lookup.randomize.timeBetween.maximum)
+      );
+      $('#bwFileTdEstimate').text(
+        formatString('{0} to {1}', bwFileStats.minestimate, bwFileStats.maxestimate)
+      );
+    } else {
+      bwFileStats.minestimate = conversions.msToHumanTime(
+        bwFileStats.linecount! * settings.lookupGeneral.timeBetween
+      );
+      $('#bwFileSpanTimebetweenminmax').addClass('is-hidden');
+      $('#bwFileSpanTimebetweenmin').text(settings.lookupGeneral.timeBetween + 'ms');
+      $('#bwFileTdEstimate').text(formatString('> {0}', bwFileStats.minestimate));
+    }
+
+    bwFileStats.filepreview = bwFileContents.toString().substring(0, 50);
+    debug(bwFileStats.filepreview);
+    $('#bwFileinputloading').addClass('is-hidden');
+    $('#bwFileinputconfirm').removeClass('is-hidden');
+
+    // stats
+    $('#bwFileTdName').text(String(bwFileStats.filename));
+    $('#bwFileTdLastmodified').text(conversions.getDate(bwFileStats.mtime) ?? '');
+    $('#bwFileTdLastaccess').text(conversions.getDate(bwFileStats.atime) ?? '');
+    $('#bwFileTdFilesize').text(
+      String(bwFileStats.humansize) + formatString(' ({0} line(s))', String(bwFileStats.linecount))
+    );
+    $('#bwFileTdFilepreview').text(String(bwFileStats.filepreview) + '...');
+    //$('#bwTableMaxEstimate').text(bwFileStats['maxestimate']);
+    debug('cont:' + bwFileContents);
+
+    debug(bwFileStats.linecount);
+
+    if (chosenPath) {
+      bwFileWatcher = await electron.watch(chosenPath, { persistent: false }, (evt: string) => {
+        if (evt === 'change') void refreshBwFile(chosenPath);
+      });
+    }
+  }
+
+  return;
+}
+
 /*
   electron.on('bw:fileinput.confirmation', function(...) {...});
     // File input, path and information confirmation container
@@ -85,122 +206,8 @@ async function refreshBwFile(pathToFile: string): Promise<void> {
  */
 electron.on(
   'bw:fileinput.confirmation',
-  async function (event, filePath: string | string[] | null = null, isDragDrop = false) {
-    let bwFileStats: FileStats; // File stats, size, last changed, etc
-    const misc = settings.lookupMisc;
-    const lookup = {
-      randomize: {
-        timeBetween: settings.lookupRandomizeTimeBetween
-      }
-    };
-
-    if (bwFileWatcher) {
-      bwFileWatcher.close();
-      bwFileWatcher = undefined;
-    }
-
-    const chosenPath = Array.isArray(filePath)
-      ? filePath
-        ? (filePath as string[])[0]
-        : null
-      : (filePath as string | null);
-
-    debug(filePath);
-    if (filePath === undefined || filePath == '' || filePath === null) {
-      debug(filePath);
-      $('#bwFileinputloading').addClass('is-hidden');
-      $('#bwEntry').removeClass('is-hidden');
-    } else {
-      $('#bwLoadingInfo').text('Loading file stats...');
-      if (isDragDrop === true) {
-        $('#bwEntry').addClass('is-hidden');
-        $('#bwFileinputloading').removeClass('is-hidden');
-        try {
-          bwFileStats = (await electron.stat(filePath as string)) as FileStats;
-          bwFileStats.filename = electron.path.basename(filePath as string);
-          bwFileStats.humansize = conversions.byteToHumanFileSize(
-            bwFileStats.size,
-            misc.useStandardSize
-          );
-          $('#bwFileSpanInfo').text('Loading file contents...');
-          bwFileContents = await electron.readFile(filePath as string);
-        } catch (e) {
-          electron.send('app:error', `Failed to read file: ${e}`);
-          $('#bwFileSpanInfo').text('Failed to load file');
-          return;
-        }
-      } else {
-        try {
-          bwFileStats = (await electron.stat((filePath as string[])[0])) as FileStats;
-          bwFileStats.filename = electron.path.basename((filePath as string[])[0]);
-          bwFileStats.humansize = conversions.byteToHumanFileSize(
-            bwFileStats.size,
-            misc.useStandardSize
-          );
-          $('#bwFileSpanInfo').text('Loading file contents...');
-          bwFileContents = await electron.readFile((filePath as string[])[0]);
-        } catch (e) {
-          electron.send('app:error', `Failed to read file: ${e}`);
-          $('#bwFileSpanInfo').text('Failed to load file');
-          return;
-        }
-      }
-      $('#bwFileSpanInfo').text('Getting line count...');
-      bwFileStats.linecount = bwFileContents.toString().split('\n').length;
-
-      if (lookup.randomize.timeBetween.randomize === true) {
-        bwFileStats.minestimate = conversions.msToHumanTime(
-          bwFileStats.linecount! * lookup.randomize.timeBetween.minimum
-        );
-        bwFileStats.maxestimate = conversions.msToHumanTime(
-          bwFileStats.linecount! * lookup.randomize.timeBetween.maximum
-        );
-
-        $('#bwFileSpanTimebetweenmin').text(
-          formatString('{0}ms ', lookup.randomize.timeBetween.minimum)
-        );
-        $('#bwFileSpanTimebetweenmax').text(
-          formatString('/ {0}ms', lookup.randomize.timeBetween.maximum)
-        );
-        $('#bwFileTdEstimate').text(
-          formatString('{0} to {1}', bwFileStats.minestimate, bwFileStats.maxestimate)
-        );
-      } else {
-        bwFileStats.minestimate = conversions.msToHumanTime(
-          bwFileStats.linecount! * settings.lookupGeneral.timeBetween
-        );
-        $('#bwFileSpanTimebetweenminmax').addClass('is-hidden');
-        $('#bwFileSpanTimebetweenmin').text(settings.lookupGeneral.timeBetween + 'ms');
-        $('#bwFileTdEstimate').text(formatString('> {0}', bwFileStats.minestimate));
-      }
-
-      bwFileStats.filepreview = bwFileContents.toString().substring(0, 50);
-      debug(bwFileStats.filepreview);
-      $('#bwFileinputloading').addClass('is-hidden');
-      $('#bwFileinputconfirm').removeClass('is-hidden');
-
-      // stats
-      $('#bwFileTdName').text(String(bwFileStats.filename));
-      $('#bwFileTdLastmodified').text(conversions.getDate(bwFileStats.mtime) ?? '');
-      $('#bwFileTdLastaccess').text(conversions.getDate(bwFileStats.atime) ?? '');
-      $('#bwFileTdFilesize').text(
-        String(bwFileStats.humansize) +
-          formatString(' ({0} line(s))', String(bwFileStats.linecount))
-      );
-      $('#bwFileTdFilepreview').text(String(bwFileStats.filepreview) + '...');
-      //$('#bwTableMaxEstimate').text(bwFileStats['maxestimate']);
-      debug('cont:' + bwFileContents);
-
-      debug(bwFileStats.linecount);
-
-      if (chosenPath) {
-        bwFileWatcher = await electron.watch(chosenPath, { persistent: false }, (evt: string) => {
-          if (evt === 'change') void refreshBwFile(chosenPath);
-        });
-      }
-    }
-
-    return;
+  (_event, filePath: string | string[] | null = null, isDragDrop = false) => {
+    void handleFileConfirmation(filePath, isDragDrop);
   }
 );
 
@@ -210,8 +217,9 @@ electron.on(
  */
 $(document).on('click', '#bwEntryButtonFile', function () {
   $('#bwEntry').addClass('is-hidden');
-  $.when($('#bwFileinputloading').removeClass('is-hidden').delay(10)).done(function () {
-    electron.send('bw:input.file');
+  $.when($('#bwFileinputloading').removeClass('is-hidden').delay(10)).done(async function () {
+    const filePath = await electron.invoke(IpcChannel.BwInputFile);
+    await handleFileConfirmation(filePath);
   });
 
   return;
@@ -257,7 +265,7 @@ $(document).on('click', '#bwFileButtonConfirm', function () {
   debug(bwDomainArray);
   debug(bwTldsArray);
 
-  electron.send('bw:lookup', bwDomainArray, bwTldsArray);
+  void electron.invoke(IpcChannel.BwLookup, bwDomainArray, bwTldsArray);
 });
 
 /*

--- a/app/ts/renderer/bw/wordlistinput.ts
+++ b/app/ts/renderer/bw/wordlistinput.ts
@@ -10,6 +10,7 @@ import { tableReset } from './auxiliary.js';
 import $ from '../../../vendor/jquery.js';
 
 import { formatString } from '../../common/stringformat.js';
+import { IpcChannel } from '../../common/ipcChannels.js';
 
 let bwWordlistContents = ''; // Global wordlist input contents
 
@@ -33,7 +34,7 @@ $(document).on('click', '#bwSuggestButton', async () => {
   electron.on('bw:wordlistinput.confirmation', function() {...});
     Wordlist input, contents confirmation container
  */
-electron.on('bw:wordlistinput.confirmation', function () {
+function handleWordlistConfirmation(): void {
   const bwFileStats: Record<string, any> = {};
 
   bwWordlistContents = String($('#bwWordlistTextareaDomains').val() ?? '');
@@ -80,6 +81,10 @@ electron.on('bw:wordlistinput.confirmation', function () {
   }
 
   return;
+}
+
+electron.on('bw:wordlistinput.confirmation', () => {
+  handleWordlistConfirmation();
 });
 
 /*
@@ -110,7 +115,10 @@ $(document).on('click', '#bwWordlistinputButtonCancel', function () {
  */
 $(document).on('click', '#bwWordlistinputButtonConfirm', function () {
   $('#bwWordlistinput').addClass('is-hidden');
-  electron.send('bw:input.wordlist');
+  void (async () => {
+    await electron.invoke(IpcChannel.BwInputWordlist);
+    handleWordlistConfirmation();
+  })();
 
   return;
 });
@@ -145,7 +153,7 @@ $(document).on('click', '#bwWordlistconfirmButtonStart', function () {
   $('#bwWordlistconfirm').addClass('is-hidden');
   $('#bwProcessing').removeClass('is-hidden');
 
-  electron.send('bw:lookup', bwDomainArray, bwTldsArray);
+  void electron.invoke(IpcChannel.BwLookup, bwDomainArray, bwTldsArray);
 
   return;
 });

--- a/test/bwFileinputMain.test.ts
+++ b/test/bwFileinputMain.test.ts
@@ -1,0 +1,43 @@
+const ipcMainHandlers: Record<string, (...args: any[]) => any> = {};
+export const mockShowOpenDialogSync = jest.fn();
+
+jest.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, listener: (...args: any[]) => any) => {
+      ipcMainHandlers[channel] = listener;
+    },
+    on: jest.fn()
+  },
+  dialog: { showOpenDialogSync: mockShowOpenDialogSync },
+  app: undefined,
+  BrowserWindow: class {},
+  Menu: {}
+}));
+
+import '../app/ts/main/bw/fileinput';
+
+const handler = () => ipcMainHandlers['bw:input.file'];
+
+describe('bw fileinput handler', () => {
+  beforeEach(() => {
+    mockShowOpenDialogSync.mockReset();
+  });
+
+  test('returns selected file path', async () => {
+    mockShowOpenDialogSync.mockReturnValue('/tmp/test.txt');
+    const result = await handler()({} as any);
+
+    expect(mockShowOpenDialogSync).toHaveBeenCalledWith({
+      title: 'Select wordlist file',
+      buttonLabel: 'Open',
+      properties: ['openFile', 'showHiddenFiles']
+    });
+    expect(result).toBe('/tmp/test.txt');
+  });
+
+  test('returns undefined when no file selected', async () => {
+    mockShowOpenDialogSync.mockReturnValue(undefined);
+    const result = await handler()({} as any);
+    expect(result).toBeUndefined();
+  });
+});

--- a/test/bwRenderer.test.ts
+++ b/test/bwRenderer.test.ts
@@ -1,0 +1,87 @@
+/** @jest-environment jsdom */
+import jQuery from 'jquery';
+const handlers: Record<string, (...args: any[]) => void> = {};
+const invokeMock = jest.fn();
+const sendMock = jest.fn();
+const statMock = jest.fn();
+const readFileMock = jest.fn();
+
+jest.mock('electron', () => ({
+  ipcRenderer: {
+    invoke: (...args: any[]) => invokeMock(...args),
+    send: (...args: any[]) => sendMock(...args),
+    on: (channel: string, cb: (...args: any[]) => void) => {
+      handlers[channel] = cb;
+    }
+  }
+}));
+
+beforeEach(() => {
+  jest.resetModules();
+  document.body.innerHTML = `
+    <button id="bwEntryButtonFile"></button>
+    <div id="bwFileinputloading" class="is-hidden"></div>
+    <div id="bwEntry"></div>
+    <button id="bwFileButtonConfirm"></button>
+    <input id="bwFileInputTlds" />
+    <div id="bwFileinputconfirm"></div>
+    <div id="bwProcessing" class="is-hidden"></div>
+    <textarea id="bwWordlistTextareaDomains"></textarea>
+    <button id="bwWordlistinputButtonConfirm"></button>
+    <div id="bwWordlistinput"></div>
+    <button id="bwWordlistconfirmButtonStart"></button>
+    <input id="bwWordlistInputTlds" />
+    <div id="bwWordlistconfirm"></div>
+  `;
+  (window as any).$ = (window as any).jQuery = jQuery;
+  (window as any).electron = {
+    invoke: invokeMock,
+    send: sendMock,
+    on: (channel: string, cb: (...args: any[]) => void) => {
+      handlers[channel] = cb;
+    },
+    stat: statMock,
+    readFile: readFileMock,
+    path: { basename: require('path').basename },
+    watch: jest.fn(async () => ({ close: jest.fn() }))
+  };
+  invokeMock.mockReset();
+  sendMock.mockReset();
+  statMock.mockResolvedValue({ size: 0, mtime: new Date(), atime: new Date() });
+  readFileMock.mockResolvedValue(Buffer.from('a\nb'));
+});
+
+test('invokes bw:input.file and bw:lookup', async () => {
+  jest.isolateModules(() => {
+    require('../app/ts/renderer/bw/fileinput');
+  });
+  jQuery('#bwEntryButtonFile').trigger('click');
+  await new Promise((r) => setTimeout(r, 20));
+  expect(invokeMock).toHaveBeenCalledWith('bw:input.file');
+  invokeMock.mockClear();
+  handlers['bw:fileinput.confirmation']?.({}, '/tmp/list.txt', false);
+  await new Promise((r) => setTimeout(r, 0));
+  jQuery('#bwFileInputTlds').val('com');
+
+  jQuery('#bwFileButtonConfirm').trigger('click');
+  await new Promise((r) => setTimeout(r, 0));
+
+  expect(invokeMock).toHaveBeenCalledWith('bw:lookup', ['a', 'b'], ['com']);
+});
+
+test('invokes bw:input.wordlist and lookup', async () => {
+  jest.isolateModules(() => {
+    require('../app/ts/renderer/bw/wordlistinput');
+  });
+  jQuery('#bwWordlistTextareaDomains').val('c\nd');
+  jQuery('#bwWordlistInputTlds').val('net');
+  jQuery('#bwWordlistinputButtonConfirm').trigger('click');
+  await new Promise((r) => setTimeout(r, 0));
+  expect(invokeMock).toHaveBeenCalledWith('bw:input.wordlist');
+  invokeMock.mockClear();
+  handlers['bw:wordlistinput.confirmation']?.();
+  jQuery('#bwWordlistconfirmButtonStart').trigger('click');
+  await new Promise((r) => setTimeout(r, 0));
+  expect(invokeMock).toHaveBeenCalledWith('bw:lookup', ['c', 'd'], ['net']);
+});
+

--- a/test/bwWordlistMain.test.ts
+++ b/test/bwWordlistMain.test.ts
@@ -1,0 +1,23 @@
+const ipcMainHandlers: Record<string, (...args: any[]) => any> = {};
+
+jest.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, listener: (...args: any[]) => any) => {
+      ipcMainHandlers[channel] = listener;
+    }
+  },
+  app: undefined,
+  BrowserWindow: class {},
+  Menu: {}
+}));
+
+import '../app/ts/main/bw/wordlistinput';
+
+const handler = () => ipcMainHandlers['bw:input.wordlist'];
+
+describe('bw wordlist handler', () => {
+  test('resolves without value', async () => {
+    const res = await handler()({} as any);
+    expect(res).toBeUndefined();
+  });
+});

--- a/test/fileWatcher.test.ts
+++ b/test/fileWatcher.test.ts
@@ -3,6 +3,7 @@
 import { EventEmitter } from 'events';
 import jQuery from 'jquery';
 import path from 'path';
+jest.setTimeout(10000);
 const ipc = new EventEmitter() as any;
 ipc.send = jest.fn();
 const watchEmitter = new EventEmitter() as any;

--- a/test/rendererOptions.test.ts
+++ b/test/rendererOptions.test.ts
@@ -3,6 +3,7 @@
 let jQuery: typeof import('../app/vendor/jquery.js');
 let settingsModule: any;
 const invokeMock = jest.fn();
+jest.setTimeout(10000);
 const openPathMock = jest.fn();
 
 jest.mock('worker_threads', () => ({


### PR DESCRIPTION
## Summary
- refactor bulk WHOIS workflow to use `ipcMain.handle`/`ipcRenderer.invoke`
- centralize IPC channel names
- update renderer logic for new IPC APIs
- add unit tests for new IPC handlers

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6862fe6373e08325886189713e889edb