### PR TITLE
refactor: move options watcher to main

### DIFF
--- a/app/ts/main/index.ts
+++ b/app/ts/main/index.ts
@@ -5,3 +5,4 @@ import './to.js';
 import './cache.js';
 import './ai.js';
 import './history.js';
+import './options.js';

--- a/app/ts/main/options.ts
+++ b/app/ts/main/options.ts
@@ -1,0 +1,125 @@
+import { ipcMain } from 'electron';
+import path from 'path';
+import fs from 'fs';
+import chokidar from 'chokidar';
+import { Worker } from 'worker_threads';
+import { dirnameCompat } from '../utils/dirnameCompat.js';
+
+interface WatchState {
+  worker?: Worker;
+  watcher?: chokidar.FSWatcher;
+  configPath: string;
+  dataDir: string;
+  sender: Electron.WebContents;
+}
+
+const states = new Map<number, WatchState>();
+let counter = 0;
+const baseDir = dirnameCompat();
+
+async function dirSize(dir: string): Promise<number> {
+  let total = 0;
+  const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    try {
+      if (entry.isDirectory()) {
+        total += await dirSize(full);
+      } else {
+        total += (await fs.promises.stat(full)).size;
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+  return total;
+}
+
+async function computeStats(configPath: string, dataDir: string) {
+  let mtime: number | null = null;
+  let loaded = false;
+  let cfgSize = 0;
+  let readWrite = false;
+  try {
+    const st = await fs.promises.stat(configPath);
+    mtime = st.mtimeMs;
+    cfgSize = st.size;
+    loaded = true;
+    try {
+      await fs.promises.access(configPath, fs.constants.R_OK | fs.constants.W_OK);
+      readWrite = true;
+    } catch {
+      readWrite = false;
+    }
+  } catch {
+    loaded = false;
+    cfgSize = 0;
+  }
+  let size = 0;
+  try {
+    size = await dirSize(dataDir);
+  } catch {
+    size = 0;
+  }
+  return {
+    mtime,
+    loaded,
+    size,
+    configPath,
+    configSize: cfgSize,
+    readWrite,
+    dataPath: dataDir
+  };
+}
+
+function launchWorker(state: WatchState) {
+  const workerPath = path.join(baseDir, '..', 'renderer', 'workers', 'statsWorker.js');
+  try {
+    state.worker = new Worker(workerPath, {
+      workerData: { configPath: state.configPath, dataDir: state.dataDir }
+    });
+    state.worker.on('message', (msg) => {
+      state.sender.send('options:stats', msg);
+    });
+  } catch {
+    state.watcher = chokidar.watch([state.configPath, state.dataDir], { ignoreInitial: true });
+    const send = async () => {
+      state.sender.send('options:stats', await computeStats(state.configPath, state.dataDir));
+    };
+    state.watcher.on('all', () => {
+      void send();
+    });
+    void send();
+  }
+}
+
+ipcMain.handle('options:start-stats', async (e, configPath: string, dataDir: string) => {
+  const id = ++counter;
+  const state: WatchState = { configPath, dataDir, sender: e.sender };
+  states.set(id, state);
+  launchWorker(state);
+  return id;
+});
+
+ipcMain.handle('options:refresh-stats', async (e, id: number) => {
+  const state = states.get(id);
+  if (!state) return;
+  if (state.worker) {
+    state.worker.postMessage('refresh');
+  } else {
+    const stats = await computeStats(state.configPath, state.dataDir);
+    e.sender.send('options:stats', stats);
+  }
+});
+
+ipcMain.handle('options:stop-stats', (_e, id: number) => {
+  const state = states.get(id);
+  if (!state) return;
+  state.worker?.terminate();
+  state.watcher?.close();
+  states.delete(id);
+});
+
+ipcMain.handle('options:get-stats', async (_e, configPath: string, dataDir: string) => {
+  return computeStats(configPath, dataDir);
+});

--- a/app/ts/preload.ts
+++ b/app/ts/preload.ts
@@ -15,6 +15,11 @@ const api = {
   unlink: (p: string) => ipcRenderer.invoke('fs:unlink', p),
   access: (p: string, mode?: number) => ipcRenderer.invoke('fs:access', p, mode),
   exists: (p: string) => ipcRenderer.invoke('fs:exists', p),
+  startOptionsStats: (cfg: string, dir: string) =>
+    ipcRenderer.invoke('options:start-stats', cfg, dir),
+  refreshOptionsStats: (id: number) => ipcRenderer.invoke('options:refresh-stats', id),
+  stopOptionsStats: (id: number) => ipcRenderer.invoke('options:stop-stats', id),
+  getOptionsStats: (cfg: string, dir: string) => ipcRenderer.invoke('options:get-stats', cfg, dir),
   watch: async (p: string, opts: any, cb: (evt: string) => void) => {
     const id = await ipcRenderer.invoke('fs:watch', p, opts);
     const chan = `fs:watch:${id}`;

--- a/test/fileWatcher.test.ts
+++ b/test/fileWatcher.test.ts
@@ -1,5 +1,7 @@
 /** @jest-environment jsdom */
 
+jest.setTimeout(10000);
+
 import { EventEmitter } from 'events';
 import jQuery from 'jquery';
 import path from 'path';

--- a/test/optionsIpc.test.ts
+++ b/test/optionsIpc.test.ts
@@ -1,0 +1,26 @@
+import './electronMainMock';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { ipcMainHandlers } from './electronMainMock';
+
+jest.isolateModules(() => {
+  require('../app/ts/main/options');
+});
+
+const getHandler = (c: string) => ipcMainHandlers[c];
+
+describe('options IPC handlers', () => {
+  test('options:get-stats returns file stats', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'opt-'));
+    const dataDir = path.join(root, 'data');
+    fs.mkdirSync(dataDir);
+    const cfg = path.join(root, 'config.json');
+    fs.writeFileSync(cfg, 'cfg');
+
+    const handler = getHandler('options:get-stats');
+    const stats = await handler({}, cfg, dataDir);
+
+    expect(stats).toEqual(expect.objectContaining({ configPath: cfg, dataPath: dataDir }));
+  });
+});

--- a/test/rendererOptions.test.ts
+++ b/test/rendererOptions.test.ts
@@ -5,14 +5,6 @@ let settingsModule: any;
 const invokeMock = jest.fn();
 const openPathMock = jest.fn();
 
-jest.mock('worker_threads', () => ({
-  Worker: jest.fn().mockImplementation(() => ({
-    on: jest.fn(),
-    postMessage: jest.fn(),
-    terminate: jest.fn()
-  }))
-}));
-
 const saveSettingsMock = jest.fn().mockResolvedValue('SAVED');
 
 jest.mock('../app/ts/renderer/settings-renderer', () => {
@@ -43,6 +35,10 @@ beforeEach(() => {
     openPath: openPathMock,
     send: jest.fn(),
     on: jest.fn(),
+    startOptionsStats: (...args: any[]) => invokeMock('options:start-stats', ...args),
+    refreshOptionsStats: (...args: any[]) => invokeMock('options:refresh-stats', ...args),
+    stopOptionsStats: (...args: any[]) => invokeMock('options:stop-stats', ...args),
+    getOptionsStats: (...args: any[]) => invokeMock('options:get-stats', ...args),
     path: { join: (...args: string[]) => require('path').join(...args) },
     readdir: jest.fn(async () => []),
     stat: jest.fn(async () => ({ size: 0, mtime: new Date(), atime: new Date() })),
@@ -78,6 +74,15 @@ test('reloadApp invokes ipcRenderer', async () => {
   (window as any).$ = (window as any).jQuery = jQuery;
   require('../app/ts/renderer/options');
   jQuery.ready();
+
+  await new Promise((r) => setTimeout(r, 0));
+  expect(invokeMock).toHaveBeenCalledWith(
+    'options:start-stats',
+    expect.any(String),
+    expect.any(String)
+  );
+
+  invokeMock.mockClear();
 
   await new Promise((r) => setTimeout(r, 0));
 

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -46,6 +46,10 @@ declare module 'electron' {
     ondragstart: [string];
     'singlewhois:lookup': [string];
     'singlewhois:openlink': [string];
+    'options:start-stats': [string, string];
+    'options:refresh-stats': [number];
+    'options:stop-stats': [number];
+    'options:get-stats': [string, string];
   }
 
   interface MainToRendererIpc {
@@ -56,6 +60,7 @@ declare module 'electron' {
     'bw:export.error': [string];
     'singlewhois:results': [any];
     'singlewhois:copied': [];
+    'options:stats': [any];
   }
 
   export interface IpcMain {
@@ -162,6 +167,10 @@ declare global {
       invoke: (channel: string, ...args: any[]) => Promise<any>;
       on: (channel: string, listener: (...args: any[]) => void) => void;
       openPath: (path: string) => Promise<string>;
+      startOptionsStats: (cfg: string, dir: string) => Promise<number>;
+      refreshOptionsStats: (id: number) => Promise<void>;
+      stopOptionsStats: (id: number) => Promise<void>;
+      getOptionsStats: (cfg: string, dir: string) => Promise<any>;
     };
   }
 }


### PR DESCRIPTION
## Summary
- add main process handlers for options stats
- invoke handlers from the renderer instead of using workers
- expose new preload APIs and update type declarations
- update tests for new IPC flow

## Testing
- `npm run lint`
- `npm run format`
- `npm test`
- `npx tsc --noEmit`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686305ec2b608325a51e3c662f204c7e