### PR TITLE
fix prebuild mkdir issue

### DIFF
--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -28,7 +28,20 @@ if (!fs.existsSync(modulesPath)) {
 }
 
 fs.mkdirSync(vendorDir, { recursive: true });
-fs.mkdirSync(distCliDir, { recursive: true });
+// Ensure CLI dist directory exists and is a directory
+try {
+  fs.mkdirSync(distCliDir, { recursive: true });
+} catch (err) {
+  if (err?.code === 'EEXIST') {
+    const stats = fs.statSync(distCliDir);
+    if (!stats.isDirectory()) {
+      fs.rmSync(distCliDir, { force: true });
+      fs.mkdirSync(distCliDir, { recursive: true });
+    }
+  } else {
+    throw err;
+  }
+}
 regenerateVendor();
 
 // Precompile Handlebars templates so development builds have them ready


### PR DESCRIPTION
## Summary
- handle prebuild EEXIST error when CLI dist dir already exists

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test --silent --runInBand`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6863b60c235883258cc14685181f0213