### PR TITLE
Fix electron launch path

### DIFF
--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -67,6 +67,10 @@ if (fs.existsSync(builtRenderer)) {
 if (fs.existsSync(builtMainFile)) {
   fs.mkdirSync(finalMain, { recursive: true });
   fs.renameSync(builtMainFile, finalMainFile);
+  // Adjust import paths in the relocated main.js to match the new layout
+  let mainJs = fs.readFileSync(finalMainFile, 'utf8');
+  mainJs = mainJs.replaceAll('./main/', './');
+  fs.writeFileSync(finalMainFile, mainJs);
 }
 
 // Precompile Handlebars templates into dist/app/compiled-templates


### PR DESCRIPTION
## Summary
- fix up postbuild paths so Electron can load main.js

## Testing
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6863b9b4527c8325b21d847c4b438f6f