### PR TITLE
Refactor IPC handlers

### DIFF
--- a/app/ts/common/ipcChannels.ts
+++ b/app/ts/common/ipcChannels.ts
@@ -4,5 +4,10 @@ export enum IpcChannel {
   BwLookupContinue = 'bw:lookup.continue',
   BwLookupStop = 'bw:lookup.stop',
   BwInputFile = 'bw:input.file',
-  BwInputWordlist = 'bw:input.wordlist'
+  BwInputWordlist = 'bw:input.wordlist',
+  BwaInputFile = 'bwa:input.file',
+  BwaAnalyserStart = 'bwa:analyser.start',
+  ToInputFile = 'to:input.file',
+  ToProcess = 'to:process',
+  SingleWhoisLookup = 'singlewhois:lookup'
 }

--- a/app/ts/main/bwa/analyser.ts
+++ b/app/ts/main/bwa/analyser.ts
@@ -3,6 +3,7 @@ import debugModule from 'debug';
 const debug = debugModule('main.bwa.analyser');
 
 const { app, BrowserWindow, Menu, ipcMain, dialog } = electron;
+import { IpcChannel } from '../../common/ipcChannels.js';
 
 /*
   ipcMain.on('bwa:analyser.start', function(...) {...});
@@ -11,8 +12,7 @@ const { app, BrowserWindow, Menu, ipcMain, dialog } = electron;
     event (object) - renderer object
     contents (object) - bulk whois lookup results object
  */
-ipcMain.on('bwa:analyser.start', function (event, contents) {
-  const { sender } = event;
-
-  sender.send('bwa:analyser.tablegen', contents);
+ipcMain.handle(IpcChannel.BwaAnalyserStart, async (_event, contents) => {
+  debug('Generating analyser table');
+  return contents;
 });

--- a/app/ts/main/bwa/fileinput.ts
+++ b/app/ts/main/bwa/fileinput.ts
@@ -4,6 +4,7 @@ const debug = debugModule('main.bwa.fileinput');
 
 const { app, BrowserWindow, Menu, ipcMain, dialog } = electron;
 import { formatString } from '../../common/stringformat.js';
+import { IpcChannel } from '../../common/ipcChannels.js';
 
 /*
   ipcMain.on('bwa:input.file', function(...) {...});
@@ -11,9 +12,7 @@ import { formatString } from '../../common/stringformat.js';
   parameters
     event
  */
-ipcMain.on('bwa:input.file', function (event) {
-  const { sender } = event;
-
+ipcMain.handle(IpcChannel.BwaInputFile, async () => {
   debug('Waiting for file selection');
   const filePath = dialog.showOpenDialogSync({
     title: 'Select wordlist file',
@@ -21,7 +20,7 @@ ipcMain.on('bwa:input.file', function (event) {
     properties: ['openFile', 'showHiddenFiles']
   });
   debug(formatString('Using selected file at {0}', filePath));
-  sender.send('bwa:fileinput.confirmation', filePath);
+  return filePath;
 });
 
 /*

--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -21,12 +21,10 @@ let bwaFileContents: any;
     event
     contents
  */
-electron.on('bwa:analyser.tablegen', function (event, contents) {
+export function renderAnalyser(contents: any): void {
   bwaFileContents = contents;
   showTable();
-
-  return;
-});
+}
 
 /*
   $('#bwaAnalyserButtonClose').click(function() {...});

--- a/test/bwaAnalyser.test.ts
+++ b/test/bwaAnalyser.test.ts
@@ -2,7 +2,7 @@ const ipcMainHandlers: Record<string, (...args: any[]) => any> = {};
 
 jest.mock('electron', () => ({
   ipcMain: {
-    on: (channel: string, listener: (...args: any[]) => void) => {
+    handle: (channel: string, listener: (...args: any[]) => any) => {
       ipcMainHandlers[channel] = listener;
     }
   },
@@ -15,13 +15,12 @@ jest.mock('electron', () => ({
 import '../app/ts/main/bwa/analyser';
 
 describe('bwa analyser handler', () => {
-  test('forwards results to renderer', () => {
+  test('returns analyser contents', async () => {
     const handler = ipcMainHandlers['bwa:analyser.start'];
-    const send = jest.fn();
     const contents = { id: [1], domain: ['example.com'] } as any;
 
-    handler({ sender: { send } } as any, contents);
+    const result = await handler({}, contents);
 
-    expect(send).toHaveBeenCalledWith('bwa:analyser.tablegen', contents);
+    expect(result).toBe(contents);
   });
 });

--- a/test/bwaFileinput.test.ts
+++ b/test/bwaFileinput.test.ts
@@ -3,9 +3,10 @@ export const mockShowOpenDialogSync = jest.fn();
 
 jest.mock('electron', () => ({
   ipcMain: {
-    on: (channel: string, listener: (...args: any[]) => void) => {
+    handle: (channel: string, listener: (...args: any[]) => any) => {
       ipcMainHandlers[channel] = listener;
-    }
+    },
+    on: jest.fn()
   },
   dialog: { showOpenDialogSync: mockShowOpenDialogSync },
   app: undefined,
@@ -20,28 +21,26 @@ describe('bwa fileinput handler', () => {
     mockShowOpenDialogSync.mockReset();
   });
 
-  test('sends selected file path to renderer', () => {
+  test('returns selected file path', async () => {
     const handler = ipcMainHandlers['bwa:input.file'];
     mockShowOpenDialogSync.mockReturnValue('/tmp/test.txt');
-    const send = jest.fn();
 
-    handler({ sender: { send } } as any);
+    const result = await handler({} as any);
 
     expect(mockShowOpenDialogSync).toHaveBeenCalledWith({
       title: 'Select wordlist file',
       buttonLabel: 'Open',
       properties: ['openFile', 'showHiddenFiles']
     });
-    expect(send).toHaveBeenCalledWith('bwa:fileinput.confirmation', '/tmp/test.txt');
+    expect(result).toBe('/tmp/test.txt');
   });
 
-  test('forwards undefined when no file selected', () => {
+  test('returns undefined when no file selected', async () => {
     const handler = ipcMainHandlers['bwa:input.file'];
     mockShowOpenDialogSync.mockReturnValue(undefined);
-    const send = jest.fn();
 
-    handler({ sender: { send } } as any);
+    const result = await handler({} as any);
 
-    expect(send).toHaveBeenCalledWith('bwa:fileinput.confirmation', undefined);
+    expect(result).toBeUndefined();
   });
 });

--- a/test/singlewhoisLookup.test.ts
+++ b/test/singlewhoisLookup.test.ts
@@ -1,0 +1,42 @@
+const ipcMainHandlers: Record<string, (...args: any[]) => any> = {};
+
+jest.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, listener: (...args: any[]) => any) => {
+      ipcMainHandlers[channel] = listener;
+    },
+    on: (channel: string, listener: (...args: any[]) => void) => {
+      ipcMainHandlers[channel] = listener;
+    }
+  },
+  clipboard: { writeText: jest.fn() },
+  shell: {},
+  app: undefined,
+  Menu: {},
+  dialog: {},
+  remote: {}
+}));
+
+const lookupMock = jest.fn();
+jest.mock('../app/ts/common/lookup.js', () => ({
+  lookup: (...args: any[]) => lookupMock(...args)
+}));
+jest.mock('../app/ts/common/availability.js', () => ({ isDomainAvailable: () => 'available' }));
+jest.mock('../app/ts/common/history.js', () => ({ addEntry: jest.fn() }));
+
+import '../app/ts/main/singlewhois';
+
+describe('singlewhois lookup handler', () => {
+  test('returns lookup data', async () => {
+    lookupMock.mockResolvedValue('ok');
+    const handler = ipcMainHandlers['singlewhois:lookup'];
+    const result = await handler({}, 'example.com');
+    expect(result).toBe('ok');
+  });
+
+  test('propagates errors', async () => {
+    lookupMock.mockRejectedValue(new Error('fail'));
+    const handler = ipcMainHandlers['singlewhois:lookup'];
+    await expect(handler({}, 'bad.com')).rejects.toThrow('fail');
+  });
+});

--- a/test/toRenderer.test.ts
+++ b/test/toRenderer.test.ts
@@ -45,10 +45,10 @@ afterEach(() => {
 });
 
 test('select and process file flow', async () => {
+  invokeMock.mockResolvedValueOnce('/tmp/list.txt');
   jQuery('#toButtonSelect').trigger('click');
-  expect(sendMock).toHaveBeenCalledWith('to:input.file');
-
-  handlers['to:fileinput.confirmation']?.({}, '/tmp/list.txt');
+  await new Promise((r) => setTimeout(r, 0));
+  expect(invokeMock).toHaveBeenCalledWith('to:input.file');
   expect(jQuery('#toFileSelected').text()).toBe('/tmp/list.txt');
 
   jQuery('#toPrefix').val('pre');
@@ -58,6 +58,7 @@ test('select and process file flow', async () => {
   jQuery('#toDedupe').prop('checked', true);
   jQuery('#radioAsc').prop('checked', true);
 
+  invokeMock.mockResolvedValueOnce('ok');
   jQuery('#toButtonProcess').trigger('click');
   await new Promise((r) => setTimeout(r, 0));
 
@@ -69,7 +70,5 @@ test('select and process file flow', async () => {
     dedupe: true,
     sort: 'asc'
   });
-
-  handlers['to:process.result']?.({}, 'ok');
   expect(jQuery('#toOutput').text()).toBe('ok');
 });


### PR DESCRIPTION
## Summary
- use `ipcMain.handle`/`ipcRenderer.invoke` for request/response flows
- centralize channel names in `IpcChannel`
- update renderer to await responses
- test new IPC handlers

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6863b61b346483259a079c1bce0dfdbd