### PR TITLE
refactor: remove fs usage from renderer

### DIFF
--- a/app/ts/preload.ts
+++ b/app/ts/preload.ts
@@ -1,5 +1,4 @@
 import { contextBridge, ipcRenderer, shell } from 'electron';
-import fs from 'fs';
 import path from 'path';
 
 const api = {

--- a/test/electronMock.ts
+++ b/test/electronMock.ts
@@ -1,3 +1,6 @@
+import fs from 'fs';
+import path from 'path';
+
 export const mockGetPath = jest.fn().mockReturnValue('');
 export const mockIpcSend = jest.fn();
 
@@ -7,3 +10,28 @@ jest.mock('electron', () => ({
   app: undefined,
   remote: { app: { getPath: mockGetPath } }
 }));
+
+if (!(global as any).window) {
+  (global as any).window = {};
+}
+
+(global as any).window.electron = {
+  send: jest.fn(),
+  invoke: jest.fn(),
+  on: jest.fn(),
+  openPath: jest.fn(),
+  readFile: (p: string, opts?: any) => fs.promises.readFile(p, opts),
+  stat: (p: string) => fs.promises.stat(p),
+  readdir: (p: string, opts?: any) => fs.promises.readdir(p, opts),
+  unlink: (p: string) => fs.promises.unlink(p),
+  access: (p: string, mode?: number) => fs.promises.access(p, mode),
+  exists: async (p: string) => fs.existsSync(p),
+  watch: async (p: string, opts: any, cb: (ev: string) => void) => {
+    const watcher = fs.watch(p, opts, cb);
+    return { close: () => watcher.close() };
+  },
+  path: {
+    join: (...args: string[]) => path.join(...args),
+    basename: (p: string) => path.basename(p)
+  }
+};

--- a/test/openUrl.test.ts
+++ b/test/openUrl.test.ts
@@ -5,6 +5,9 @@ jest.mock('electron', () => ({
   ipcMain: {
     on: (channel: string, listener: (...args: any[]) => void) => {
       ipcMainHandlers[channel] = listener;
+    },
+    handle: (channel: string, listener: (...args: any[]) => any) => {
+      ipcMainHandlers[channel] = listener;
     }
   },
   shell: { openExternal: openExternalMock },


### PR DESCRIPTION
## Summary
- drop `fs` import from preload
- access configuration files via IPC in renderer
- extend electronMock with file operations for tests
- patch openUrl test to mock `ipcMain.handle`

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6863c0a7967883259f6ac819863064f5