### PR TITLE
Refactor renderer settings to avoid node imports

### DIFF
--- a/app/ts/appsettings.ts
+++ b/app/ts/appsettings.ts
@@ -1,5 +1,3 @@
-import * as path from 'path';
-
 // Default application settings
 const appSettings = {
   settings: {

--- a/app/ts/common/settings-base.ts
+++ b/app/ts/common/settings-base.ts
@@ -1,0 +1,98 @@
+export interface Settings {
+  lookupConversion: { enabled: boolean; algorithm: string };
+  lookupGeneral: {
+    type: 'dns' | 'whois';
+    psl: boolean;
+    server: string;
+    verbose: boolean;
+    follow: number;
+    timeout: number;
+    timeBetween: number;
+    dnsTimeBetweenOverride: boolean;
+    dnsTimeBetween: number;
+  };
+  lookupRandomizeFollow: { randomize: boolean; minimumDepth: number; maximumDepth: number };
+  lookupRandomizeTimeout: { randomize: boolean; minimum: number; maximum: number };
+  lookupRandomizeTimeBetween: { randomize: boolean; minimum: number; maximum: number };
+  lookupProxy: {
+    enable: boolean;
+    mode: 'single' | 'multi';
+    multimode: 'sequential' | 'random' | 'ascending' | 'descending';
+    check: boolean;
+    checktype: 'ping' | 'request' | 'ping+request';
+    single?: string;
+    list?: string[];
+  };
+  lookupAssumptions: {
+    uniregistry: boolean;
+    ratelimit: boolean;
+    unparsable: boolean;
+    dnsFailureUnavailable: boolean;
+    expired?: boolean;
+  };
+  requestCache: {
+    enabled: boolean;
+    database: string;
+    ttl: number;
+  };
+  customConfiguration: { filepath: string; load: boolean; save: boolean };
+  theme: { darkMode: boolean; followSystem: boolean };
+  ui: { liveReload: boolean; confirmExit: boolean; language: string };
+  ai: {
+    enabled: boolean;
+    modelPath: string;
+    dataPath: string;
+    modelURL: string;
+    openai: { url: string; apiKey: string };
+  };
+  [key: string]: any;
+}
+
+import { debugFactory } from './logger.js';
+import appDefaults from '../appsettings.js';
+
+export const settings: Settings = appDefaults.settings as Settings;
+export const defaultSettings: Settings = JSON.parse(JSON.stringify(settings));
+export const defaultCustomConfiguration = settings.customConfiguration;
+
+export let customSettingsLoaded = false;
+export function setCustomSettingsLoaded(value: boolean): void {
+  customSettingsLoaded = value;
+}
+const debug = debugFactory('settings.base');
+
+export function getSettings(): Settings {
+  return settings;
+}
+
+export function setSettings(newSettings: Settings): void {
+  Object.assign(settings, newSettings);
+}
+
+export function mergeDefaults(partial: Partial<Settings>): Settings {
+  function merge(target: any, source: any, path: string[] = []): void {
+    for (const key of Object.keys(source)) {
+      const src = (source as any)[key];
+      if (src === undefined) continue;
+      const tgt = target[key];
+      if (src && typeof src === 'object' && !Array.isArray(src)) {
+        if (tgt !== undefined && typeof tgt !== 'object') {
+          throw new TypeError(`Invalid type at ${[...path, key].join('.')}`);
+        }
+        if (tgt === undefined) target[key] = {};
+        merge(target[key], src, [...path, key]);
+      } else {
+        if (tgt !== undefined && typeof src !== typeof tgt) {
+          throw new TypeError(`Invalid type at ${[...path, key].join('.')}`);
+        }
+        target[key] = src;
+      }
+    }
+  }
+
+  const clone = JSON.parse(JSON.stringify(defaultSettings));
+  merge(clone, partial);
+  return clone as Settings;
+}
+
+export const validateSettings = mergeDefaults;

--- a/test/bwRenderer.test.ts
+++ b/test/bwRenderer.test.ts
@@ -84,4 +84,3 @@ test('invokes bw:input.wordlist and lookup', async () => {
   await new Promise((r) => setTimeout(r, 0));
   expect(invokeMock).toHaveBeenCalledWith('bw:lookup', ['c', 'd'], ['net']);
 });
-

--- a/test/electronMock.ts
+++ b/test/electronMock.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-export const mockGetPath = jest.fn().mockReturnValue('');
+export const mockGetPath = jest.fn().mockReturnValue(path.join(__dirname, '../app/data'));
 export const mockIpcSend = jest.fn();
 
 jest.mock('electron', () => ({
@@ -17,7 +17,17 @@ if (!(global as any).window) {
 
 (global as any).window.electron = {
   send: jest.fn(),
-  invoke: jest.fn(),
+  invoke: jest.fn((channel: string, ...args: any[]) => {
+    if (channel === 'settings:load') {
+      const { load, getUserDataPath } = require('../app/ts/common/settings');
+      return { settings: load(), userDataPath: getUserDataPath() };
+    }
+    if (channel === 'settings:save') {
+      const { save } = require('../app/ts/common/settings');
+      return save(args[0]);
+    }
+    return Promise.resolve(undefined);
+  }),
   on: jest.fn(),
   openPath: jest.fn(),
   readFile: (p: string, opts?: any) => fs.promises.readFile(p, opts),

--- a/test/statsWorker.test.ts
+++ b/test/statsWorker.test.ts
@@ -54,7 +54,11 @@ async function computeStats(configPath: string, dataDir: string) {
   return { mtime, loaded, size, configPath, configSize: cfgSize, readWrite, dataPath: dataDir };
 }
 
-const workerPath = path.join(process.cwd(), 'dist', 'renderer', 'workers', 'statsWorker.js');
+const workerPath = fs.existsSync(
+  path.join(process.cwd(), 'dist', 'renderer', 'workers', 'statsWorker.js')
+)
+  ? path.join(process.cwd(), 'dist', 'renderer', 'workers', 'statsWorker.js')
+  : path.join(process.cwd(), 'dist', 'app', 'ts', 'renderer', 'workers', 'statsWorker.js');
 
 beforeAll(() => {
   if (!fs.existsSync(workerPath)) {


### PR DESCRIPTION
## Summary
- streamline electron mock and stats worker test paths
- initialize renderer settings path from `remote.app.getPath`

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: settingsPartial, isDomainAvailableAi)*
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6863d46debb083258303b1502a1a3a37