### PR TITLE
refactor: split settings modules

### DIFF
--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -5,8 +5,8 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const baseDir = path.dirname(__filename);
 import debugModule from 'debug';
-import { loadSettings, settings as store } from './common/settings.js';
-import type { Settings as BaseSettings } from './common/settings.js';
+import { loadSettings, settings as store } from './main/settings-main.js';
+import type { Settings as BaseSettings } from './main/settings-main.js';
 import { formatString } from './common/stringformat.js';
 import { RequestCache } from './common/requestCache.js';
 import {

--- a/app/ts/main/ai.ts
+++ b/app/ts/main/ai.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron';
 import debugModule from 'debug';
-import { settings } from '../common/settings.js';
+import { settings } from './settings-main.js';
 import { downloadModel } from '../ai/modelDownloader.js';
 import { suggestWords } from '../ai/openaiSuggest.js';
 

--- a/app/ts/main/bw/export.ts
+++ b/app/ts/main/bw/export.ts
@@ -9,7 +9,7 @@ import { formatString } from '../../common/stringformat.js';
 
 const { app, BrowserWindow, Menu, ipcMain, dialog, remote, shell } = electron;
 
-import { getSettings } from '../../common/settings.js';
+import { getSettings } from '../settings-main.js';
 import { generateFilename } from '../../cli/export.js';
 
 /*

--- a/app/ts/main/bw/fileinput.ts
+++ b/app/ts/main/bw/fileinput.ts
@@ -5,7 +5,7 @@ const debug = debugModule('main.bw.fileinput');
 const { app, BrowserWindow, Menu, ipcMain, dialog } = electron;
 import { formatString } from '../../common/stringformat.js';
 
-import { getSettings } from '../../common/settings.js';
+import { getSettings } from '../settings-main.js';
 
 /*
   ipcMain.on('bw:input.file', function(...) {...});

--- a/app/ts/main/bw/process.ts
+++ b/app/ts/main/bw/process.ts
@@ -10,7 +10,7 @@ import { processDomain, counter } from './scheduler.js';
 import { resetObject } from '../../common/resetObject.js';
 import { resetUiCounters } from './auxiliary.js';
 
-import { getSettings } from '../../common/settings.js';
+import { getSettings } from '../settings-main.js';
 
 const { app, BrowserWindow, Menu, ipcMain, dialog, remote } = electron;
 import { formatString } from '../../common/stringformat.js';

--- a/app/ts/main/bw/queue.ts
+++ b/app/ts/main/bw/queue.ts
@@ -1,6 +1,6 @@
 import debugModule from 'debug';
 import { formatString } from '../../common/stringformat.js';
-import type { Settings } from '../../common/settings.js';
+import type { Settings } from '../settings-main.js';
 import type { DomainSetup } from './types.js';
 
 const debug = debugModule('main.bw.queue');

--- a/app/ts/main/bw/resultHandler.ts
+++ b/app/ts/main/bw/resultHandler.ts
@@ -2,7 +2,7 @@ import debugModule from 'debug';
 import { isDomainAvailable, getDomainParameters } from '../../common/availability.js';
 import { toJSON } from '../../common/parser.js';
 import { performance } from 'perf_hooks';
-import { getSettings } from '../../common/settings.js';
+import { getSettings } from '../settings-main.js';
 import { formatString } from '../../common/stringformat.js';
 import type { BulkWhois, ProcessedResult } from './types.js';
 import * as dns from '../../common/dnsLookup.js';

--- a/app/ts/main/bw/scheduler.ts
+++ b/app/ts/main/bw/scheduler.ts
@@ -5,7 +5,7 @@ import * as dns from '../../common/dnsLookup.js';
 import { Result, DnsLookupError } from '../../common/errors.js';
 import { formatString } from '../../common/stringformat.js';
 import { msToHumanTime } from '../../common/conversions.js';
-import { getSettings } from '../../common/settings.js';
+import { getSettings } from '../settings-main.js';
 import type { BulkWhois, DomainSetup } from './types.js';
 import { processData } from './resultHandler.js';
 import type { IpcMainEvent } from 'electron';

--- a/app/ts/main/settings-main.ts
+++ b/app/ts/main/settings-main.ts
@@ -1,0 +1,88 @@
+import fs from 'fs';
+import path from 'path';
+import { debugFactory } from '../common/logger.js';
+import appDefaults from '../appsettings.js';
+import {
+  settings,
+  customSettingsLoaded,
+  getUserDataPath,
+  getSettings,
+  mergeDefaults,
+  validateSettings,
+  setSettings,
+  load as baseLoad,
+  save as baseSave,
+  type Settings
+} from '../common/settings.js';
+
+const debug = debugFactory('main.settings');
+const defaultSettings: Settings = JSON.parse(JSON.stringify(appDefaults.settings as Settings));
+const defaultCustomConfiguration = settings.customConfiguration;
+let watcher: fs.FSWatcher | undefined;
+
+function getCustomConfiguration() {
+  return settings.customConfiguration ?? defaultCustomConfiguration;
+}
+
+function getConfigFile(): string {
+  const { filepath } = getCustomConfiguration();
+  return path.join(getUserDataPath(), filepath);
+}
+
+function watchConfig(): void {
+  if (watcher) {
+    watcher.close();
+  }
+  const cfg = getConfigFile();
+  if (!fs.existsSync(cfg)) {
+    return;
+  }
+  watcher = fs.watch(cfg, { persistent: false }, async (event) => {
+    if (event !== 'change') return;
+    try {
+      const raw = await fs.promises.readFile(cfg, 'utf8');
+      const parsed = JSON.parse(raw) as Partial<Settings>;
+      try {
+        const merged = mergeDefaults(parsed);
+        if ((merged as any).appWindowWebPreferences) {
+          (merged as any).appWindowWebPreferences.contextIsolation = true;
+        }
+        setSettings(merged);
+        debug(`Reloaded custom configuration at ${cfg}`);
+        if (typeof window !== 'undefined' && settings.ui?.liveReload) {
+          window.dispatchEvent(new Event('settings-reloaded'));
+        }
+      } catch (mergeError) {
+        const defaults = JSON.parse(JSON.stringify(defaultSettings));
+        if ((defaults as any).appWindowWebPreferences) {
+          (defaults as any).appWindowWebPreferences.contextIsolation = true;
+        }
+        setSettings(defaults);
+        debug(`Failed to merge configuration with error: ${mergeError}`);
+        if (typeof window !== 'undefined' && settings.ui?.liveReload) {
+          window.dispatchEvent(new Event('settings-reloaded'));
+        }
+      }
+    } catch (e) {
+      debug(`Failed to reload configuration with error: ${e}`);
+    }
+  });
+}
+
+export async function loadSettings(): Promise<Settings> {
+  const result = await baseLoad();
+  watchConfig();
+  return result;
+}
+
+export const saveSettings = baseSave;
+export {
+  settings,
+  customSettingsLoaded,
+  getUserDataPath,
+  getSettings,
+  mergeDefaults,
+  validateSettings,
+  setSettings,
+  type Settings
+};

--- a/app/ts/main/singlewhois.ts
+++ b/app/ts/main/singlewhois.ts
@@ -11,8 +11,8 @@ const debug = debugModule('main.singlewhois');
 const { app, Menu, ipcMain, dialog, remote, clipboard, shell } = electron;
 import { formatString } from '../common/stringformat.js';
 
-import { settings } from '../common/settings.js';
-import type { Settings } from '../common/settings.js';
+import { settings } from './settings-main.js';
+import type { Settings } from './settings-main.js';
 
 /*
   ipcMain.on('singlewhois:lookup', function(...) {...});

--- a/app/ts/renderer.ts
+++ b/app/ts/renderer.ts
@@ -2,7 +2,7 @@
 import $ from '../vendor/jquery.js';
 
 import './renderer/index.js';
-import { loadSettings, settings, customSettingsLoaded } from './common/settings.js';
+import { loadSettings, settings, customSettingsLoaded } from './renderer/settings-renderer.js';
 import { loadTranslations, registerTranslationHelpers } from './renderer/i18n.js';
 import { formatString } from './common/stringformat.js';
 import { sendDebug, sendError } from './renderer/logger.js';

--- a/app/ts/renderer/bw/fileinput.ts
+++ b/app/ts/renderer/bw/fileinput.ts
@@ -16,7 +16,7 @@ import { tableReset } from './auxiliary.js';
 import $ from '../../../vendor/jquery.js';
 
 import { formatString } from '../../common/stringformat.js';
-import { settings } from '../../common/settings.js';
+import { settings } from '../settings-renderer.js';
 
 let bwFileContents: Buffer;
 let bwFileWatcher: { close: () => void } | undefined;

--- a/app/ts/renderer/bw/wordlistinput.ts
+++ b/app/ts/renderer/bw/wordlistinput.ts
@@ -1,5 +1,5 @@
 import * as conversions from '../../common/conversions.js';
-import { settings } from '../../common/settings.js';
+import { settings } from '../settings-renderer.js';
 
 const electron = (window as any).electron as {
   send: (channel: string, ...args: any[]) => void;

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -3,7 +3,7 @@ import type { FileStats } from '../../common/fileStats.js';
 import Papa from 'papaparse';
 import datatables from 'datatables';
 const dt = datatables();
-import { settings } from '../../common/settings.js';
+import { settings } from '../settings-renderer.js';
 
 const electron = (window as any).electron as { send: (channel: string, ...args: any[]) => void; invoke: (channel: string, ...args: any[]) => Promise<any>; on: (channel: string, listener: (...args: any[]) => void) => void; readFile: (p: string, opts?: any) => Promise<any>; stat: (p: string) => Promise<any>; watch: (p: string, opts: any, cb: (evt: string) => void) => Promise<{ close: () => void }>; path: { basename: (p: string) => string }; };
 import $ from '../../../vendor/jquery.js';

--- a/app/ts/renderer/darkmode.ts
+++ b/app/ts/renderer/darkmode.ts
@@ -1,5 +1,5 @@
 import $ from '../../vendor/jquery.js';
-import { settings, saveSettings } from '../common/settings.js';
+import { settings, saveSettings } from './settings-renderer.js';
 
 function applyDarkMode(enabled: boolean): void {
   const html = document.documentElement;

--- a/app/ts/renderer/navigation.ts
+++ b/app/ts/renderer/navigation.ts
@@ -1,7 +1,7 @@
 import { formatString } from '../common/stringformat.js';
 import $ from '../../vendor/jquery.js';
 import { populateInputs } from './options.js';
-import { settings } from '../common/settings.js';
+import { settings } from './settings-renderer.js';
 
 const electron = (window as any).electron as {
   send: (channel: string, ...args: any[]) => void;

--- a/app/ts/renderer/options.ts
+++ b/app/ts/renderer/options.ts
@@ -25,7 +25,7 @@ import {
   loadSettings,
   customSettingsLoaded,
   getUserDataPath
-} from '../common/settings.js';
+} from './settings-renderer.js';
 import { byteToHumanFileSize } from '../common/conversions.js';
 import appDefaults, { appSettingsDescriptions } from '../appsettings.js';
 

--- a/app/ts/renderer/settings-renderer.ts
+++ b/app/ts/renderer/settings-renderer.ts
@@ -1,0 +1,88 @@
+import fs from 'fs';
+import path from 'path';
+import { debugFactory } from '../common/logger.js';
+import appDefaults from '../appsettings.js';
+import {
+  settings,
+  customSettingsLoaded,
+  getUserDataPath,
+  getSettings,
+  mergeDefaults,
+  validateSettings,
+  setSettings,
+  load as baseLoad,
+  save as baseSave,
+  type Settings
+} from '../common/settings.js';
+
+const debug = debugFactory('renderer.settings');
+const defaultSettings: Settings = JSON.parse(JSON.stringify(appDefaults.settings as Settings));
+const defaultCustomConfiguration = settings.customConfiguration;
+let watcher: fs.FSWatcher | undefined;
+
+function getCustomConfiguration() {
+  return settings.customConfiguration ?? defaultCustomConfiguration;
+}
+
+function getConfigFile(): string {
+  const { filepath } = getCustomConfiguration();
+  return path.join(getUserDataPath(), filepath);
+}
+
+function watchConfig(): void {
+  if (watcher) {
+    watcher.close();
+  }
+  const cfg = getConfigFile();
+  if (!fs.existsSync(cfg)) {
+    return;
+  }
+  watcher = fs.watch(cfg, { persistent: false }, async (event) => {
+    if (event !== 'change') return;
+    try {
+      const raw = await fs.promises.readFile(cfg, 'utf8');
+      const parsed = JSON.parse(raw) as Partial<Settings>;
+      try {
+        const merged = mergeDefaults(parsed);
+        if ((merged as any).appWindowWebPreferences) {
+          (merged as any).appWindowWebPreferences.contextIsolation = true;
+        }
+        setSettings(merged);
+        debug(`Reloaded custom configuration at ${cfg}`);
+        if (typeof window !== 'undefined' && settings.ui?.liveReload) {
+          window.dispatchEvent(new Event('settings-reloaded'));
+        }
+      } catch (mergeError) {
+        const defaults = JSON.parse(JSON.stringify(defaultSettings));
+        if ((defaults as any).appWindowWebPreferences) {
+          (defaults as any).appWindowWebPreferences.contextIsolation = true;
+        }
+        setSettings(defaults);
+        debug(`Failed to merge configuration with error: ${mergeError}`);
+        if (typeof window !== 'undefined' && settings.ui?.liveReload) {
+          window.dispatchEvent(new Event('settings-reloaded'));
+        }
+      }
+    } catch (e) {
+      debug(`Failed to reload configuration with error: ${e}`);
+    }
+  });
+}
+
+export async function loadSettings(): Promise<Settings> {
+  const result = await baseLoad();
+  watchConfig();
+  return result;
+}
+
+export const saveSettings = baseSave;
+export {
+  settings,
+  customSettingsLoaded,
+  getUserDataPath,
+  getSettings,
+  mergeDefaults,
+  validateSettings,
+  setSettings,
+  type Settings
+};

--- a/test/bulkScheduling.test.ts
+++ b/test/bulkScheduling.test.ts
@@ -17,7 +17,7 @@ jest.mock('../app/ts/main/bw/resultHandler', () => ({
 import defaultBulkWhois from '../app/ts/main/bw/process.defaults';
 import { compileQueue, getDomainSetup } from '../app/ts/main/bw/queue';
 import { processDomain } from '../app/ts/main/bw/scheduler';
-import { settings } from '../app/ts/common/settings';
+import { settings } from '../app/ts/main/settings-main';
 
 const { processData } = require('../app/ts/main/bw/resultHandler');
 

--- a/test/cacheOverride.test.ts
+++ b/test/cacheOverride.test.ts
@@ -5,7 +5,7 @@ import whois from 'whois';
 import dns from 'dns/promises';
 import { lookup } from '../app/ts/common/lookup';
 import { nsLookup } from '../app/ts/common/dnsLookup';
-import { settings, getUserDataPath } from '../app/ts/common/settings';
+import { settings, getUserDataPath } from '../app/ts/renderer/settings-renderer';
 
 describe('cache override', () => {
   const dbFile = 'override-cache.sqlite';

--- a/test/convertDomain.test.ts
+++ b/test/convertDomain.test.ts
@@ -1,7 +1,7 @@
 import '../test/electronMock';
 
 import { convertDomain } from '../app/ts/common/lookup';
-import { settings } from '../app/ts/common/settings';
+import { settings } from '../app/ts/renderer/settings-renderer';
 
 describe('convertDomain', () => {
   test('punycode conversion handles unicode domains', () => {

--- a/test/darkmode.test.ts
+++ b/test/darkmode.test.ts
@@ -31,7 +31,7 @@ beforeEach(() => {
 async function loadDarkmode(): Promise<any> {
   jQuery = require('../app/vendor/jquery.js');
   (window as any).$ = (window as any).jQuery = jQuery;
-  const settingsModule = require('../app/ts/common/settings');
+  const settingsModule = require('../app/ts/renderer/settings-renderer');
   settingsModule.settings.theme.followSystem = true;
   settingsModule.settings.theme.darkMode = false;
   require('../app/ts/renderer/darkmode');

--- a/test/exportOptions.test.ts
+++ b/test/exportOptions.test.ts
@@ -1,7 +1,7 @@
 import './electronMainMock';
 import fs from 'fs';
 import { ipcMainHandlers, mockShowSaveDialogSync, openPathMock } from './electronMainMock';
-import { settings } from '../app/ts/common/settings';
+import { settings } from '../app/ts/main/settings-main';
 import '../app/ts/main/bw/export';
 
 const results = {

--- a/test/getDomainSetup.test.ts
+++ b/test/getDomainSetup.test.ts
@@ -1,6 +1,6 @@
 import './electronMainMock';
 import { getDomainSetup } from '../app/ts/main/bw/process';
-import { settings } from '../app/ts/common/settings';
+import { settings } from '../app/ts/main/settings-main';
 
 describe('getDomainSetup', () => {
   test('returns randomized values within configured bounds', () => {

--- a/test/history.test.ts
+++ b/test/history.test.ts
@@ -1,5 +1,5 @@
 import '../test/electronMock';
-import { getUserDataPath } from '../app/ts/common/settings';
+import { getUserDataPath } from '../app/ts/renderer/settings-renderer';
 import * as fs from 'fs';
 import * as path from 'path';
 

--- a/test/isDomainAvailableAi.test.ts
+++ b/test/isDomainAvailableAi.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import '../test/electronMock';
-import { settings, getUserDataPath } from '../app/ts/common/settings';
+import { settings, getUserDataPath } from '../app/ts/renderer/settings-renderer';
 import { loadModel } from '../app/ts/ai/availabilityModel';
 import { trainFromSamples } from '../scripts/train-ai';
 import { isDomainAvailable } from '../app/ts/common/availability';

--- a/test/jqueryAvailability.test.ts
+++ b/test/jqueryAvailability.test.ts
@@ -9,7 +9,7 @@ jest.mock('@electron/remote', () => ({
 jest.mock('../app/ts/renderer/index', () => ({}));
 jest.mock('../app/ts/renderer/navigation', () => ({}));
 
-jest.mock('../app/ts/common/settings', () => ({
+jest.mock('../app/ts/renderer/settings-renderer', () => ({
   loadSettings: jest.fn(() => ({
     customConfiguration: { filepath: 'test.json', load: false, save: false },
     appWindowNavigation: {

--- a/test/openUrl.test.ts
+++ b/test/openUrl.test.ts
@@ -15,7 +15,7 @@ jest.mock('electron', () => ({
   clipboard: { writeText: jest.fn() }
 }));
 
-import { settings } from '../app/ts/common/settings';
+import { settings } from '../app/ts/main/settings-main';
 import '../app/ts/main/singlewhois';
 
 describe('openUrl', () => {

--- a/test/optionsHelpers.test.ts
+++ b/test/optionsHelpers.test.ts
@@ -1,7 +1,7 @@
 /** @jest-environment jsdom */
 
 import { _test } from '../app/ts/renderer/options';
-import { settings } from '../app/ts/common/settings';
+import { settings } from '../app/ts/renderer/settings-renderer';
 import appDefaults from '../app/ts/appsettings';
 
 const { getValue, setValue, parseValue, getDefault } = _test;

--- a/test/processDomain.test.ts
+++ b/test/processDomain.test.ts
@@ -16,7 +16,7 @@ jest.mock('../app/ts/main/bw/resultHandler', () => ({
 
 import defaultBulkWhois from '../app/ts/main/bw/process.defaults';
 import { processDomain } from '../app/ts/main/bw/scheduler';
-import { settings } from '../app/ts/common/settings';
+import { settings } from '../app/ts/main/settings-main';
 import type { DomainSetup } from '../app/ts/main/bw/types';
 
 const { lookup } = require('../app/ts/common/lookup');

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -1,5 +1,5 @@
 import './electronMock';
-import { settings } from '../app/ts/common/settings';
+import { settings } from '../app/ts/renderer/settings-renderer';
 import { getProxy, resetProxyRotation } from '../app/ts/common/proxy';
 
 describe('proxy helper', () => {

--- a/test/rendererOptions.test.ts
+++ b/test/rendererOptions.test.ts
@@ -15,8 +15,8 @@ jest.mock('worker_threads', () => ({
 
 const saveSettingsMock = jest.fn().mockResolvedValue('SAVED');
 
-jest.mock('../app/ts/common/settings', () => {
-  const actual = jest.requireActual('../app/ts/common/settings');
+jest.mock('../app/ts/renderer/settings-renderer', () => {
+  const actual = jest.requireActual('../app/ts/renderer/settings-renderer');
   return { ...actual, saveSettings: saveSettingsMock };
 });
 
@@ -59,7 +59,7 @@ beforeEach(() => {
 test('changing setting updates configuration', async () => {
   jQuery = require('../app/vendor/jquery.js');
   (window as any).$ = (window as any).jQuery = jQuery;
-  settingsModule = require('../app/ts/common/settings');
+  settingsModule = require('../app/ts/renderer/settings-renderer');
   require('../app/ts/renderer/options');
   jQuery.ready();
   const { settings } = settingsModule;

--- a/test/requestCache.test.ts
+++ b/test/requestCache.test.ts
@@ -1,5 +1,5 @@
 import '../test/electronMock';
-import { settings, getUserDataPath } from '../app/ts/common/settings';
+import { settings, getUserDataPath } from '../app/ts/renderer/settings-renderer';
 import { RequestCache } from '../app/ts/common/requestCache';
 import fs from 'fs';
 import path from 'path';

--- a/test/resultHandler.test.ts
+++ b/test/resultHandler.test.ts
@@ -1,7 +1,7 @@
 import { performance } from 'perf_hooks';
 import defaultBulkWhois from '../app/ts/main/bw/process.defaults';
 import { processData } from '../app/ts/main/bw/resultHandler';
-import { settings } from '../app/ts/common/settings';
+import { settings } from '../app/ts/main/settings-main';
 
 jest.mock('../app/ts/common/availability', () => ({
   isDomainAvailable: jest.fn(),

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { mockGetPath } from '../test/electronMock';
 
-import { loadSettings, settings } from '../app/ts/common/settings';
+import { loadSettings, settings } from '../app/ts/renderer/settings-renderer';
 
 describe('settings load', () => {
   test('falls back to defaults when config is corrupt', async () => {

--- a/test/settingsMerge.test.ts
+++ b/test/settingsMerge.test.ts
@@ -1,5 +1,5 @@
 import '../test/electronMock';
-import { mergeDefaults, settings } from '../app/ts/common/settings';
+import { mergeDefaults, settings } from '../app/ts/renderer/settings-renderer';
 
 describe('mergeDefaults', () => {
   test('overrides array values', () => {

--- a/test/settingsPartial.test.ts
+++ b/test/settingsPartial.test.ts
@@ -4,7 +4,9 @@ import '../test/electronMock';
 
 describe('settings partial load', () => {
   test('missing fields fall back to defaults', async () => {
-    const { loadSettings, settings, getUserDataPath } = await import('../app/ts/common/settings');
+    const { loadSettings, settings, getUserDataPath } = await import(
+      '../app/ts/renderer/settings-renderer'
+    );
     const dir = getUserDataPath();
     fs.mkdirSync(dir, { recursive: true });
 

--- a/test/settingsReadError.test.ts
+++ b/test/settingsReadError.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import '../test/electronMock';
 import { mockGetPath, mockIpcSend } from '../test/electronMock';
-import { loadSettings, settings } from '../app/ts/common/settings';
+import { loadSettings, settings } from '../app/ts/renderer/settings-renderer';
 
 describe('settings load error handling', () => {
   test('fails silently when read fails', async () => {

--- a/test/settingsReload.test.ts
+++ b/test/settingsReload.test.ts
@@ -6,7 +6,7 @@ import { mockGetPath } from '../test/electronMock';
 
 import { convertDomain } from '../app/ts/common/lookup';
 import { nsLookup } from '../app/ts/common/dnsLookup';
-import { loadSettings, saveSettings, settings } from '../app/ts/common/settings';
+import { loadSettings, saveSettings, settings } from '../app/ts/renderer/settings-renderer';
 
 describe('settings reload', () => {
   test('convertDomain reflects saved settings', async () => {


### PR DESCRIPTION
## Summary
- separate main/renderer settings
- move Electron-specific watchers out of common module
- update imports for environment-specific settings
- adjust unit tests for new modules

## Testing
- `npm run lint`
- `npm run format`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6862c38597b88325b00239b49767e507