### PR TITLE
feat: add renderer module load logging

### DIFF
--- a/app/ts/common/logger.ts
+++ b/app/ts/common/logger.ts
@@ -1,7 +1,10 @@
 export function debugFactory(namespace: string) {
   return (...args: unknown[]): void => {
     const message = `[${namespace}] ${args.map(String).join(' ')}`;
-    if (typeof window !== 'undefined' && (window as any)?.electron) {
+    if (
+      typeof window !== 'undefined' &&
+      (window as any)?.electron?.send instanceof Function
+    ) {
       (window as any).electron.send('app:debug', message);
     } else {
       console.debug(message);
@@ -12,7 +15,10 @@ export function debugFactory(namespace: string) {
 export function errorFactory(namespace: string) {
   return (...args: unknown[]): void => {
     const message = `[${namespace}] ${args.map(String).join(' ')}`;
-    if (typeof window !== 'undefined' && (window as any)?.electron) {
+    if (
+      typeof window !== 'undefined' &&
+      (window as any)?.electron?.send instanceof Function
+    ) {
       (window as any).electron.send('app:error', message);
     } else {
       console.error(message);

--- a/app/ts/renderer.ts
+++ b/app/ts/renderer.ts
@@ -6,12 +6,16 @@ import { loadSettings, settings, customSettingsLoaded } from './renderer/setting
 import { loadTranslations, registerTranslationHelpers } from './renderer/i18n.js';
 import { formatString } from './common/stringformat.js';
 import { sendDebug, sendError } from './renderer/logger.js';
+import { debugFactory } from './common/logger.js';
 
 const electron = (window as any).electron as {
   send: (channel: string, ...args: any[]) => void;
   invoke: (channel: string, ...args: any[]) => Promise<any>;
   on: (channel: string, listener: (...args: any[]) => void) => void;
 };
+
+const debug = debugFactory('renderer.entry');
+debug('loaded');
 
 (window as any).$ = $;
 (window as any).jQuery = $;

--- a/app/ts/renderer/bw.ts
+++ b/app/ts/renderer/bw.ts
@@ -3,3 +3,8 @@ import './bw/wordlistinput.js'; // Bulk whois by wordlist input
 import './bw/fileinput.js'; // Bulk whois by file input
 import './bw/process.js'; // Bulk whois requests processing
 import './bw/export.js'; // Export processing
+
+import { debugFactory } from '../common/logger.js';
+
+const debug = debugFactory('renderer.bw');
+debug('loaded');

--- a/app/ts/renderer/bw/auxiliary.ts
+++ b/app/ts/renderer/bw/auxiliary.ts
@@ -1,5 +1,9 @@
 import { resetObject } from '../../common/resetObject.js';
 import $ from '../../../vendor/jquery.js';
+import { debugFactory } from '../../common/logger.js';
+
+const debug = debugFactory('renderer.bw.auxiliary');
+debug('loaded');
 
 /*
   tableReset

--- a/app/ts/renderer/bw/export.defaults.ts
+++ b/app/ts/renderer/bw/export.defaults.ts
@@ -1,4 +1,9 @@
 // Default export options values
+import { debugFactory } from '../../common/logger.js';
+
+const debug = debugFactory('renderer.bw.export.defaults');
+debug('loaded');
+
 const defaultExportOptions = {
   filetype: 'csv', // Filetype to export
   domains: 'available', // Export only available domains

--- a/app/ts/renderer/bw/export.ts
+++ b/app/ts/renderer/bw/export.ts
@@ -1,12 +1,16 @@
 import * as conversions from '../../common/conversions.js';
 import defaultExportOptions from './export.defaults.js';
 import $ from '../../../vendor/jquery.js';
+import { debugFactory } from '../../common/logger.js';
 
 const electron = (window as any).electron as {
   send: (channel: string, ...args: any[]) => void;
   invoke: (channel: string, ...args: any[]) => Promise<any>;
   on: (channel: string, listener: (...args: any[]) => void) => void;
 };
+
+const debug = debugFactory('renderer.bw.export');
+debug('loaded');
 import { resetObject } from '../../common/resetObject.js';
 import { getExportOptions, setExportOptions, setExportOptionsEx } from './auxiliary.js';
 

--- a/app/ts/renderer/bw/fileinput.ts
+++ b/app/ts/renderer/bw/fileinput.ts
@@ -2,6 +2,7 @@ import * as conversions from '../../common/conversions.js';
 import type { FileStats } from '../../common/fileStats.js';
 import { debugFactory } from '../../common/logger.js';
 const debug = debugFactory('renderer.bw.fileinput');
+debug('loaded');
 
 const electron = (window as any).electron as {
   send: (channel: string, ...args: any[]) => void;

--- a/app/ts/renderer/bw/process.ts
+++ b/app/ts/renderer/bw/process.ts
@@ -1,5 +1,6 @@
 import * as conversions from '../../common/conversions.js';
 import parseRawData from '../../common/parser.js';
+import { debugFactory } from '../../common/logger.js';
 const base = 10;
 
 const electron = (window as any).electron as {
@@ -8,6 +9,9 @@ const electron = (window as any).electron as {
   on: (channel: string, listener: (...args: any[]) => void) => void;
 };
 import $ from '../../../vendor/jquery.js';
+
+const debug = debugFactory('renderer.bw.process');
+debug('loaded');
 
 import { formatString } from '../../common/stringformat.js';
 

--- a/app/ts/renderer/bw/wordlistinput.ts
+++ b/app/ts/renderer/bw/wordlistinput.ts
@@ -1,5 +1,6 @@
 import * as conversions from '../../common/conversions.js';
 import { settings } from '../settings-renderer.js';
+import { debugFactory } from '../../common/logger.js';
 
 const electron = (window as any).electron as {
   send: (channel: string, ...args: any[]) => void;
@@ -8,6 +9,9 @@ const electron = (window as any).electron as {
 };
 import { tableReset } from './auxiliary.js';
 import $ from '../../../vendor/jquery.js';
+
+const debug = debugFactory('renderer.bw.wordlistinput');
+debug('loaded');
 
 import { formatString } from '../../common/stringformat.js';
 import { IpcChannel } from '../../common/ipcChannels.js';

--- a/app/ts/renderer/bwa.ts
+++ b/app/ts/renderer/bwa.ts
@@ -1,3 +1,8 @@
 /* Bulk whois analyser handling */
 import './bwa/fileinput.js';
 import './bwa/analyser.js';
+
+import { debugFactory } from '../common/logger.js';
+
+const debug = debugFactory('renderer.bwa');
+debug('loaded');

--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -2,12 +2,16 @@ import * as conversions from '../../common/conversions.js';
 import $ from '../../../vendor/jquery.js';
 import datatables from '../../../vendor/datatables.js';
 datatables();
+import { debugFactory } from '../../common/logger.js';
 
 const electron = (window as any).electron as {
   send: (channel: string, ...args: any[]) => void;
   invoke: (channel: string, ...args: any[]) => Promise<any>;
   on: (channel: string, listener: (...args: any[]) => void) => void;
 };
+
+const debug = debugFactory('renderer.bwa.analyser');
+debug('loaded');
 
 import { formatString } from '../../common/stringformat.js';
 

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -4,8 +4,12 @@ import $ from '../../../vendor/jquery.js';
 import datatables from '../../../vendor/datatables.js';
 datatables();
 import { settings } from '../settings-renderer.js';
+import { debugFactory } from '../../common/logger.js';
 
 const electron = (window as any).electron as { send: (channel: string, ...args: any[]) => void; invoke: (channel: string, ...args: any[]) => Promise<any>; on: (channel: string, listener: (...args: any[]) => void) => void; readFile: (p: string, opts?: any) => Promise<any>; stat: (p: string) => Promise<any>; watch: (p: string, opts: any, cb: (evt: string) => void) => Promise<{ close: () => void }>; path: { basename: (p: string) => string }; };
+
+const debug = debugFactory('renderer.bwa.fileinput');
+debug('loaded');
 
 import { formatString } from '../../common/stringformat.js';
 import { IpcChannel } from '../../common/ipcChannels.js';

--- a/app/ts/renderer/darkmode.ts
+++ b/app/ts/renderer/darkmode.ts
@@ -1,5 +1,9 @@
 import $ from '../../vendor/jquery.js';
 import { settings, saveSettings } from './settings-renderer.js';
+import { debugFactory } from '../common/logger.js';
+
+const debug = debugFactory('renderer.darkmode');
+debug('loaded');
 
 function applyDarkMode(enabled: boolean): void {
   const html = document.documentElement;

--- a/app/ts/renderer/history.ts
+++ b/app/ts/renderer/history.ts
@@ -2,6 +2,10 @@ import $ from '../../vendor/jquery.js';
 const electron = (window as any).electron as {
   invoke: (channel: string, ...args: any[]) => Promise<any>;
 };
+import { debugFactory } from '../common/logger.js';
+
+const debug = debugFactory('renderer.history');
+debug('loaded');
 
 function formatDate(ts: number): string {
   return new Date(ts).toLocaleString();

--- a/app/ts/renderer/i18n.ts
+++ b/app/ts/renderer/i18n.ts
@@ -2,6 +2,10 @@ import { dirnameCompat } from '../utils/dirnameCompat.js';
 
 const baseDir = dirnameCompat();
 import Handlebars from '../../vendor/handlebars.runtime.js';
+import { debugFactory } from '../common/logger.js';
+
+const debug = debugFactory('renderer.i18n');
+debug('loaded');
 
 const electron = (window as any).electron as {
   readFile: (p: string, enc?: any) => Promise<any>;

--- a/app/ts/renderer/index.ts
+++ b/app/ts/renderer/index.ts
@@ -5,3 +5,8 @@ import './darkmode.js';
 import './options.js';
 import './to.js';
 import './history.js';
+
+import { debugFactory } from '../common/logger.js';
+
+const debug = debugFactory('renderer.index');
+debug('loaded');

--- a/app/ts/renderer/navigation.ts
+++ b/app/ts/renderer/navigation.ts
@@ -3,6 +3,11 @@ import $ from '../../vendor/jquery.js';
 import { populateInputs } from './options.js';
 import { settings } from './settings-renderer.js';
 
+import { debugFactory } from '../common/logger.js';
+
+const debug = debugFactory('renderer.navigation');
+debug('loaded');
+
 const electron = (window as any).electron as {
   send: (channel: string, ...args: any[]) => void;
   invoke: (channel: string, ...args: any[]) => Promise<any>;

--- a/app/ts/renderer/options.ts
+++ b/app/ts/renderer/options.ts
@@ -1,6 +1,8 @@
 import $ from '../../vendor/jquery.js';
 import { dirnameCompat } from '../utils/dirnameCompat.js';
 
+import { debugFactory } from '../common/logger.js';
+
 const baseDir = dirnameCompat();
 const electron = (window as any).electron as {
   readFile: (p: string, opts?: any) => Promise<any>;
@@ -16,6 +18,9 @@ const electron = (window as any).electron as {
   on: (channel: string, listener: (...args: any[]) => void) => void;
   openPath: (path: string) => Promise<string>;
 };
+
+const debug = debugFactory('renderer.options');
+debug('loaded');
 import {
   settings,
   saveSettings,

--- a/app/ts/renderer/registerPartials.ts
+++ b/app/ts/renderer/registerPartials.ts
@@ -1,4 +1,8 @@
 import Handlebars from '../../vendor/handlebars.runtime.js';
+import { debugFactory } from '../common/logger.js';
+
+const debug = debugFactory('renderer.registerPartials');
+debug('loaded');
 
 import bwEntry from '../../compiled-templates/bwEntry.js';
 import bwExport from '../../compiled-templates/bwExport.js';

--- a/app/ts/renderer/settings-renderer.ts
+++ b/app/ts/renderer/settings-renderer.ts
@@ -19,6 +19,7 @@ import {
 } from '../common/settings-base.js';
 
 const debug = debugFactory('renderer.settings');
+debug('loaded');
 const defaultSettings: Settings = JSON.parse(JSON.stringify(appDefaults.settings as Settings));
 const defaultCustomConfiguration = settings.customConfiguration;
 let userDataPath = (electron as any)?.remote?.app?.getPath('userData') ?? '';

--- a/app/ts/renderer/singlewhois.ts
+++ b/app/ts/renderer/singlewhois.ts
@@ -12,6 +12,10 @@ import { formatString } from '../common/stringformat.js';
 
 import $ from '../../vendor/jquery.js';
 (window as any).$ = (window as any).jQuery = $;
+import { debugFactory } from '../common/logger.js';
+
+const debug = debugFactory('renderer.singlewhois');
+debug('loaded');
 
 interface SingleWhois {
   input: {

--- a/app/ts/renderer/templateLoader.ts
+++ b/app/ts/renderer/templateLoader.ts
@@ -1,5 +1,9 @@
 import $ from '../../vendor/jquery.js';
 import Handlebars from '../../vendor/handlebars.runtime.js';
+import { debugFactory } from '../common/logger.js';
+
+const debug = debugFactory('renderer.templateLoader');
+debug('loaded');
 
 export async function loadTemplate(
   selector: string,

--- a/app/ts/renderer/to.ts
+++ b/app/ts/renderer/to.ts
@@ -1,6 +1,10 @@
 import { ipcRenderer } from 'electron';
 import { IpcChannel } from '../common/ipcChannels.js';
 import $ from '../../vendor/jquery.js';
+import { debugFactory } from '../common/logger.js';
+
+const debug = debugFactory('renderer.to');
+debug('loaded');
 
 let filePath: string | null = null;
 

--- a/app/ts/renderer/workers/statsWorker.ts
+++ b/app/ts/renderer/workers/statsWorker.ts
@@ -1,4 +1,8 @@
 import { parentPort, workerData } from 'worker_threads';
+import { debugFactory } from '../../common/logger.js';
+
+const debug = debugFactory('renderer.workers.statsWorker');
+debug('loaded');
 
 interface WorkerData {
   configPath: string;

--- a/test/electronMock.ts
+++ b/test/electronMock.ts
@@ -43,5 +43,6 @@ if (!(global as any).window) {
   path: {
     join: (...args: string[]) => path.join(...args),
     basename: (p: string) => path.basename(p)
-  }
+  },
+  remote: { app: { getPath: mockGetPath } }
 };


### PR DESCRIPTION
## Summary
- add runtime checks for window.electron to logger
- emit debug messages when renderer modules load
- update tests to provide electron.remote for renderer

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6866940c68d883258ae116bfffb6483b