### PR TITLE
Refactor renderer dirnameCompat usage

### DIFF
--- a/app/ts/renderer/i18n.ts
+++ b/app/ts/renderer/i18n.ts
@@ -1,16 +1,15 @@
-import { dirnameCompat } from '../utils/dirnameCompat.js';
+const electron = (window as any).electron as {
+  dirnameCompat: (metaUrl?: string | URL) => string;
+  readFile: (p: string, enc?: any) => Promise<any>;
+  path: { join: (...args: string[]) => string };
+};
 
-const baseDir = dirnameCompat();
+const baseDir = electron.dirnameCompat();
 import Handlebars from '../../vendor/handlebars.runtime.js';
 import { debugFactory } from '../common/logger.js';
 
 const debug = debugFactory('renderer.i18n');
 debug('loaded');
-
-const electron = (window as any).electron as {
-  readFile: (p: string, enc?: any) => Promise<any>;
-  path: { join: (...args: string[]) => string };
-};
 let translations: Record<string, string> = {};
 
 export async function loadTranslations(lang: string): Promise<void> {

--- a/app/ts/renderer/options.ts
+++ b/app/ts/renderer/options.ts
@@ -1,10 +1,8 @@
 import $ from '../../vendor/jquery.js';
-import { dirnameCompat } from '../utils/dirnameCompat.js';
-
 import { debugFactory } from '../common/logger.js';
 
-const baseDir = dirnameCompat();
 const electron = (window as any).electron as {
+  dirnameCompat: (metaUrl?: string | URL) => string;
   readFile: (p: string, opts?: any) => Promise<any>;
   stat: (p: string) => Promise<any>;
   readdir: (p: string, opts?: any) => Promise<any>;
@@ -18,6 +16,8 @@ const electron = (window as any).electron as {
   on: (channel: string, listener: (...args: any[]) => void) => void;
   openPath: (path: string) => Promise<string>;
 };
+
+const baseDir = electron.dirnameCompat();
 
 const debug = debugFactory('renderer.options');
 debug('loaded');

--- a/test/electronMock.ts
+++ b/test/electronMock.ts
@@ -17,6 +17,12 @@ if (!(global as any).window) {
 
 (global as any).window.electron = {
   send: jest.fn(),
+  dirnameCompat: jest.fn((metaUrl?: string | URL) => {
+    if (metaUrl) {
+      return path.dirname(new URL(metaUrl.toString()).pathname);
+    }
+    return __dirname;
+  }),
   invoke: jest.fn((channel: string, ...args: any[]) => {
     if (channel === 'settings:load') {
       const { load, getUserDataPath } = require('../app/ts/common/settings');

--- a/test/i18n.test.ts
+++ b/test/i18n.test.ts
@@ -12,6 +12,7 @@ describe('i18n loader', () => {
   beforeEach(() => {
     readFileMock.mockReset();
     (window as any).electron = {
+      dirnameCompat: () => __dirname,
       readFile: readFileMock,
       path: { join: (...args: string[]) => require('path').join(...args) }
     };

--- a/test/navigation.test.ts
+++ b/test/navigation.test.ts
@@ -22,6 +22,7 @@ beforeEach(() => {
   sendMock = jest.fn();
   invokeMock = jest.fn();
   (window as any).electron = {
+    dirnameCompat: () => __dirname,
     send: sendMock,
     invoke: invokeMock,
     on: jest.fn()

--- a/test/optionsHelpers.test.ts
+++ b/test/optionsHelpers.test.ts
@@ -1,5 +1,7 @@
 /** @jest-environment jsdom */
 
+(window as any).electron = { dirnameCompat: () => __dirname };
+
 import { _test } from '../app/ts/renderer/options';
 import { settings } from '../app/ts/renderer/settings-renderer';
 import appDefaults from '../app/ts/appsettings';

--- a/test/preload.test.ts
+++ b/test/preload.test.ts
@@ -37,6 +37,7 @@ describe('preload', () => {
     expect(typeof api.invoke).toBe('function');
     api.invoke('chan', 2);
     expect(ipcInvokeMock).toHaveBeenCalledWith('chan', 2);
+    expect(typeof api.dirnameCompat).toBe('function');
     expect(typeof api.on).toBe('function');
     const listener = jest.fn();
     api.on('chan', listener);
@@ -59,5 +60,6 @@ describe('preload', () => {
     const api = (global as any).window.electron;
     api.send('chan2');
     expect(ipcSendMock).toHaveBeenCalledWith('chan2');
+    expect(typeof api.dirnameCompat).toBe('function');
   });
 });

--- a/test/rendererOptions.test.ts
+++ b/test/rendererOptions.test.ts
@@ -32,6 +32,7 @@ beforeEach(() => {
     <div id="opSearchNoResults"></div>
   `;
   (window as any).electron = {
+    dirnameCompat: () => __dirname,
     invoke: invokeMock,
     openPath: openPathMock,
     send: jest.fn(),


### PR DESCRIPTION
## Summary
- expose `dirnameCompat` from the preload script
- use the preload implementation in renderer files
- adjust mocks and unit tests for new API

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: session not created error)*

------
https://chatgpt.com/codex/tasks/task_e_686698a2c12c8325aa3b6db9ccd90297