### PR TITLE
refactor: preload uses shared dirnameCompat

### DIFF
--- a/app/ts/preload.ts
+++ b/app/ts/preload.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer, shell } from 'electron';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { dirnameCompat } from './utils/dirnameCompat.js';
 
 const api = {
   send: (channel: string, ...args: unknown[]) => ipcRenderer.send(channel, ...args),
@@ -32,49 +32,7 @@ const api = {
       }
     };
   },
-  dirnameCompat: (metaUrl?: string | URL) => {
-    const globalDir = (global as any).__dirname;
-    if (typeof globalDir === 'string') {
-      return globalDir;
-    }
-    if (metaUrl) {
-      try {
-        return path.dirname(fileURLToPath(metaUrl));
-      } catch {
-        /* ignore */
-      }
-    }
-    if (typeof __dirname !== 'undefined') {
-      return __dirname;
-    }
-    let url = metaUrl;
-    if (!url) {
-      try {
-        url = Function(
-          'return typeof import!=="undefined" && import.meta && import.meta.url ? import.meta.url : undefined'
-        )();
-      } catch {
-        url = undefined;
-      }
-    }
-    if (typeof url === 'string') {
-      try {
-        return path.dirname(fileURLToPath(url));
-      } catch {
-        /* ignore */
-      }
-    }
-    if (typeof __filename !== 'undefined') {
-      return path.dirname(__filename);
-    }
-    if (process.mainModule && process.mainModule.filename) {
-      return path.dirname(process.mainModule.filename);
-    }
-    if (process.argv[1]) {
-      return path.dirname(process.argv[1]);
-    }
-    return process.cwd();
-  },
+  dirnameCompat,
   path: {
     join: (...args: string[]) => path.join(...args),
     basename: (p: string) => path.basename(p)


### PR DESCRIPTION
## Summary
- import dirnameCompat utility in preload
- expose dirnameCompat in the preload API

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6866a297b3f48325848e8f2b7f7055f3