### PR TITLE
fix: electron preload compatibility

### DIFF
--- a/app/ts/renderer/to.ts
+++ b/app/ts/renderer/to.ts
@@ -1,4 +1,6 @@
-import { ipcRenderer } from 'electron';
+// In the renderer process we access IPC methods exposed from the preload script
+// via the `window.electron` bridge instead of importing from 'electron'.
+const { invoke, send } = (window as any).electron;
 import { IpcChannel } from '../common/ipcChannels.js';
 import $ from '../../vendor/jquery.js';
 import { debugFactory } from '../common/logger.js';
@@ -14,7 +16,7 @@ let filePath: string | null = null;
 */
 $(document).on('click', '#toButtonSelect', function () {
   void (async () => {
-    const result = await ipcRenderer.invoke(IpcChannel.ToInputFile);
+    const result = await invoke(IpcChannel.ToInputFile);
     filePath = Array.isArray(result) ? result[0] : result;
     $('#toFileSelected').text(filePath ?? '');
   })();
@@ -28,10 +30,10 @@ $(document).on('click', '#toButtonProcess', async function () {
   if (!filePath) return;
   const options = collectOptions();
   try {
-    const result = await ipcRenderer.invoke(IpcChannel.ToProcess, filePath, options);
+    const result = await invoke(IpcChannel.ToProcess, filePath, options);
     $('#toOutput').text(result);
   } catch (e) {
-    ipcRenderer.send('app:error', `Processing failed: ${e}`);
+    send('app:error', `Processing failed: ${e}`);
   }
 });
 

--- a/test/toRenderer.test.ts
+++ b/test/toRenderer.test.ts
@@ -31,6 +31,13 @@ beforeEach(() => {
     <div id="toOutput"></div>
   `;
   (window as any).$ = (window as any).jQuery = jQuery;
+  (window as any).electron = {
+    send: (...args: any[]) => sendMock(...args),
+    invoke: (...args: any[]) => invokeMock(...args),
+    on: (channel: string, cb: (...args: any[]) => void) => {
+      handlers[channel] = cb;
+    }
+  };
   sendMock.mockClear();
   invokeMock.mockReset();
   require('../app/ts/renderer/to');


### PR DESCRIPTION
## Summary
- use CommonJS requires in `preload.ts` so Electron can load it
- expose IPC bridge in renderer through `window.electron`
- update tests to register mocked bridge

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6866abd66ac48325be3f87d2bca55815