### PR TITLE
fix: ensure preload and partials load

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -18,4 +18,7 @@ app/ts/renderer/singlewhois.ts
 app/ts/common/logger.ts
 app/vendor/datatables.js
 app/vendor/handlebars.runtime.js
+app/vendor/jquery.js
+app/vendor/change-case.js
+app/vendor/html-entities/
 package.json

--- a/app/html/startup.js
+++ b/app/html/startup.js
@@ -1,3 +1,8 @@
+// Ensure Handlebars runtime is loaded before registering partials. The runtime
+// is a UMD bundle so we import it for its side effects which expose a global
+// `Handlebars` object.
+import '../vendor/handlebars.runtime.js';
+
 import registerPartials from '../ts/renderer/registerPartials.js';
 registerPartials();
 

--- a/app/ts/preload.ts
+++ b/app/ts/preload.ts
@@ -1,12 +1,15 @@
-import { contextBridge, ipcRenderer, shell } from 'electron';
-import path from 'path';
-import { dirnameCompat } from './utils/dirnameCompat.js';
+// Use CommonJS imports so the compiled preload script works when loaded via
+// Electron's `require` mechanism.
+const { contextBridge, ipcRenderer, shell } = require('electron');
+const path = require('path');
+const { dirnameCompat } = require('./utils/dirnameCompat.js');
+type IpcRendererEvent = import('electron').IpcRendererEvent;
 
 const api = {
   send: (channel: string, ...args: unknown[]) => ipcRenderer.send(channel, ...args),
   invoke: (channel: string, ...args: unknown[]) => ipcRenderer.invoke(channel, ...args),
   on: (channel: string, listener: (...args: unknown[]) => void) => {
-    ipcRenderer.on(channel, (_event, ...args) => listener(...args));
+    ipcRenderer.on(channel, (_event: IpcRendererEvent, ...args: unknown[]) => listener(...args));
   },
   openPath: (path: string) => shell.openPath(path),
   readFile: (p: string, opts?: any) => ipcRenderer.invoke('fs:readFile', p, opts),
@@ -23,7 +26,7 @@ const api = {
   watch: async (p: string, opts: any, cb: (evt: string) => void) => {
     const id = await ipcRenderer.invoke('fs:watch', p, opts);
     const chan = `fs:watch:${id}`;
-    const handler = (_e: any, ev: string) => cb(ev);
+    const handler = (_e: IpcRendererEvent, ev: string) => cb(ev);
     ipcRenderer.on(chan, handler);
     return {
       close: () => {

--- a/app/ts/renderer/registerPartials.ts
+++ b/app/ts/renderer/registerPartials.ts
@@ -1,5 +1,10 @@
-import Handlebars from '../../vendor/handlebars.runtime.js';
+// Handlebars runtime is provided via a global `Handlebars` variable after
+// loading `vendor/handlebars.runtime.js` in startup.ts. Importing it as an ES
+// module would fail because the vendor script is UMD. Instead we read it from
+// `window`.
 import { debugFactory } from '../common/logger.js';
+
+const Handlebars: typeof import('handlebars') = (window as any).Handlebars;
 
 const debug = debugFactory('renderer.registerPartials');
 debug('loaded');

--- a/app/ts/renderer/to.ts
+++ b/app/ts/renderer/to.ts
@@ -1,4 +1,6 @@
-import { ipcRenderer } from 'electron';
+// In the renderer process we access IPC methods exposed from the preload script
+// via the `window.electron` bridge instead of importing from 'electron'.
+const { invoke, send } = (window as any).electron;
 import { IpcChannel } from '../common/ipcChannels.js';
 import $ from '../../vendor/jquery.js';
 import { debugFactory } from '../common/logger.js';
@@ -14,7 +16,7 @@ let filePath: string | null = null;
 */
 $(document).on('click', '#toButtonSelect', function () {
   void (async () => {
-    const result = await ipcRenderer.invoke(IpcChannel.ToInputFile);
+    const result = await invoke(IpcChannel.ToInputFile);
     filePath = Array.isArray(result) ? result[0] : result;
     $('#toFileSelected').text(filePath ?? '');
   })();
@@ -28,10 +30,10 @@ $(document).on('click', '#toButtonProcess', async function () {
   if (!filePath) return;
   const options = collectOptions();
   try {
-    const result = await ipcRenderer.invoke(IpcChannel.ToProcess, filePath, options);
+    const result = await invoke(IpcChannel.ToProcess, filePath, options);
     $('#toOutput').text(result);
   } catch (e) {
-    ipcRenderer.send('app:error', `Processing failed: ${e}`);
+    send('app:error', `Processing failed: ${e}`);
   }
 });
 

--- a/test/toRenderer.test.ts
+++ b/test/toRenderer.test.ts
@@ -31,6 +31,13 @@ beforeEach(() => {
     <div id="toOutput"></div>
   `;
   (window as any).$ = (window as any).jQuery = jQuery;
+  (window as any).electron = {
+    send: (...args: any[]) => sendMock(...args),
+    invoke: (...args: any[]) => invokeMock(...args),
+    on: (channel: string, cb: (...args: any[]) => void) => {
+      handlers[channel] = cb;
+    }
+  };
   sendMock.mockClear();
   invokeMock.mockReset();
   require('../app/ts/renderer/to');


### PR DESCRIPTION
## Summary
- load Handlebars runtime in startup script and read from `window`
- expose preload API without ESM markers
- adapt registerPartials to use global Handlebars
- update test to mock global and adjust assertions
- ignore additional vendor files for Prettier

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run format:check`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6866abd66ac48325be3f87d2bca55815