### PR TITLE
Refactor renderer IPC usage

### DIFF
--- a/app/ts/common/ipcChannels.ts
+++ b/app/ts/common/ipcChannels.ts
@@ -12,5 +12,6 @@ export enum IpcChannel {
   SingleWhoisLookup = 'singlewhois:lookup',
   ParseCsv = 'csv:parse',
   AvailabilityCheck = 'availability:check',
-  DomainParameters = 'availability:params'
+  DomainParameters = 'availability:params',
+  OpenPath = 'shell:openPath'
 }

--- a/app/ts/main/utils.ts
+++ b/app/ts/main/utils.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron';
+import { ipcMain, shell } from 'electron';
 import Papa from 'papaparse';
 import { isDomainAvailable, getDomainParameters } from '../common/availability.js';
 import { IpcChannel } from '../common/ipcChannels.js';
@@ -29,3 +29,7 @@ ipcMain.handle(
     );
   }
 );
+
+ipcMain.handle(IpcChannel.OpenPath, async (_e, p: string) => {
+  return shell.openPath(p);
+});

--- a/app/ts/preload.ts
+++ b/app/ts/preload.ts
@@ -1,6 +1,6 @@
 // Use CommonJS imports so the compiled preload script works when loaded via
 // Electron's `require` mechanism.
-const { contextBridge, ipcRenderer, shell } = require('electron');
+const { contextBridge, ipcRenderer } = require('electron');
 const path = require('path');
 const { dirnameCompat } = require('./utils/dirnameCompat.js');
 import type { IpcRendererEvent } from 'electron';
@@ -11,7 +11,6 @@ const api = {
   on: (channel: string, listener: (...args: unknown[]) => void) => {
     ipcRenderer.on(channel, (_event: IpcRendererEvent, ...args: unknown[]) => listener(...args));
   },
-  openPath: (path: string) => shell.openPath(path),
   readFile: (p: string, opts?: any) => ipcRenderer.invoke('fs:readFile', p, opts),
   stat: (p: string) => ipcRenderer.invoke('fs:stat', p),
   readdir: (p: string, opts?: any) => ipcRenderer.invoke('fs:readdir', p, opts),

--- a/app/ts/renderer/options.ts
+++ b/app/ts/renderer/options.ts
@@ -1,5 +1,6 @@
 import $ from '../../vendor/jquery.js';
 import { debugFactory } from '../common/logger.js';
+import { IpcChannel } from '../common/ipcChannels.js';
 
 const electron = (window as any).electron as {
   dirnameCompat: (metaUrl?: string | URL) => string;
@@ -14,7 +15,6 @@ const electron = (window as any).electron as {
   send: (channel: string, ...args: any[]) => void;
   invoke: (channel: string, ...args: any[]) => Promise<any>;
   on: (channel: string, listener: (...args: any[]) => void) => void;
-  openPath: (path: string) => Promise<string>;
 };
 
 const baseDir = electron.dirnameCompat();
@@ -308,7 +308,7 @@ $(document).ready(() => {
 
   $('#openDataFolder').on('click', async () => {
     const dataDir = getUserDataPath();
-    const result = await electron.openPath(dataDir);
+    const result = await electron.invoke(IpcChannel.OpenPath, dataDir);
     if (result) {
       showToast('Failed to open data directory', false);
     }

--- a/test/preload.test.ts
+++ b/test/preload.test.ts
@@ -45,9 +45,6 @@ describe('preload', () => {
     const onHandler = ipcOnMock.mock.calls[0][1];
     onHandler({}, 'a', 'b');
     expect(listener).toHaveBeenCalledWith('a', 'b');
-    expect(typeof api.openPath).toBe('function');
-    api.openPath('/tmp');
-    expect(shellOpenPathMock).toHaveBeenCalledWith('/tmp');
   });
 
   test('assigns api to window when not contextIsolated', () => {

--- a/test/rendererOptions.test.ts
+++ b/test/rendererOptions.test.ts
@@ -4,7 +4,6 @@ let jQuery: typeof import('../app/vendor/jquery.js');
 let settingsModule: any;
 const invokeMock = jest.fn();
 jest.setTimeout(10000);
-const openPathMock = jest.fn();
 
 const saveSettingsMock = jest.fn().mockResolvedValue('SAVED');
 
@@ -34,7 +33,6 @@ beforeEach(() => {
   (window as any).electron = {
     dirnameCompat: () => __dirname,
     invoke: invokeMock,
-    openPath: openPathMock,
     send: jest.fn(),
     on: jest.fn(),
     startOptionsStats: (...args: any[]) => invokeMock('options:start-stats', ...args),
@@ -50,7 +48,6 @@ beforeEach(() => {
     watch: jest.fn(async () => ({ close: () => {} }))
   };
   invokeMock.mockClear();
-  openPathMock.mockClear();
   saveSettingsMock.mockClear();
 });
 
@@ -95,7 +92,7 @@ test('reloadApp invokes ipcRenderer', async () => {
   expect(invokeMock).toHaveBeenCalledWith('app:reload');
 });
 
-test('openDataFolder calls shell.openPath', async () => {
+test('openDataFolder invokes shell:openPath', async () => {
   jQuery = require('../app/vendor/jquery.js');
   (window as any).$ = (window as any).jQuery = jQuery;
   require('../app/ts/renderer/options');
@@ -107,5 +104,5 @@ test('openDataFolder calls shell.openPath', async () => {
 
   await Promise.resolve();
 
-  expect(openPathMock).toHaveBeenCalled();
+  expect(invokeMock).toHaveBeenCalledWith('shell:openPath', expect.any(String));
 });

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -166,7 +166,6 @@ declare global {
       send: (channel: string, ...args: any[]) => void;
       invoke: (channel: string, ...args: any[]) => Promise<any>;
       on: (channel: string, listener: (...args: any[]) => void) => void;
-      openPath: (path: string) => Promise<string>;
       startOptionsStats: (cfg: string, dir: string) => Promise<number>;
       refreshOptionsStats: (id: number) => Promise<void>;
       stopOptionsStats: (id: number) => Promise<void>;


### PR DESCRIPTION
## Summary
- add `shell:openPath` IPC channel
- handle shell.openPath in main process
- remove openPath direct usage in preload and renderer
- update unit tests for new IPC

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6866e125c0c883259fabe24df814c18c