### PR TITLE
fix build output path

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "type": "module",
   "description": "Bulk whois lookup tool",
-  "main": "./dist/app/ts/main.js",
+  "main": "./dist/main/main.js",
   "scripts": {
     "start": "npm run build && npm run postbuild && cross-env NODE_OPTIONS=--experimental-specifier-resolution=node electron .",
     "debug-powershell": "@powershell -Command $env:DEBUG='*';npm start;",

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -87,7 +87,8 @@ for (const file of fs.readdirSync(partialDir)) {
   if (file === 'mainPanel.js' || !file.endsWith('.js')) continue;
   const specPath = path.join(partialDir, file);
   const spec = (await import(pathToFileURL(specPath).href)).default;
-  Handlebars.registerPartial(path.basename(file, '.js'), Handlebars.template(spec));
+  const alias = path.basename(file, '.js').replace('bulkwhois', 'bw');
+  Handlebars.registerPartial(alias, Handlebars.template(spec));
 }
 
 const mainSpecPath = path.join(partialDir, 'mainPanel.js');


### PR DESCRIPTION
## Summary
- register short partial aliases when pre-rendering main panel
- point `main` entry to relocated build output

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npx jest --runTestsByPath test/dirnameCompat.test.ts --json --outputFile=/tmp/test_summary.json`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6866e7e00be8832599a513bff943f802