### PR TITLE
fix: compile preload as commonjs

### DIFF
--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -126,7 +126,7 @@ app.on('ready', async function () {
       backgroundThrottling: webPreferences.backgroundThrottling, // Whether to throttle animations and timers when the page becomes background
       offscreen: webPreferences.offscreen, // enable offscreen rendering for the browser window
       spellcheck: webPreferences.spellcheck, // Enable builtin spellchecker
-      preload: path.resolve(baseDir, 'preload.js')
+      preload: path.resolve(baseDir, 'preload.cjs')
     }
   });
 

--- a/app/ts/preload.cts
+++ b/app/ts/preload.cts
@@ -3,7 +3,7 @@
 const { contextBridge, ipcRenderer } = require('electron');
 const path = require('path');
 const { dirnameCompat } = require('./utils/dirnameCompat.js');
-import type { IpcRendererEvent } from 'electron';
+type IpcRendererEvent = import('electron').IpcRendererEvent;
 
 const api = {
   send: (channel: string, ...args: unknown[]) => ipcRenderer.send(channel, ...args),

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,9 +2,10 @@ export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/test/**/*.test.ts'],
-  extensionsToTreatAsEsm: ['.ts'],
+  extensionsToTreatAsEsm: ['.ts', '.cts'],
   transform: {
     '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.json', diagnostics: false, useESM: true }],
+    '^.+\\.cts$': ['ts-jest', { tsconfig: 'tsconfig.json', diagnostics: false, useESM: true }],
     '^.+\\.m?js$': 'babel-jest'
   },
   transformIgnorePatterns: ['node_modules/(?!(change-case|html-entities)/)'],

--- a/test/preload.test.ts
+++ b/test/preload.test.ts
@@ -27,7 +27,7 @@ describe('preload', () => {
 
   test('uses contextBridge when contextIsolated', () => {
     (process as any).contextIsolated = true;
-    require('../app/ts/preload');
+    require('../app/ts/preload.cts');
 
     expect(exposeMock).toHaveBeenCalledTimes(1);
     const api = exposeMock.mock.calls[0][1];
@@ -50,7 +50,7 @@ describe('preload', () => {
   test('assigns api to window when not contextIsolated', () => {
     (process as any).contextIsolated = false;
     (global as any).window = {};
-    require('../app/ts/preload');
+    require('../app/ts/preload.cts');
 
     expect(exposeMock).not.toHaveBeenCalled();
     expect((global as any).window.electron).toBeDefined();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,6 @@
     "rootDir": ".",
     "outDir": "dist"
   },
-  "include": ["app/ts/**/*.ts", "scripts/**/*.ts", "**/*.d.ts"],
+  "include": ["app/ts/**/*.ts", "app/ts/**/*.cts", "scripts/**/*.ts", "**/*.d.ts"],
   "exclude": ["test", "app/compiled-templates"]
 }


### PR DESCRIPTION
## Summary
- compile preload as `.cts` and update import path
- adjust Jest config and tests for `.cts` files
- include `.cts` in `tsconfig.json`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npx tsc --noEmit`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6866f318bc6c83259388371cec1aebf7