### PR TITLE
fix: update bulkwhois import

### DIFF
--- a/app/ts/renderer/index.ts
+++ b/app/ts/renderer/index.ts
@@ -1,5 +1,5 @@
 import './singlewhois.js';
-import './bw.js';
+import './bulkwhois.js';
 import './bwa.js';
 import './darkmode.js';
 import './options.js';


### PR DESCRIPTION
## Summary
- fix leftover reference to `bw.js` by importing `bulkwhois.js`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module '../../vendor/jquery.js' etc.)*
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: WebDriverError: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6866f53d59d8832583066dee1774ec05