### PR TITLE
refactor: move path ops to ipc

### DIFF
--- a/app/ts/common/ipcChannels.ts
+++ b/app/ts/common/ipcChannels.ts
@@ -13,5 +13,7 @@ export enum IpcChannel {
   ParseCsv = 'csv:parse',
   AvailabilityCheck = 'availability:check',
   DomainParameters = 'availability:params',
-  OpenPath = 'shell:openPath'
+  OpenPath = 'shell:openPath',
+  PathJoin = 'path:join',
+  PathBasename = 'path:basename'
 }

--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -75,6 +75,7 @@ interface MainSettings extends BaseSettings {
 }
 
 import './main/fsIpc.js';
+import './main/pathIpc.js';
 import './main/utils.js';
 
 let settings: MainSettings;

--- a/app/ts/main/pathIpc.ts
+++ b/app/ts/main/pathIpc.ts
@@ -1,0 +1,10 @@
+import { ipcMain } from 'electron';
+import path from 'path';
+
+ipcMain.handle('path:join', (_e, ...args: string[]) => {
+  return path.join(...args);
+});
+
+ipcMain.handle('path:basename', (_e, p: string) => {
+  return path.basename(p);
+});

--- a/app/ts/preload.cts
+++ b/app/ts/preload.cts
@@ -1,7 +1,6 @@
 // Use CommonJS imports so the compiled preload script works when loaded via
 // Electron's `require` mechanism.
 const { contextBridge, ipcRenderer } = require('electron');
-const path = require('path');
 const { dirnameCompat } = require('./utils/dirnameCompat.js');
 type IpcRendererEvent = import('electron').IpcRendererEvent;
 
@@ -36,8 +35,8 @@ const api = {
   },
   dirnameCompat,
   path: {
-    join: (...args: string[]) => path.join(...args),
-    basename: (p: string) => path.basename(p)
+    join: (...args: string[]) => ipcRenderer.invoke('path:join', ...args),
+    basename: (p: string) => ipcRenderer.invoke('path:basename', p)
   }
 };
 

--- a/app/ts/renderer/bulkwhois/fileinput.ts
+++ b/app/ts/renderer/bulkwhois/fileinput.ts
@@ -11,7 +11,7 @@ const electron = (window as any).electron as {
   readFile: (p: string, opts?: any) => Promise<any>;
   stat: (p: string) => Promise<any>;
   watch: (p: string, opts: any, cb: (evt: string) => void) => Promise<{ close: () => void }>;
-  path: { basename: (p: string) => string };
+  path: { basename: (p: string) => Promise<string> };
 };
 import { tableReset } from './auxiliary.js';
 import $ from '../../../vendor/jquery.js';
@@ -32,7 +32,7 @@ async function refreshBwFile(pathToFile: string): Promise<void> {
       }
     };
     const bwFileStats = (await electron.stat(pathToFile)) as FileStats;
-    bwFileStats.filename = electron.path.basename(pathToFile);
+    bwFileStats.filename = await electron.path.basename(pathToFile);
     bwFileStats.humansize = conversions.byteToHumanFileSize(bwFileStats.size, misc.useStandardSize);
     bwFileContents = await electron.readFile(pathToFile);
     bwFileStats.linecount = bwFileContents.toString().split('\n').length;
@@ -112,7 +112,7 @@ async function handleFileConfirmation(
       $('#bwFileinputloading').removeClass('is-hidden');
       try {
         bwFileStats = (await electron.stat(filePath as string)) as FileStats;
-        bwFileStats.filename = electron.path.basename(filePath as string);
+        bwFileStats.filename = await electron.path.basename(filePath as string);
         bwFileStats.humansize = conversions.byteToHumanFileSize(
           bwFileStats.size,
           misc.useStandardSize
@@ -127,7 +127,7 @@ async function handleFileConfirmation(
     } else {
       try {
         bwFileStats = (await electron.stat((filePath as string[])[0])) as FileStats;
-        bwFileStats.filename = electron.path.basename((filePath as string[])[0]);
+        bwFileStats.filename = await electron.path.basename((filePath as string[])[0]);
         bwFileStats.humansize = conversions.byteToHumanFileSize(
           bwFileStats.size,
           misc.useStandardSize

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -6,7 +6,7 @@ datatables();
 import { settings } from '../settings-renderer.js';
 import { debugFactory } from '../../common/logger.js';
 
-const electron = (window as any).electron as { send: (channel: string, ...args: any[]) => void; invoke: (channel: string, ...args: any[]) => Promise<any>; on: (channel: string, listener: (...args: any[]) => void) => void; readFile: (p: string, opts?: any) => Promise<any>; stat: (p: string) => Promise<any>; watch: (p: string, opts: any, cb: (evt: string) => void) => Promise<{ close: () => void }>; path: { basename: (p: string) => string }; };
+const electron = (window as any).electron as { send: (channel: string, ...args: any[]) => void; invoke: (channel: string, ...args: any[]) => Promise<any>; on: (channel: string, listener: (...args: any[]) => void) => void; readFile: (p: string, opts?: any) => Promise<any>; stat: (p: string) => Promise<any>; watch: (p: string, opts: any, cb: (evt: string) => void) => Promise<{ close: () => void }>; path: { basename: (p: string) => Promise<string> }; };
 
 const debug = debugFactory('renderer.bwa.fileinput');
 debug('loaded');
@@ -21,7 +21,7 @@ let bwaFileWatcher: { close: () => void } | undefined;
 async function refreshBwaFile(pathToFile: string): Promise<void> {
   try {
     const bwaFileStats = (await electron.stat(pathToFile)) as FileStats;
-    bwaFileStats.filename = electron.path.basename(pathToFile);
+    bwaFileStats.filename = await electron.path.basename(pathToFile);
     bwaFileStats.humansize = conversions.byteToHumanFileSize(
       bwaFileStats.size,
       settings.lookupMisc.useStandardSize
@@ -86,8 +86,8 @@ async function handleFileConfirmation(
         $('#bwaEntry').addClass('is-hidden');
         $('#bwaFileinputloading').removeClass('is-hidden');
         try {
-          bwaFileStats = await electron.stat(filePath as string) as FileStats;
-          bwaFileStats.filename = electron.path.basename(filePath as string);
+          bwaFileStats = (await electron.stat(filePath as string)) as FileStats;
+          bwaFileStats.filename = await electron.path.basename(filePath as string);
           bwaFileStats.humansize = conversions.byteToHumanFileSize(
             bwaFileStats.size,
             settings.lookupMisc.useStandardSize
@@ -104,8 +104,8 @@ async function handleFileConfirmation(
         }
       } else {
         try {
-          bwaFileStats = await electron.stat((filePath as string[])[0]) as FileStats;
-          bwaFileStats.filename = electron.path.basename((filePath as string[])[0]);
+          bwaFileStats = (await electron.stat((filePath as string[])[0])) as FileStats;
+          bwaFileStats.filename = await electron.path.basename((filePath as string[])[0]);
           bwaFileStats.humansize = conversions.byteToHumanFileSize(
             bwaFileStats.size,
             settings.lookupMisc.useStandardSize

--- a/app/ts/renderer/i18n.ts
+++ b/app/ts/renderer/i18n.ts
@@ -13,7 +13,7 @@ debug('loaded');
 let translations: Record<string, string> = {};
 
 export async function loadTranslations(lang: string): Promise<void> {
-  const file = electron.path.join(baseDir, '..', 'locales', `${lang}.json`);
+  const file = await electron.path.join(baseDir, '..', 'locales', `${lang}.json`);
   try {
     const raw = await electron.readFile(file, 'utf8');
     translations = JSON.parse(raw);

--- a/app/ts/renderer/options.ts
+++ b/app/ts/renderer/options.ts
@@ -11,7 +11,7 @@ const electron = (window as any).electron as {
   access: (p: string, mode?: number) => Promise<any>;
   exists: (p: string) => Promise<any>;
   watch: (p: string, opts: any, cb: (evt: string) => void) => Promise<{ close: () => void }>;
-  path: { join: (...args: string[]) => string; basename: (p: string) => string };
+  path: { join: (...args: string[]) => Promise<string>; basename: (p: string) => Promise<string> };
   send: (channel: string, ...args: any[]) => void;
   invoke: (channel: string, ...args: any[]) => Promise<any>;
   on: (channel: string, listener: (...args: any[]) => void) => void;
@@ -69,7 +69,10 @@ async function startStatsWorker(): Promise<void> {
     void electron.invoke('options:stop-stats', statsWatcherId);
     statsWatcherId = null;
   }
-  statsConfigPath = electron.path.join(getUserDataPath(), settings.customConfiguration.filepath);
+  statsConfigPath = await electron.path.join(
+    getUserDataPath(),
+    settings.customConfiguration.filepath
+  );
   statsDataDir = getUserDataPath();
   statsWatcherId = await electron.invoke('options:start-stats', statsConfigPath, statsDataDir);
   electron.on('options:stats', (_e, data) => updateStats(data));
@@ -290,7 +293,10 @@ $(document).ready(() => {
     await loadSettings();
     sessionStorage.setItem('customSettingsLoaded', customSettingsLoaded ? 'true' : 'false');
     populateInputs();
-    const filePath = electron.path.join(getUserDataPath(), settings.customConfiguration.filepath);
+    const filePath = await electron.path.join(
+      getUserDataPath(),
+      settings.customConfiguration.filepath
+    );
     const exists = await electron.exists(filePath);
     const success = customSettingsLoaded || !exists;
     showToast(success ? 'Configuration reloaded' : 'Failed to reload configuration', success);
@@ -340,7 +346,10 @@ $(document).ready(() => {
   });
 
   $('#deleteConfigYes').on('click', async () => {
-    const filePath = electron.path.join(getUserDataPath(), settings.customConfiguration.filepath);
+    const filePath = await electron.path.join(
+      getUserDataPath(),
+      settings.customConfiguration.filepath
+    );
     try {
       await electron.unlink(filePath);
       showToast('Configuration deleted', true);

--- a/test/bulkwhoisRenderer.test.ts
+++ b/test/bulkwhoisRenderer.test.ts
@@ -42,7 +42,7 @@ beforeEach(() => {
     },
     stat: statMock,
     readFile: readFileMock,
-    path: { basename: require('path').basename },
+    path: { basename: async (p: string) => require('path').basename(p) },
     watch: jest.fn(async () => ({ close: jest.fn() }))
   };
   invokeMock.mockReset();


### PR DESCRIPTION
## Summary
- route path join and basename through IPC
- update preload to use new IPC channels
- adjust renderer code for async path helpers
- update bulkwhoisRenderer test for async basename

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*


------
https://chatgpt.com/codex/tasks/task_e_6866f6f38ccc8325867a336a09bb2c60