### PR TITLE
fix: support esm vendor runtime

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -18,4 +18,8 @@ app/ts/renderer/singlewhois.ts
 app/ts/common/logger.ts
 app/vendor/datatables.js
 app/vendor/handlebars.runtime.js
+app/vendor/change-case.js
+app/vendor/jquery.js
+app/vendor/html-entities/*.js
+app/vendor/html-entities/index.d.ts
 package.json

--- a/scripts/create-esm-links.js
+++ b/scripts/create-esm-links.js
@@ -14,10 +14,22 @@ function processDir(dir) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
       processDir(full);
-    } else if (entry.isFile() && entry.name.endsWith('.js')) {
-      const base = full.slice(0, -3);
-      if (!fs.existsSync(base)) {
-        fs.symlinkSync(entry.name, base); // relative link within same dir
+    } else if (entry.isFile()) {
+      if (entry.name.endsWith('.cjs')) {
+        const jsName = entry.name.replace(/\.cjs$/, '.js');
+        const jsPath = path.join(dir, jsName);
+        if (!fs.existsSync(jsPath)) {
+          fs.symlinkSync(entry.name, jsPath);
+        }
+        const base = jsPath.slice(0, -3);
+        if (!fs.existsSync(base)) {
+          fs.symlinkSync(jsName, base);
+        }
+      } else if (entry.name.endsWith('.js')) {
+        const base = full.slice(0, -3);
+        if (!fs.existsSync(base)) {
+          fs.symlinkSync(entry.name, base); // relative link within same dir
+        }
       }
     }
   }

--- a/scripts/regenerateVendor.js
+++ b/scripts/regenerateVendor.js
@@ -21,6 +21,10 @@ copyFile(
   path.join(modulesDir, 'handlebars', 'dist', 'handlebars.runtime.js'),
   path.join(vendorDir, 'handlebars.runtime.js')
 );
+fs.appendFileSync(
+  path.join(vendorDir, 'handlebars.runtime.js'),
+  '\nexport default globalThis.Handlebars;\n'
+);
 writeFile(
   path.join(vendorDir, 'handlebars.runtime.d.ts'),
   "import Handlebars from 'handlebars';\nexport default Handlebars;\n"

--- a/scripts/regenerateVendor.mjs
+++ b/scripts/regenerateVendor.mjs
@@ -22,6 +22,10 @@ export function regenerateVendor() {
     path.join(modulesDir, 'handlebars', 'dist', 'handlebars.runtime.js'),
     path.join(vendorDir, 'handlebars.runtime.js')
   );
+  fs.appendFileSync(
+    path.join(vendorDir, 'handlebars.runtime.js'),
+    '\nexport default globalThis.Handlebars;\n'
+  );
   writeFile(
     path.join(vendorDir, 'handlebars.runtime.d.ts'),
     "import Handlebars from 'handlebars';\nexport default Handlebars;\n"


### PR DESCRIPTION
## Summary
- generate a default export for vendor Handlebars runtime
- copy symlink logic for `.cjs` builds
- ignore additional vendor files in Prettier

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6866fa27deac83258e684f9c9ac9bee2