### PR TITLE
fix: ensure preload vendor exports

### DIFF
--- a/scripts/regenerateVendor.mjs
+++ b/scripts/regenerateVendor.mjs
@@ -18,20 +18,27 @@ function writeFile(dest, content) {
 }
 
 export function regenerateVendor() {
-  copyFile(
-    path.join(modulesDir, 'handlebars', 'dist', 'handlebars.runtime.js'),
-    path.join(vendorDir, 'handlebars.runtime.js')
-  );
-  fs.appendFileSync(
-    path.join(vendorDir, 'handlebars.runtime.js'),
-    '\nexport default globalThis.Handlebars;\n'
-  );
+  const hbSrc = path.join(modulesDir, 'handlebars', 'dist', 'handlebars.runtime.js');
+  const hbDest = path.join(vendorDir, 'handlebars.runtime.js');
+  copyFile(hbSrc, hbDest);
+  const hbExport = '\nexport default globalThis.Handlebars;\n';
+  const hbContent = fs.readFileSync(hbDest, 'utf8');
+  if (!hbContent.includes('export default globalThis.Handlebars')) {
+    fs.appendFileSync(hbDest, hbExport);
+  }
   writeFile(
     path.join(vendorDir, 'handlebars.runtime.d.ts'),
     "import Handlebars from 'handlebars';\nexport default Handlebars;\n"
   );
 
-  copyFile(path.join(modulesDir, 'jquery', 'dist', 'jquery.js'), path.join(vendorDir, 'jquery.js'));
+  const jqSrc = path.join(modulesDir, 'jquery', 'dist', 'jquery.js');
+  const jqDest = path.join(vendorDir, 'jquery.js');
+  copyFile(jqSrc, jqDest);
+  const jqExport = '\nexport default window.jQuery;\n';
+  const jqContent = fs.readFileSync(jqDest, 'utf8');
+  if (!jqContent.includes('export default')) {
+    fs.appendFileSync(jqDest, jqExport);
+  }
   writeFile(
     path.join(vendorDir, 'jquery.d.ts'),
     "import jQuery from 'jquery';\nexport default jQuery;\n"


### PR DESCRIPTION
## Summary
- update vendor generation to only append exports once
- add missing export for jquery

## Testing
- `npm test`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6866ff73aa4c8325a04beae129d9857e