### PR TITLE
fix: handle windows build issues

### DIFF
--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -1,7 +1,6 @@
 import * as conversions from '../../common/conversions.js';
 import $ from '../../../vendor/jquery.js';
-import datatables from '../../../vendor/datatables.js';
-datatables();
+import '../../../vendor/datatables.js';
 import { debugFactory } from '../../common/logger.js';
 
 const electron = (window as any).electron as {

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -1,8 +1,7 @@
 import * as conversions from '../../common/conversions.js';
 import type { FileStats } from '../../common/fileStats.js';
 import $ from '../../../vendor/jquery.js';
-import datatables from '../../../vendor/datatables.js';
-datatables();
+import '../../../vendor/datatables.js';
 import { settings } from '../settings-renderer.js';
 import { debugFactory } from '../../common/logger.js';
 


### PR DESCRIPTION
## Summary
- avoid default import for DataTables
- make create-esm-links copy files when symlinks fail

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6867062ef12c8325ad0322fd33654719