### PR TITLE
Use Node dirname directly in preload

### DIFF
--- a/app/ts/preload.cts
+++ b/app/ts/preload.cts
@@ -1,7 +1,7 @@
 // Use CommonJS imports so the compiled preload script works when loaded via
 // Electron's `require` mechanism.
 const { contextBridge, ipcRenderer } = require('electron');
-const { dirnameCompat } = require('./utils/dirnameCompat.js');
+const dirnameCompat = () => __dirname;
 type IpcRendererEvent = import('electron').IpcRendererEvent;
 
 const api = {


### PR DESCRIPTION
## Summary
- simplify preload dirname by referencing Node's `__dirname`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module '../../vendor/change-case.js')*
- `npm run lint`
- `npm run format`
- `npm test -- -t preload`
- `npm run test:e2e` *(fails: WebDriverError: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6867067ff5b4832584053595388807f5