### PR TITLE
fix: ensure handlebars runtime works in ESM

### DIFF
--- a/scripts/regenerateVendor.js
+++ b/scripts/regenerateVendor.js
@@ -17,14 +17,17 @@ function writeFile(dest, content) {
   fs.writeFileSync(dest, content);
 }
 
-copyFile(
-  path.join(modulesDir, 'handlebars', 'dist', 'handlebars.runtime.js'),
-  path.join(vendorDir, 'handlebars.runtime.js')
-);
-fs.appendFileSync(
-  path.join(vendorDir, 'handlebars.runtime.js'),
-  '\nexport default globalThis.Handlebars;\n'
-);
+const hbSrc = path.join(modulesDir, 'handlebars', 'dist', 'handlebars.runtime.js');
+const hbDest = path.join(vendorDir, 'handlebars.runtime.js');
+copyFile(hbSrc, hbDest);
+let hbContent = fs.readFileSync(hbDest, 'utf8');
+if (hbContent.includes('})(this, function()')) {
+  hbContent = hbContent.replace('})(this, function()', '})(globalThis, function()');
+  fs.writeFileSync(hbDest, hbContent);
+}
+if (!hbContent.includes('export default globalThis.Handlebars')) {
+  fs.appendFileSync(hbDest, '\nexport default globalThis.Handlebars;\n');
+}
 writeFile(
   path.join(vendorDir, 'handlebars.runtime.d.ts'),
   "import Handlebars from 'handlebars';\nexport default Handlebars;\n"

--- a/scripts/regenerateVendor.mjs
+++ b/scripts/regenerateVendor.mjs
@@ -21,8 +21,12 @@ export function regenerateVendor() {
   const hbSrc = path.join(modulesDir, 'handlebars', 'dist', 'handlebars.runtime.js');
   const hbDest = path.join(vendorDir, 'handlebars.runtime.js');
   copyFile(hbSrc, hbDest);
+  let hbContent = fs.readFileSync(hbDest, 'utf8');
+  if (hbContent.includes('})(this, function()')) {
+    hbContent = hbContent.replace('})(this, function()', '})(globalThis, function()');
+    fs.writeFileSync(hbDest, hbContent);
+  }
   const hbExport = '\nexport default globalThis.Handlebars;\n';
-  const hbContent = fs.readFileSync(hbDest, 'utf8');
   if (!hbContent.includes('export default globalThis.Handlebars')) {
     fs.appendFileSync(hbDest, hbExport);
   }


### PR DESCRIPTION
## Summary
- tweak vendor regeneration script so Handlebars runtime attaches to `globalThis`

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68679ab1a82083258b1eeacfd755970f