### PR TITLE
fix: robust asset loading

### DIFF
--- a/app/ts/common/fontawesome.ts
+++ b/app/ts/common/fontawesome.ts
@@ -3,7 +3,11 @@
 // but guard against missing dependencies when packaging
 async function loadFontAwesome(): Promise<void> {
   try {
-    await import('@fortawesome/fontawesome-free/js/all.js');
+    const url = new URL(
+      '../../../node_modules/@fortawesome/fontawesome-free/js/all.js',
+      import.meta.url
+    );
+    await import(url.href);
   } catch (err) {
     console.error('Failed to load Font Awesome:', err);
   }

--- a/app/ts/preload.cts
+++ b/app/ts/preload.cts
@@ -1,7 +1,22 @@
 // Use CommonJS imports so the compiled preload script works when loaded via
 // Electron's `require` mechanism.
 const { contextBridge, ipcRenderer } = require('electron');
-const dirnameCompat = () => __dirname;
+const path = require('path');
+const { fileURLToPath } = require('url');
+
+const dirnameCompat = (metaUrl?: string | URL) => {
+  if (typeof __dirname !== 'undefined') {
+    return __dirname;
+  }
+  if (metaUrl) {
+    try {
+      return path.dirname(fileURLToPath(metaUrl));
+    } catch {
+      /* ignore */
+    }
+  }
+  return process.cwd();
+};
 type IpcRendererEvent = import('electron').IpcRendererEvent;
 
 const api = {


### PR DESCRIPTION
## Summary
- fix Font Awesome loading path
- make preload dirname utility work without `__dirname`

## Testing
- `npm run lint`
- `npm run format:check`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6867d606d6148325924492215098bbff