### PR TITLE
feat: vendor fontawesome

### DIFF
--- a/app/ts/common/fontawesome.ts
+++ b/app/ts/common/fontawesome.ts
@@ -3,10 +3,7 @@
 // but guard against missing dependencies when packaging
 async function loadFontAwesome(): Promise<void> {
   try {
-    const url = new URL(
-      '../../../node_modules/@fortawesome/fontawesome-free/js/all.js',
-      import.meta.url
-    );
+    const url = new URL('../../vendor/fontawesome.js', import.meta.url);
     await import(url.href);
   } catch (err) {
     console.error('Failed to load Font Awesome:', err);

--- a/scripts/regenerateVendor.js
+++ b/scripts/regenerateVendor.js
@@ -40,6 +40,15 @@ writeFile(
 );
 
 copyFile(
+  path.join(modulesDir, '@fortawesome', 'fontawesome-free', 'js', 'all.js'),
+  path.join(vendorDir, 'fontawesome.js')
+);
+writeFile(
+  path.join(vendorDir, 'fontawesome.d.ts'),
+  'const fontawesome: any;\nexport default fontawesome;\n'
+);
+
+copyFile(
   path.join(modulesDir, 'change-case', 'dist', 'index.js'),
   path.join(vendorDir, 'change-case.js')
 );

--- a/scripts/regenerateVendor.mjs
+++ b/scripts/regenerateVendor.mjs
@@ -49,6 +49,15 @@ export function regenerateVendor() {
   );
 
   copyFile(
+    path.join(modulesDir, '@fortawesome', 'fontawesome-free', 'js', 'all.js'),
+    path.join(vendorDir, 'fontawesome.js')
+  );
+  writeFile(
+    path.join(vendorDir, 'fontawesome.d.ts'),
+    'const fontawesome: any;\nexport default fontawesome;\n'
+  );
+
+  copyFile(
     path.join(modulesDir, 'change-case', 'dist', 'index.js'),
     path.join(vendorDir, 'change-case.js')
   );

--- a/test/regenerateVendor.test.ts
+++ b/test/regenerateVendor.test.ts
@@ -35,6 +35,10 @@ describe('regenerateVendor', () => {
       path.join(rootDir, 'app', 'vendor', 'jquery.js')
     );
     expect(copyFileMock).toHaveBeenCalledWith(
+      path.join(rootDir, 'node_modules', '@fortawesome', 'fontawesome-free', 'js', 'all.js'),
+      path.join(rootDir, 'app', 'vendor', 'fontawesome.js')
+    );
+    expect(copyFileMock).toHaveBeenCalledWith(
       path.join(rootDir, 'node_modules', 'change-case', 'dist', 'index.js'),
       path.join(rootDir, 'app', 'vendor', 'change-case.js')
     );


### PR DESCRIPTION
## Summary
- copy FontAwesome into vendor scripts
- load FontAwesome from vendor folder
- test vendor generation for FontAwesome

## Testing
- `npm run format`
- `npm run lint`
- `npm run prebuild`
- `npx tsc --noEmit`
- `npm test --silent`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6867da66afe083258ca1c12d27146cd8