### PR TITLE
refactor: drop path usage from preload

### DIFF
--- a/app/ts/preload.cts
+++ b/app/ts/preload.cts
@@ -1,19 +1,9 @@
 // Use CommonJS imports so the compiled preload script works when loaded via
 // Electron's `require` mechanism.
 const { contextBridge, ipcRenderer } = require('electron');
-const path = require('path');
-const { fileURLToPath } = require('url');
-
-const dirnameCompat = (metaUrl?: string | URL) => {
+const dirnameCompat = (_metaUrl?: string | URL) => {
   if (typeof __dirname !== 'undefined') {
     return __dirname;
-  }
-  if (metaUrl) {
-    try {
-      return path.dirname(fileURLToPath(metaUrl));
-    } catch {
-      /* ignore */
-    }
   }
   return process.cwd();
 };


### PR DESCRIPTION
## Summary
- remove Node path requirement from preload

## Testing
- `npm run prebuild`
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6867e01e743c832584b2c03e87fa3b0c