### PR TITLE
refactor: remove cwd reliance in renderer

### DIFF
--- a/app/ts/common/ipcChannels.ts
+++ b/app/ts/common/ipcChannels.ts
@@ -15,5 +15,6 @@ export enum IpcChannel {
   DomainParameters = 'availability:params',
   OpenPath = 'shell:openPath',
   PathJoin = 'path:join',
-  PathBasename = 'path:basename'
+  PathBasename = 'path:basename',
+  GetBaseDir = 'app:get-base-dir'
 }

--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -9,6 +9,7 @@ import { loadSettings, settings as store } from './main/settings-main.js';
 import type { Settings as BaseSettings } from './main/settings-main.js';
 import { formatString } from './common/stringformat.js';
 import { RequestCache } from './common/requestCache.js';
+import { IpcChannel } from './common/ipcChannels.js';
 import {
   initialize as initializeRemote,
   enable as enableRemote
@@ -248,6 +249,10 @@ ipcMain.on('app:exit-confirmed', function () {
 ipcMain.handle('app:reload', function () {
   app.relaunch();
   app.exit(0);
+});
+
+ipcMain.handle(IpcChannel.GetBaseDir, function () {
+  return baseDir;
 });
 
 /*

--- a/app/ts/preload.cts
+++ b/app/ts/preload.cts
@@ -1,12 +1,6 @@
 // Use CommonJS imports so the compiled preload script works when loaded via
 // Electron's `require` mechanism.
 const { contextBridge, ipcRenderer } = require('electron');
-const dirnameCompat = (_metaUrl?: string | URL) => {
-  if (typeof __dirname !== 'undefined') {
-    return __dirname;
-  }
-  return process.cwd();
-};
 type IpcRendererEvent = import('electron').IpcRendererEvent;
 
 const api = {
@@ -38,7 +32,7 @@ const api = {
       }
     };
   },
-  dirnameCompat,
+  getBaseDir: () => ipcRenderer.invoke('app:get-base-dir'),
   path: {
     join: (...args: string[]) => ipcRenderer.invoke('path:join', ...args),
     basename: (p: string) => ipcRenderer.invoke('path:basename', p)

--- a/app/ts/renderer/i18n.ts
+++ b/app/ts/renderer/i18n.ts
@@ -1,10 +1,8 @@
 const electron = (window as any).electron as {
-  dirnameCompat: (metaUrl?: string | URL) => string;
+  getBaseDir: () => Promise<string>;
   readFile: (p: string, enc?: any) => Promise<any>;
   path: { join: (...args: string[]) => string };
 };
-
-const baseDir = electron.dirnameCompat();
 import Handlebars from '../../vendor/handlebars.runtime.js';
 import { debugFactory } from '../common/logger.js';
 
@@ -13,6 +11,7 @@ debug('loaded');
 let translations: Record<string, string> = {};
 
 export async function loadTranslations(lang: string): Promise<void> {
+  const baseDir = await electron.getBaseDir();
   const file = await electron.path.join(baseDir, '..', 'locales', `${lang}.json`);
   try {
     const raw = await electron.readFile(file, 'utf8');

--- a/app/ts/renderer/options.ts
+++ b/app/ts/renderer/options.ts
@@ -3,7 +3,7 @@ import { debugFactory } from '../common/logger.js';
 import { IpcChannel } from '../common/ipcChannels.js';
 
 const electron = (window as any).electron as {
-  dirnameCompat: (metaUrl?: string | URL) => string;
+  getBaseDir: () => Promise<string>;
   readFile: (p: string, opts?: any) => Promise<any>;
   stat: (p: string) => Promise<any>;
   readdir: (p: string, opts?: any) => Promise<any>;
@@ -16,8 +16,6 @@ const electron = (window as any).electron as {
   invoke: (channel: string, ...args: any[]) => Promise<any>;
   on: (channel: string, listener: (...args: any[]) => void) => void;
 };
-
-const baseDir = electron.dirnameCompat();
 
 const debug = debugFactory('renderer.options');
 debug('loaded');

--- a/test/electronMock.ts
+++ b/test/electronMock.ts
@@ -17,12 +17,7 @@ if (!(global as any).window) {
 
 (global as any).window.electron = {
   send: jest.fn(),
-  dirnameCompat: jest.fn((metaUrl?: string | URL) => {
-    if (metaUrl) {
-      return path.dirname(new URL(metaUrl.toString()).pathname);
-    }
-    return __dirname;
-  }),
+  getBaseDir: jest.fn(() => Promise.resolve(__dirname)),
   invoke: jest.fn((channel: string, ...args: any[]) => {
     if (channel === 'settings:load') {
       const { load, getUserDataPath } = require('../app/ts/common/settings');

--- a/test/exportRenderer.test.ts
+++ b/test/exportRenderer.test.ts
@@ -25,6 +25,7 @@ beforeEach(() => {
   (window as any).$ = (window as any).jQuery = jQuery;
   invokeMock = jest.fn().mockResolvedValue('ok');
   (window as any).electron = {
+    getBaseDir: () => Promise.resolve(__dirname),
     invoke: invokeMock,
     send: jest.fn(),
     on: (channel: string, cb: (...args: any[]) => void) => {

--- a/test/i18n.test.ts
+++ b/test/i18n.test.ts
@@ -12,7 +12,7 @@ describe('i18n loader', () => {
   beforeEach(() => {
     readFileMock.mockReset();
     (window as any).electron = {
-      dirnameCompat: () => __dirname,
+      getBaseDir: () => Promise.resolve(__dirname),
       readFile: readFileMock,
       path: { join: (...args: string[]) => require('path').join(...args) }
     };

--- a/test/navigation.test.ts
+++ b/test/navigation.test.ts
@@ -22,7 +22,7 @@ beforeEach(() => {
   sendMock = jest.fn();
   invokeMock = jest.fn();
   (window as any).electron = {
-    dirnameCompat: () => __dirname,
+    getBaseDir: () => Promise.resolve(__dirname),
     send: sendMock,
     invoke: invokeMock,
     on: jest.fn()

--- a/test/optionsHelpers.test.ts
+++ b/test/optionsHelpers.test.ts
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 
-(window as any).electron = { dirnameCompat: () => __dirname };
+(window as any).electron = { getBaseDir: () => Promise.resolve(__dirname) };
 
 import { _test } from '../app/ts/renderer/options';
 import { settings } from '../app/ts/renderer/settings-renderer';

--- a/test/preload.test.ts
+++ b/test/preload.test.ts
@@ -37,7 +37,7 @@ describe('preload', () => {
     expect(typeof api.invoke).toBe('function');
     api.invoke('chan', 2);
     expect(ipcInvokeMock).toHaveBeenCalledWith('chan', 2);
-    expect(typeof api.dirnameCompat).toBe('function');
+    expect(typeof api.getBaseDir).toBe('function');
     expect(typeof api.on).toBe('function');
     const listener = jest.fn();
     api.on('chan', listener);
@@ -57,6 +57,6 @@ describe('preload', () => {
     const api = (global as any).window.electron;
     api.send('chan2');
     expect(ipcSendMock).toHaveBeenCalledWith('chan2');
-    expect(typeof api.dirnameCompat).toBe('function');
+    expect(typeof api.getBaseDir).toBe('function');
   });
 });

--- a/test/rendererOptions.test.ts
+++ b/test/rendererOptions.test.ts
@@ -31,7 +31,7 @@ beforeEach(() => {
     <div id="opSearchNoResults"></div>
   `;
   (window as any).electron = {
-    dirnameCompat: () => __dirname,
+    getBaseDir: () => Promise.resolve(__dirname),
     invoke: invokeMock,
     send: jest.fn(),
     on: jest.fn(),

--- a/types/vendor.d.ts
+++ b/types/vendor.d.ts
@@ -1,0 +1,26 @@
+declare module '*vendor/jquery.js' {
+  const jq: typeof import('jquery');
+  export default jq;
+}
+
+declare module '*vendor/handlebars.runtime.js' {
+  import Handlebars from 'handlebars';
+  export default Handlebars;
+}
+declare module '*vendor/change-case.js' {
+  export * from 'change-case';
+}
+
+declare module '*vendor/html-entities/index.js' {
+  export * from 'html-entities';
+}
+
+declare module '*vendor/datatables.js' {
+  const d: any;
+  export default d;
+}
+
+declare module '*vendor/fontawesome.js' {
+  const d: any;
+  export default d;
+}


### PR DESCRIPTION
## Summary
- add `GetBaseDir` IPC channel
- expose `getBaseDir` API in preload
- update i18n and options renderers to use `getBaseDir`
- adjust main process to provide base dir
- update tests and vendor type declarations

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6867e2d9d5d08325895ddb4276dd2ef7