### PR TITLE
fix: register main IPC handlers

### DIFF
--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -78,6 +78,7 @@ interface MainSettings extends BaseSettings {
 import './main/fsIpc.js';
 import './main/pathIpc.js';
 import './main/utils.js';
+import './main/index.js';
 
 let settings: MainSettings;
 let mainWindow: BrowserWindow;


### PR DESCRIPTION
## Summary
- load all main process IPC handlers by importing `main/index.js` on startup

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6867e746c6bc8325b1a593568b247109