### PR TITLE
fix: prevent duplicate options stats listeners

### DIFF
--- a/test/rendererOptions.test.ts
+++ b/test/rendererOptions.test.ts
@@ -35,6 +35,7 @@ beforeEach(() => {
     invoke: invokeMock,
     send: jest.fn(),
     on: jest.fn(),
+    off: jest.fn(),
     startOptionsStats: (...args: any[]) => invokeMock('options:start-stats', ...args),
     refreshOptionsStats: (...args: any[]) => invokeMock('options:refresh-stats', ...args),
     stopOptionsStats: (...args: any[]) => invokeMock('options:stop-stats', ...args),

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -78,7 +78,11 @@ declare module 'electron' {
     send<C extends keyof RendererToMainIpc>(channel: C, ...args: RendererToMainIpc[C]): void;
     on<C extends keyof MainToRendererIpc>(
       channel: C,
-      listener: (event: IpcRendererEvent, ...args: MainToRendererIpc[C]) => void
+      listener: (...args: MainToRendererIpc[C]) => void
+    ): void;
+    off<C extends keyof MainToRendererIpc>(
+      channel: C,
+      listener: (...args: MainToRendererIpc[C]) => void
     ): void;
     invoke<C extends keyof RendererToMainIpc>(
       channel: C,


### PR DESCRIPTION
## Summary
- expose `off` helper in preload to allow removing listeners
- clean up existing `options:stats` listener before starting a new watcher
- extend custom IPC typings and tests for new method

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6867f6fe0c688325880bdecbdb190b4a