### PR TITLE
feat: open data folder via dedicated IPC

### DIFF
--- a/app/ts/common/ipcChannels.ts
+++ b/app/ts/common/ipcChannels.ts
@@ -14,6 +14,7 @@ export enum IpcChannel {
   AvailabilityCheck = 'availability:check',
   DomainParameters = 'availability:params',
   OpenPath = 'shell:openPath',
+  OpenDataDir = 'app:open-data-dir',
   PathJoin = 'path:join',
   PathBasename = 'path:basename',
   GetBaseDir = 'app:get-base-dir'

--- a/app/ts/main/utils.ts
+++ b/app/ts/main/utils.ts
@@ -3,6 +3,7 @@ import Papa from 'papaparse';
 import { isDomainAvailable, getDomainParameters } from '../common/availability.js';
 import { IpcChannel } from '../common/ipcChannels.js';
 import { toJSON } from '../common/parser.js';
+import { getUserDataPath } from '../common/settings.js';
 
 ipcMain.handle(IpcChannel.ParseCsv, async (_e, text: string) => {
   return Papa.parse(text, { header: true });
@@ -32,4 +33,9 @@ ipcMain.handle(
 
 ipcMain.handle(IpcChannel.OpenPath, async (_e, p: string) => {
   return shell.openPath(p);
+});
+
+ipcMain.handle(IpcChannel.OpenDataDir, async () => {
+  const dir = getUserDataPath();
+  return shell.openPath(dir);
 });

--- a/app/ts/preload.cts
+++ b/app/ts/preload.cts
@@ -44,6 +44,7 @@ const api = {
     };
   },
   getBaseDir: () => ipcRenderer.invoke('app:get-base-dir'),
+  openDataDir: () => ipcRenderer.invoke('app:open-data-dir'),
   path: {
     join: (...args: string[]) => ipcRenderer.invoke('path:join', ...args),
     basename: (p: string) => ipcRenderer.invoke('path:basename', p)

--- a/app/ts/renderer/options.ts
+++ b/app/ts/renderer/options.ts
@@ -16,6 +16,7 @@ const electron = (window as any).electron as {
   invoke: (channel: string, ...args: any[]) => Promise<any>;
   on: (channel: string, listener: (...args: any[]) => void) => void;
   off: (channel: string, listener: (...args: any[]) => void) => void;
+  openDataDir: () => Promise<any>;
 };
 
 const debug = debugFactory('renderer.options');
@@ -318,8 +319,7 @@ $(document).ready(() => {
   });
 
   $('#openDataFolder').on('click', async () => {
-    const dataDir = getUserDataPath();
-    const result = await electron.invoke(IpcChannel.OpenPath, dataDir);
+    const result = await electron.openDataDir();
     if (result) {
       showToast('Failed to open data directory', false);
     }

--- a/test/preload.test.ts
+++ b/test/preload.test.ts
@@ -38,6 +38,7 @@ describe('preload', () => {
     api.invoke('chan', 2);
     expect(ipcInvokeMock).toHaveBeenCalledWith('chan', 2);
     expect(typeof api.getBaseDir).toBe('function');
+    expect(typeof api.openDataDir).toBe('function');
     expect(typeof api.on).toBe('function');
     const listener = jest.fn();
     api.on('chan', listener);
@@ -58,5 +59,6 @@ describe('preload', () => {
     api.send('chan2');
     expect(ipcSendMock).toHaveBeenCalledWith('chan2');
     expect(typeof api.getBaseDir).toBe('function');
+    expect(typeof api.openDataDir).toBe('function');
   });
 });

--- a/test/rendererOptions.test.ts
+++ b/test/rendererOptions.test.ts
@@ -36,6 +36,7 @@ beforeEach(() => {
     send: jest.fn(),
     on: jest.fn(),
     off: jest.fn(),
+    openDataDir: () => invokeMock('app:open-data-dir'),
     startOptionsStats: (...args: any[]) => invokeMock('options:start-stats', ...args),
     refreshOptionsStats: (...args: any[]) => invokeMock('options:refresh-stats', ...args),
     stopOptionsStats: (...args: any[]) => invokeMock('options:stop-stats', ...args),
@@ -93,7 +94,7 @@ test('reloadApp invokes ipcRenderer', async () => {
   expect(invokeMock).toHaveBeenCalledWith('app:reload');
 });
 
-test('openDataFolder invokes shell:openPath', async () => {
+test('openDataFolder invokes app:open-data-dir', async () => {
   jQuery = require('../app/vendor/jquery.js');
   (window as any).$ = (window as any).jQuery = jQuery;
   require('../app/ts/renderer/options');
@@ -105,5 +106,5 @@ test('openDataFolder invokes shell:openPath', async () => {
 
   await Promise.resolve();
 
-  expect(invokeMock).toHaveBeenCalledWith('shell:openPath', expect.any(String));
+  expect(invokeMock).toHaveBeenCalledWith('app:open-data-dir');
 });


### PR DESCRIPTION
## Summary
- add new `OpenDataDir` IPC channel
- expose `openDataDir` from preload
- handle new channel in main utils
- use the new API in options page
- update related unit tests

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6867fc9cb28c832586539408132da18e