### PR TITLE
fix: use punycode package

### DIFF
--- a/app/ts/common/lookup.ts
+++ b/app/ts/common/lookup.ts
@@ -1,5 +1,5 @@
 import psl from 'psl';
-import * as puny from 'punycode';
+import { toASCII } from 'punycode/';
 import uts46 from 'idna-uts46';
 import whois from 'whois';
 import debugModule from 'debug';
@@ -63,7 +63,7 @@ export function convertDomain(domain: string, mode?: string): string {
 
   switch (mode) {
     case 'punycode':
-      return puny.toASCII(domain);
+      return toASCII(domain);
     case 'uts46':
       return uts46.toAscii(domain);
     case 'uts46-transitional':

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -107,6 +107,7 @@ declare module 'punycode' {
 }
 declare module 'punycode/' {
   export function encode(input: string): string;
+  export function toASCII(input: string): string;
 }
 declare module 'idna-uts46' {
   const uts46: { toAscii(domain: string, options?: any): string };


### PR DESCRIPTION
## Summary
- avoid Node builtin punycode deprecation

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68681a2e11148325bd6921c5a0ea1a29