### PR TITLE
fix: rebuild native modules after install

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prebuild": "node scripts/prebuild.js",
     "regen:vendor": "node scripts/regenerateVendor.mjs",
     "rebuild": "electron-rebuild -f -w better-sqlite3",
-    "postinstall": "simple-git-hooks",
+    "postinstall": "simple-git-hooks && npm run rebuild",
     "clean": "rimraf dist release_builds app/compiled-templates",
     "pretest": "node scripts/prebuild.js"
   },

--- a/readme.md
+++ b/readme.md
@@ -209,9 +209,10 @@ dependencies before building. This script runs whenever you execute `npm run bui
 
 ### Rebuilding native modules
 
-If you see errors about mismatched `NODE_MODULE_VERSION` when launching the app,
-run `npm run rebuild` to rebuild dependencies like `better-sqlite3` against the
-Electron runtime.
+`npm install` automatically invokes `electron-rebuild` through the `postinstall`
+script so native modules match the bundled Electron runtime.
+If you still see errors about mismatched `NODE_MODULE_VERSION` when launching the
+app, run `npm run rebuild` manually to rebuild dependencies like `better-sqlite3`.
 
 ## Development setup
 


### PR DESCRIPTION
## Summary
- rebuild better-sqlite3 automatically after `npm install`
- document automatic rebuild

## Testing
- `npm run format:check`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686826c087488325b6f043de53e41e01