### PR TITLE
Fix modal styling

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -218,3 +218,24 @@ html[data-theme='dark'] #toTable .button {
 #opGoToBottom.is-visible {
   display: inline-flex;
 }
+
+/* Flat modal styling */
+.modal-card,
+.modal-content {
+  box-shadow: none;
+  border-radius: 0;
+}
+
+.modal-card-head,
+.modal-card-foot {
+  box-shadow: none;
+  border: 1px solid #dbdbdb;
+}
+
+.modal-card-head {
+  border-bottom: 1px solid #dbdbdb;
+}
+
+.modal-card-foot {
+  border-top: 1px solid #dbdbdb;
+}

--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Addressed missing module errors causing console noise.
 - Resolved export and open link failures in the renderer.
 - Fixed proxy rotation bug causing repeated proxy usage.
+- Modals now use a flat style without drop shadows.
 
 ## [0.0.4] - 2019-11-18
 


### PR DESCRIPTION
## Summary
- make modals flat without shadows
- note style change in changelog

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: better_sqlite3 NODE_MODULE_VERSION mismatch)*
- `npm run test:e2e` *(fails: WebDriverError session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68682f39360c8325a1a0df570c01e09e