### PR TITLE
fix: correct punycode import

### DIFF
--- a/app/ts/common/lookup.ts
+++ b/app/ts/common/lookup.ts
@@ -1,5 +1,5 @@
 import psl from 'psl';
-import { toASCII } from 'punycode/';
+import { toASCII } from 'punycode/punycode.js';
 import uts46 from 'idna-uts46';
 import whois from 'whois';
 import debugModule from 'debug';

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -105,7 +105,7 @@ declare module 'psl' {
 declare module 'punycode' {
   export function encode(input: string): string;
 }
-declare module 'punycode/' {
+declare module 'punycode/punycode.js' {
   export function encode(input: string): string;
   export function toASCII(input: string): string;
 }


### PR DESCRIPTION
## Summary
- update punycode import for ES module compatibility
- adjust custom type declaration

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: better_sqlite3.node incompatible)*
- `npm run test:e2e` *(fails: ChromeDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6868321aeabc8325a8eb28370555e4f3