### PR TITLE
Fix bulk whois IPC results

### DIFF
--- a/app/ts/renderer/bulkwhois/process.ts
+++ b/app/ts/renderer/bulkwhois/process.ts
@@ -39,12 +39,13 @@ electron.on('bulkwhois:results', function(event, domain, domainResults) {
 });
 */
 
-/*
-// Receive bulk whois results
-electron.on('bulkwhois:resultreceive', function(event, results) {
-
+// Receive bulk whois results and store them for export
+let bulkResults: any;
+electron.on('bulkwhois:result.receive', (_event, results) => {
+  bulkResults = results;
 });
-*/
+
+export { bulkResults };
 
 /*
   electron.on('bulkwhois:status.update', function(...) {...});


### PR DESCRIPTION
## Summary
- handle `bulkwhois:result.receive` in renderer

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format:check`
- `npm test` *(fails: Module did not self-register)*
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686831c491e08325987dc081b0369d17