### PR TITLE
refactor: switch options stats IPC to settings

### DIFF
--- a/app/ts/preload.cts
+++ b/app/ts/preload.cts
@@ -26,11 +26,12 @@ const api = {
   unlink: (p: string) => ipcRenderer.invoke('fs:unlink', p),
   access: (p: string, mode?: number) => ipcRenderer.invoke('fs:access', p, mode),
   exists: (p: string) => ipcRenderer.invoke('fs:exists', p),
-  startOptionsStats: (cfg: string, dir: string) =>
-    ipcRenderer.invoke('options:start-stats', cfg, dir),
-  refreshOptionsStats: (id: number) => ipcRenderer.invoke('options:refresh-stats', id),
-  stopOptionsStats: (id: number) => ipcRenderer.invoke('options:stop-stats', id),
-  getOptionsStats: (cfg: string, dir: string) => ipcRenderer.invoke('options:get-stats', cfg, dir),
+  startSettingsStats: (cfg: string, dir: string) =>
+    ipcRenderer.invoke('settings:start-stats', cfg, dir),
+  refreshSettingsStats: (id: number) => ipcRenderer.invoke('settings:refresh-stats', id),
+  stopSettingsStats: (id: number) => ipcRenderer.invoke('settings:stop-stats', id),
+  getSettingsStats: (cfg: string, dir: string) =>
+    ipcRenderer.invoke('settings:get-stats', cfg, dir),
   watch: async (p: string, opts: any, cb: (evt: string) => void) => {
     const id = await ipcRenderer.invoke('fs:watch', p, opts);
     const chan = `fs:watch:${id}`;

--- a/app/ts/renderer/settings.ts
+++ b/app/ts/renderer/settings.ts
@@ -68,9 +68,9 @@ let statsHandler: ((data: any) => void) | null = null;
 async function startStatsWorker(): Promise<void> {
   if (statsWatcherId !== null) {
     if (statsHandler) {
-      electron.off('options:stats', statsHandler);
+      electron.off('settings:stats', statsHandler);
     }
-    void electron.invoke('options:stop-stats', statsWatcherId);
+    void electron.invoke('settings:stop-stats', statsWatcherId);
     statsWatcherId = null;
     statsHandler = null;
   }
@@ -79,14 +79,14 @@ async function startStatsWorker(): Promise<void> {
     settings.customConfiguration.filepath
   );
   statsDataDir = getUserDataPath();
-  statsWatcherId = await electron.invoke('options:start-stats', statsConfigPath, statsDataDir);
+  statsWatcherId = await electron.invoke('settings:start-stats', statsConfigPath, statsDataDir);
   statsHandler = (data: any) => updateStats(data);
-  electron.on('options:stats', statsHandler);
+  electron.on('settings:stats', statsHandler);
 }
 
 function refreshStats(): void {
   if (statsWatcherId !== null) {
-    void electron.invoke('options:refresh-stats', statsWatcherId);
+    void electron.invoke('settings:refresh-stats', statsWatcherId);
   }
 }
 

--- a/test/optionsIpc.test.ts
+++ b/test/optionsIpc.test.ts
@@ -10,15 +10,15 @@ jest.isolateModules(() => {
 
 const getHandler = (c: string) => ipcMainHandlers[c];
 
-describe('options IPC handlers', () => {
-  test('options:get-stats returns file stats', async () => {
+describe('settings IPC handlers', () => {
+  test('settings:get-stats returns file stats', async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'opt-'));
     const dataDir = path.join(root, 'data');
     fs.mkdirSync(dataDir);
     const cfg = path.join(root, 'config.json');
     fs.writeFileSync(cfg, 'cfg');
 
-    const handler = getHandler('options:get-stats');
+    const handler = getHandler('settings:get-stats');
     const stats = await handler({}, cfg, dataDir);
 
     expect(stats).toEqual(expect.objectContaining({ configPath: cfg, dataPath: dataDir }));

--- a/test/rendererOptions.test.ts
+++ b/test/rendererOptions.test.ts
@@ -37,10 +37,10 @@ beforeEach(() => {
     on: jest.fn(),
     off: jest.fn(),
     openDataDir: () => invokeMock('app:open-data-dir'),
-    startOptionsStats: (...args: any[]) => invokeMock('options:start-stats', ...args),
-    refreshOptionsStats: (...args: any[]) => invokeMock('options:refresh-stats', ...args),
-    stopOptionsStats: (...args: any[]) => invokeMock('options:stop-stats', ...args),
-    getOptionsStats: (...args: any[]) => invokeMock('options:get-stats', ...args),
+    startSettingsStats: (...args: any[]) => invokeMock('settings:start-stats', ...args),
+    refreshSettingsStats: (...args: any[]) => invokeMock('settings:refresh-stats', ...args),
+    stopSettingsStats: (...args: any[]) => invokeMock('settings:stop-stats', ...args),
+    getSettingsStats: (...args: any[]) => invokeMock('settings:get-stats', ...args),
     path: { join: (...args: string[]) => require('path').join(...args) },
     readdir: jest.fn(async () => []),
     stat: jest.fn(async () => ({ size: 0, mtime: new Date(), atime: new Date() })),
@@ -78,7 +78,7 @@ test('reloadApp invokes ipcRenderer', async () => {
 
   await new Promise((r) => setTimeout(r, 0));
   expect(invokeMock).toHaveBeenCalledWith(
-    'options:start-stats',
+    'settings:start-stats',
     expect.any(String),
     expect.any(String)
   );

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -46,10 +46,10 @@ declare module 'electron' {
     ondragstart: [string];
     'singlewhois:lookup': [string];
     'singlewhois:openlink': [string];
-    'options:start-stats': [string, string];
-    'options:refresh-stats': [number];
-    'options:stop-stats': [number];
-    'options:get-stats': [string, string];
+    'settings:start-stats': [string, string];
+    'settings:refresh-stats': [number];
+    'settings:stop-stats': [number];
+    'settings:get-stats': [string, string];
   }
 
   interface MainToRendererIpc {
@@ -61,7 +61,7 @@ declare module 'electron' {
     'bulkwhois:export.error': [string];
     'singlewhois:results': [any];
     'singlewhois:copied': [];
-    'options:stats': [any];
+    'settings:stats': [any];
   }
 
   export interface IpcMain {
@@ -172,10 +172,10 @@ declare global {
       send: (channel: string, ...args: any[]) => void;
       invoke: (channel: string, ...args: any[]) => Promise<any>;
       on: (channel: string, listener: (...args: any[]) => void) => void;
-      startOptionsStats: (cfg: string, dir: string) => Promise<number>;
-      refreshOptionsStats: (id: number) => Promise<void>;
-      stopOptionsStats: (id: number) => Promise<void>;
-      getOptionsStats: (cfg: string, dir: string) => Promise<any>;
+      startSettingsStats: (cfg: string, dir: string) => Promise<number>;
+      refreshSettingsStats: (id: number) => Promise<void>;
+      stopSettingsStats: (id: number) => Promise<void>;
+      getSettingsStats: (cfg: string, dir: string) => Promise<any>;
     };
   }
 }


### PR DESCRIPTION
## Summary
- swap options stats events to `settings:*`
- rename preload helpers to match
- update type declarations
- adjust tests

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: better-sqlite3 mismatch)*
- `npm run test:e2e` *(fails: WebDriver session error)*

------
https://chatgpt.com/codex/tasks/task_e_686856b5d61083258a50cb46a8b8810f