### PR TITLE
Refactor options entry IDs

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -194,7 +194,7 @@ html[data-theme='dark'] #toTable .button {
 }
 
 /* Back to top button */
-#opBackToTop {
+#settingsBackToTop {
   position: fixed;
   bottom: 1.5rem;
   right: 1.5rem;
@@ -202,12 +202,12 @@ html[data-theme='dark'] #toTable .button {
   z-index: 900;
 }
 
-#opBackToTop.is-visible {
+#settingsBackToTop.is-visible {
   display: inline-flex;
 }
 
 /* Go to bottom button */
-#opGoToBottom {
+#settingsGoToBottom {
   position: fixed;
   bottom: 1.5rem;
   right: 4rem;
@@ -215,7 +215,7 @@ html[data-theme='dark'] #toTable .button {
   z-index: 900;
 }
 
-#opGoToBottom.is-visible {
+#settingsGoToBottom.is-visible {
   display: inline-flex;
 }
 

--- a/app/html/templates/mainPanel.hbs
+++ b/app/html/templates/mainPanel.hbs
@@ -86,9 +86,9 @@
                 {{> toEntry}}
               </div>
             </div>
-            <div id="opMainContainer" class="tab-content">
-              <div id="opEntry" class="container is-clearfix">
-                {{> opEntry}}
+            <div id="settingsMainContainer" class="tab-content">
+              <div id="settingsEntry" class="container is-clearfix">
+                {{> settingsEntry}}
               </div>
             </div>
             <div id="heMainContainer" class="tab-content">

--- a/app/html/templates/navBottom.hbs
+++ b/app/html/templates/navBottom.hbs
@@ -12,7 +12,7 @@
       <a>Tools</a>
     </li>
     <a class='is-hidden is-specialmenu'>|</a>
-    <li id='navButtonOp' data-tab='opMainContainer' class='is-hidden is-specialmenu'>
+    <li id='navButtonOp' data-tab='settingsMainContainer' class='is-hidden is-specialmenu'>
       <a>Options</a>
     </li>
     <li id='navButtonHe' data-tab='heMainContainer' class='is-hidden is-specialmenu'>

--- a/app/html/templates/settingsEntry.hbs
+++ b/app/html/templates/settingsEntry.hbs
@@ -90,12 +90,12 @@
 <p class='control'>
   <button id='clearHistory' class='button is-small is-danger'>{{t 'clear_history'}}</button>
 </p>
-<button id='opBackToTop' class='button is-info is-small back-to-top'>
+<button id='settingsBackToTop' class='button is-info is-small back-to-top'>
   <span class='icon is-small'>
     <i class='fas fa-arrow-up'></i>
   </span>
 </button>
-<button id='opGoToBottom' class='button is-info is-small go-to-bottom'>
+<button id='settingsGoToBottom' class='button is-info is-small go-to-bottom'>
   <span class='icon is-small'>
     <i class='fas fa-arrow-down'></i>
   </span>

--- a/app/ts/renderer/navigation.ts
+++ b/app/ts/renderer/navigation.ts
@@ -63,7 +63,7 @@ $(document).on('click', 'section.tabs ul li', function () {
 
     $(this).addClass('is-active');
     $('#' + tabName).addClass('current');
-    if (tabName === 'opMainContainer') {
+    if (tabName === 'settingsMainContainer') {
       populateInputs();
     }
   }

--- a/app/ts/renderer/registerPartials.ts
+++ b/app/ts/renderer/registerPartials.ts
@@ -20,7 +20,7 @@ import bwaFileinputconfirm from '../../compiled-templates/bwaFileinputconfirm.js
 import bwaProcess from '../../compiled-templates/bwaProcess.js';
 import navBottom from '../../compiled-templates/navBottom.js';
 import navTop from '../../compiled-templates/navTop.js';
-import opEntry from '../../compiled-templates/opEntry.js';
+import settingsEntry from '../../compiled-templates/settingsEntry.js';
 import singlewhois from '../../compiled-templates/singlewhois.js';
 import toEntry from '../../compiled-templates/toEntry.js';
 import he from '../../compiled-templates/he.js';
@@ -60,7 +60,7 @@ export function registerPartials(): void {
     bwaProcess: Handlebars.template((bwaProcess as any).default || (bwaProcess as any)),
     navBottom: Handlebars.template((navBottom as any).default || (navBottom as any)),
     navTop: Handlebars.template((navTop as any).default || (navTop as any)),
-    opEntry: Handlebars.template((opEntry as any).default || (opEntry as any)),
+    settingsEntry: Handlebars.template((settingsEntry as any).default || (settingsEntry as any)),
     singlewhois: Handlebars.template((singlewhois as any).default || (singlewhois as any)),
     toEntry: Handlebars.template((toEntry as any).default || (toEntry as any)),
     he: Handlebars.template((he as any).default || (he as any)),

--- a/app/ts/renderer/settings.ts
+++ b/app/ts/renderer/settings.ts
@@ -225,7 +225,7 @@ function filterOptions(term: string): void {
 }
 
 $(document).ready(() => {
-  const container = $('#opEntry');
+  const container = $('#settingsEntry');
   const table = $('#opTable');
   buildEntries(appDefaults.settings, '', table);
   filterOptions('');
@@ -373,11 +373,11 @@ $(document).ready(() => {
     $('#deleteConfigModal').removeClass('is-active');
   });
 
-  const backToTop = $('#opBackToTop');
-  const goToBottom = $('#opGoToBottom');
+  const backToTop = $('#settingsBackToTop');
+  const goToBottom = $('#settingsGoToBottom');
   const containerEl = $('#contents-container');
   containerEl.on('scroll', () => {
-    if ($('#opMainContainer').hasClass('current')) {
+    if ($('#settingsMainContainer').hasClass('current')) {
       const top = containerEl.scrollTop() ?? 0;
       const bottom = (containerEl[0]?.scrollHeight ?? 0) - (containerEl.innerHeight() ?? 0) - top;
       backToTop.toggleClass('is-visible', top > 200);

--- a/test/e2e/run.js
+++ b/test/e2e/run.js
@@ -97,7 +97,7 @@ const debug = debugModule('test:e2e');
     await browser.execute(() => document.querySelector('#navButtonOp')?.click());
     await browser.pause(500);
     active = await browser.execute(() =>
-      document.getElementById('opMainContainer')?.classList.contains('current')
+      document.getElementById('settingsMainContainer')?.classList.contains('current')
     );
     assert.ok(active, 'Options tab did not activate');
 

--- a/test/registerPartials.test.ts
+++ b/test/registerPartials.test.ts
@@ -15,7 +15,7 @@ const partialNames = [
   'bwaProcess',
   'navBottom',
   'navTop',
-  'opEntry',
+  'settingsEntry',
   'singlewhois',
   'toEntry',
   'he',

--- a/test/rendererOptions.test.ts
+++ b/test/rendererOptions.test.ts
@@ -15,7 +15,7 @@ jest.mock('../app/ts/renderer/settings-renderer', () => {
 beforeEach(() => {
   jest.resetModules();
   document.body.innerHTML = `
-    <div id="opEntry">
+    <div id="settingsEntry">
       <div class="field">
         <select id="appSettings.theme.darkMode">
           <option value="true">true</option>


### PR DESCRIPTION
## Summary
- rename `opEntry.hbs` to `settingsEntry.hbs`
- update IDs for settings container and scroll buttons
- adjust template references and navigation
- update tests for new IDs

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: better-sqlite3 NODE_MODULE_VERSION mismatch)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6868591db300832586b425087462768b