### PR TITLE
feat: add IPC to delete config file

### DIFF
--- a/app/ts/main/settings-main.ts
+++ b/app/ts/main/settings-main.ts
@@ -97,6 +97,10 @@ if (ipcMain && typeof ipcMain.handle === 'function') {
     }
     return res;
   });
+
+  ipcMain.handle('config:delete', (_e, filePath: string) => {
+    return fs.promises.unlink(filePath);
+  });
 }
 export {
   settings,

--- a/app/ts/renderer/settings.ts
+++ b/app/ts/renderer/settings.ts
@@ -356,7 +356,7 @@ $(document).ready(() => {
       settings.customConfiguration.filepath
     );
     try {
-      await electron.unlink(filePath);
+      await electron.invoke('config:delete', filePath);
       showToast('Configuration deleted', true);
     } catch (err) {
       if ((err as any).code !== 'ENOENT') {


### PR DESCRIPTION
## Summary
- add `config:delete` handler in the main process
- delete config via IPC in settings UI

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run format`
- `npm test` *(fails: better_sqlite3 binary mismatch)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686859e4c64c8325b420d56c6a293a8b