### PR TITLE
fix(types): update bulkwhois module paths

### DIFF
--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -137,13 +137,13 @@ declare module 'app/ts/common/proxy' {
   export function resetProxyRotation(): void;
 }
 
-declare module 'app/ts/main/bw/auxiliary' {
+declare module 'app/ts/main/bulkwhois/auxiliary' {
   import type { IpcMainEvent } from 'electron';
   export function resetUiCounters(event: IpcMainEvent): void;
   export { resetUiCounters as rstUiCntrs };
 }
 
-declare module 'app/ts/main/bw/process.defaults' {
+declare module 'app/ts/main/bulkwhois/process.defaults' {
   const defaults: any;
   export default defaults;
 }


### PR DESCRIPTION
## Summary
- align custom type declarations with renamed bulkwhois directory

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: better_sqlite3 native module version mismatch)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68685e9fda5c8325b29d2393049bcb76