### PR TITLE
Refactor bulk whois tab IDs

### DIFF
--- a/app/html/templates/mainPanel.hbs
+++ b/app/html/templates/mainPanel.hbs
@@ -34,34 +34,34 @@
             <div id="singlewhoisMainContainer" class="container tab-content level-item current">
               {{> singlewhois}}
             </div>
-            <div id="bwMainContainer" class="tab-content">
+            <div id="bulkwhoisMainContainer" class="tab-content">
               <!-- Bulk Whois panel -->
               <div id="bwEntry" class="container is-clearfix">
-                {{> bwEntry}}
+                {{> bulkwhoisEntry}}
               </div>
               <div id="bwFileinputloading" class="container is-clearfix is-hidden">
-                {{> bwFileInputLoading}}
+                {{> bulkwhoisFileInputLoading}}
               </div>
               <div id="bwFileinputconfirm" class="container is-clearfix is-hidden">
-                {{> bwFileInputConfirm}}
+                {{> bulkwhoisFileInputConfirm}}
               </div>
               <div id="bwWordlistinput" class="container is-clearfix is-hidden">
-                {{> bwWordlistInput}}
+                {{> bulkwhoisWordlistInput}}
               </div>
               <div id="bwWordlistloading" class="container is-clearfix is-hidden">
-                {{> bwWordlistLoading}}
+                {{> bulkwhoisWordlistLoading}}
               </div>
               <div id="bwWordlistconfirm" class="container is-clearfix is-hidden">
-                {{> bwWordlistConfirm}}
+                {{> bulkwhoisWordlistConfirm}}
               </div>
               <div id="bwProcessing" class="container is-clearfix is-hidden">
-                {{> bwProcessing}}
+                {{> bulkwhoisProcessing}}
               </div>
               <div id="bwExport" class="container is-clearfix is-hidden">
-                {{> bwExport}}
+                {{> bulkwhoisExport}}
               </div>
               <div id="bwExportloading" class="container is-clearfix is-hidden">
-                {{> bwExportLoading}}
+                {{> bulkwhoisExportLoading}}
               </div>
             </div>
             <div id="bwaMainContainer" class="tab-content">

--- a/app/html/templates/navBottom.hbs
+++ b/app/html/templates/navBottom.hbs
@@ -3,7 +3,7 @@
     <li id='navButtonSinglewhois' data-tab='singlewhoisMainContainer' class='is-active'>
       <a>Simple whois</a>
     </li>
-    <li id='navButtonBw' data-tab='bwMainContainer'><a>Bulk whois</a></li>
+    <li id='navButtonBulkwhois' data-tab='bulkwhoisMainContainer'><a>Bulk whois</a></li>
     <a class='is-hidden is-specialmenu'>|</a>
     <li id='navButtonBwa' data-tab='bwaMainContainer' class='is-hidden is-specialmenu'>
       <a>Bulk Analyser</a>

--- a/app/ts/renderer/bulkwhois/fileinput.ts
+++ b/app/ts/renderer/bulkwhois/fileinput.ts
@@ -275,7 +275,7 @@ $(document).on('click', '#bwFileButtonConfirm', function () {
  */
 (function dragDropInitialization() {
   $(document).ready(() => {
-    const holder = document.getElementById('bwMainContainer') as HTMLElement | null;
+    const holder = document.getElementById('bulkwhoisMainContainer') as HTMLElement | null;
     if (!holder) return;
 
     holder.ondragover = function () {
@@ -303,10 +303,10 @@ $(document).on('click', '#bwFileButtonConfirm', function () {
 })();
 
 /*
-  $('#bwMainContainer').on('drop', function(...) {...});
+  $('#bulkwhoisMainContainer').on('drop', function(...) {...});
     On Drop ipsum
  */
-$('#bwMainContainer').on('drop', function (event) {
+$('#bulkwhoisMainContainer').on('drop', function (event) {
   event.preventDefault();
   for (const f of Array.from((event as any).originalEvent.dataTransfer.files)) {
     const file = f as any;

--- a/app/ts/renderer/navigation.ts
+++ b/app/ts/renderer/navigation.ts
@@ -123,7 +123,7 @@ $(document).keyup(function (event) {
         break;
 
       // Bulk whois tab is active
-      case $('#navButtonBw').hasClass('is-active'):
+      case $('#navButtonBulkwhois').hasClass('is-active'):
         electron.send('app:debug', 'Hotkey, Bulk whois tab is active');
         switch (true) {
           // Bulk whois, is Stop dialog open

--- a/app/ts/renderer/registerPartials.ts
+++ b/app/ts/renderer/registerPartials.ts
@@ -28,25 +28,27 @@ import modals from '../../compiled-templates/modals.js';
 
 export function registerPartials(): void {
   const partials: Record<string, any> = {
-    bwEntry: Handlebars.template((bwEntry as any).default || (bwEntry as any)),
-    bwExport: Handlebars.template((bwExport as any).default || (bwExport as any)),
-    bwExportLoading: Handlebars.template(
+    bulkwhoisEntry: Handlebars.template((bwEntry as any).default || (bwEntry as any)),
+    bulkwhoisExport: Handlebars.template((bwExport as any).default || (bwExport as any)),
+    bulkwhoisExportLoading: Handlebars.template(
       (bwExportLoading as any).default || (bwExportLoading as any)
     ),
-    bwFileInputConfirm: Handlebars.template(
+    bulkwhoisFileInputConfirm: Handlebars.template(
       (bwFileInputConfirm as any).default || (bwFileInputConfirm as any)
     ),
-    bwFileInputLoading: Handlebars.template(
+    bulkwhoisFileInputLoading: Handlebars.template(
       (bwFileInputLoading as any).default || (bwFileInputLoading as any)
     ),
-    bwProcessing: Handlebars.template((bwProcessing as any).default || (bwProcessing as any)),
-    bwWordlistConfirm: Handlebars.template(
+    bulkwhoisProcessing: Handlebars.template(
+      (bwProcessing as any).default || (bwProcessing as any)
+    ),
+    bulkwhoisWordlistConfirm: Handlebars.template(
       (bwWordlistConfirm as any).default || (bwWordlistConfirm as any)
     ),
-    bwWordlistInput: Handlebars.template(
+    bulkwhoisWordlistInput: Handlebars.template(
       (bwWordlistInput as any).default || (bwWordlistInput as any)
     ),
-    bwWordlistLoading: Handlebars.template(
+    bulkwhoisWordlistLoading: Handlebars.template(
       (bwWordlistLoading as any).default || (bwWordlistLoading as any)
     ),
     bwaAnalyser: Handlebars.template((bwaAnalyser as any).default || (bwaAnalyser as any)),

--- a/test/e2e/run.js
+++ b/test/e2e/run.js
@@ -87,10 +87,10 @@ const debug = debugModule('test:e2e');
     assert.ok(minimized, 'Window did not minimize via IPC');
 
     // Navigate between tabs
-    await browser.execute(() => document.querySelector('#navButtonBw')?.click());
+    await browser.execute(() => document.querySelector('#navButtonBulkwhois')?.click());
     await browser.pause(500);
     let active = await browser.execute(() =>
-      document.getElementById('bwMainContainer')?.classList.contains('current')
+      document.getElementById('bulkwhoisMainContainer')?.classList.contains('current')
     );
     assert.ok(active, 'Bulk tab did not activate');
 
@@ -102,7 +102,7 @@ const debug = debugModule('test:e2e');
     assert.ok(active, 'Options tab did not activate');
 
     // Trigger sample bulk lookup using mock data
-    await browser.execute(() => document.querySelector('#navButtonBw')?.click());
+    await browser.execute(() => document.querySelector('#navButtonBulkwhois')?.click());
     await browser.pause(300);
     await browser.execute(() => {
       document.querySelector('#bwEntryButtonWordlist')?.click();

--- a/test/registerPartials.test.ts
+++ b/test/registerPartials.test.ts
@@ -57,9 +57,8 @@ describe('registerPartials', () => {
     partialNames.forEach((name, index) => {
       const precompiled = { name };
       expect((handlebars.template as jest.Mock).mock.calls[index][0]).toEqual(precompiled);
-      const partialName = name.replace('bulkwhois', 'bw');
       expect((handlebars.registerPartial as jest.Mock).mock.calls[index]).toEqual([
-        partialName,
+        name,
         `compiled-${name}`
       ]);
     });


### PR DESCRIPTION
## Summary
- rename bulk whois navigation button to `navButtonBulkwhois`
- rename container to `bulkwhoisMainContainer`
- update Handlebars partial registration names
- update selectors in navigation and file input logic
- adjust tests for new IDs

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: better-sqlite3 node module mismatch)*
- `npm run test:e2e` *(fails: WebDriverError session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686860584e84832584fb8fa5830f4970