### PR TITLE
test: update settings selectors

### DIFF
--- a/test/e2e/run.js
+++ b/test/e2e/run.js
@@ -126,8 +126,8 @@ const debug = debugModule('test:e2e');
     await browser.execute(() => document.querySelector('#navButtonOp')?.click());
     await browser.pause(500);
     await browser.execute(() => {
-      const dark = document.getElementById('appSettings.theme.darkMode');
-      const sys = document.getElementById('appSettings.theme.followSystem');
+      const dark = document.getElementById('settings.theme.darkMode');
+      const sys = document.getElementById('settings.theme.followSystem');
       if (sys) {
         sys.value = 'false';
         sys.dispatchEvent(new Event('change', { bubbles: true }));

--- a/test/optionsHelpers.test.ts
+++ b/test/optionsHelpers.test.ts
@@ -8,7 +8,7 @@ import appDefaults from '../app/ts/appsettings';
 
 const { getValue, setValue, parseValue, getDefault } = _test;
 
-describe('options helper functions', () => {
+describe('settings helper functions', () => {
   test('getValue returns nested value', () => {
     const backup = JSON.parse(JSON.stringify(settings));
     settings.lookupGeneral.timeout = 1234;

--- a/test/rendererOptions.test.ts
+++ b/test/rendererOptions.test.ts
@@ -17,7 +17,7 @@ beforeEach(() => {
   document.body.innerHTML = `
     <div id="settingsEntry">
       <div class="field">
-        <select id="appSettings.theme.darkMode">
+        <select id="settings.theme.darkMode">
           <option value="true">true</option>
           <option value="false">false</option>
         </select>
@@ -36,7 +36,7 @@ beforeEach(() => {
     send: jest.fn(),
     on: jest.fn(),
     off: jest.fn(),
-    openDataDir: () => invokeMock('app:open-data-dir'),
+    openDataDir: () => invokeMock('settings:open-data-dir'),
     startSettingsStats: (...args: any[]) => invokeMock('settings:start-stats', ...args),
     refreshSettingsStats: (...args: any[]) => invokeMock('settings:refresh-stats', ...args),
     stopSettingsStats: (...args: any[]) => invokeMock('settings:stop-stats', ...args),
@@ -63,7 +63,7 @@ test('changing setting updates configuration', async () => {
 
   await new Promise((r) => setTimeout(r, 0));
 
-  jQuery('#appSettings\\.theme\\.darkMode').val('true').trigger('change');
+  jQuery('#settings\\.theme\\.darkMode').val('true').trigger('change');
 
   await Promise.resolve();
   expect(settings.theme.darkMode).toBe(true);
@@ -94,7 +94,7 @@ test('reloadApp invokes ipcRenderer', async () => {
   expect(invokeMock).toHaveBeenCalledWith('app:reload');
 });
 
-test('openDataFolder invokes app:open-data-dir', async () => {
+test('openDataFolder invokes settings:open-data-dir', async () => {
   jQuery = require('../app/vendor/jquery.js');
   (window as any).$ = (window as any).jQuery = jQuery;
   require('../app/ts/renderer/settings');
@@ -106,5 +106,5 @@ test('openDataFolder invokes app:open-data-dir', async () => {
 
   await Promise.resolve();
 
-  expect(invokeMock).toHaveBeenCalledWith('app:open-data-dir');
+  expect(invokeMock).toHaveBeenCalledWith('settings:open-data-dir');
 });


### PR DESCRIPTION
## Summary
- switch options helper test description
- adjust rendererOptions mocks and selectors to match settings channels
- update e2e DOM selectors for settings

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: better_sqlite3.node wrong version)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6868eff8b7348325aca9f3f9e29d958f