### PR TITLE
feat: load i18n via fs bridge

### DIFF
--- a/app/ts/main/i18n.ts
+++ b/app/ts/main/i18n.ts
@@ -8,9 +8,8 @@ const baseDir = dirnameCompat();
 ipcMain.handle('i18n:load', async (_e, lang: string) => {
   const file = path.join(baseDir, '..', 'locales', `${lang}.json`);
   try {
-    const raw = await fs.promises.readFile(file, 'utf8');
-    return JSON.parse(raw) as Record<string, string>;
+    return await fs.promises.readFile(file, 'utf8');
   } catch {
-    return {};
+    return '{}';
   }
 });

--- a/test/i18n.test.ts
+++ b/test/i18n.test.ts
@@ -2,18 +2,21 @@
 
 import Handlebars from '../app/vendor/handlebars.runtime.js';
 
-const loadMock = jest.fn();
+const invokeMock = jest.fn();
+const joinMock = jest.fn(async (...args: string[]) => args.join('/'));
 
 describe('i18n loader', () => {
   beforeEach(() => {
-    loadMock.mockReset();
+    invokeMock.mockReset();
+    joinMock.mockReset();
     (window as any).electron = {
-      loadTranslations: loadMock
+      invoke: invokeMock,
+      path: { join: joinMock }
     };
   });
 
   test('loads translations and registers helper', async () => {
-    loadMock.mockResolvedValue({ hello: 'world' });
+    invokeMock.mockResolvedValue('{"hello":"world"}');
     const {
       loadTranslations,
       registerTranslationHelpers,


### PR DESCRIPTION
## Summary
- switch renderer i18n loader to use `fs:readFile`
- return raw data from main i18n handler
- update i18n unit test for new API

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Module did not self-register)*
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686a6f3a9e888325a5fb231dab78fd5a