### PR TITLE
refactor: unify bulkwhois debug namespaces

### DIFF
--- a/app/ts/main/bulkwhois.ts
+++ b/app/ts/main/bulkwhois.ts
@@ -1,6 +1,6 @@
 import electron from 'electron';
 import debugModule from 'debug';
-const debug = debugModule('main.bw');
+const debug = debugModule('bulkwhois');
 
 const { app, BrowserWindow, Menu, ipcMain, dialog, remote } = electron;
 

--- a/app/ts/main/bulkwhois/auxiliary.ts
+++ b/app/ts/main/bulkwhois/auxiliary.ts
@@ -2,7 +2,7 @@ import debugModule from 'debug';
 import type { IpcMainEvent } from 'electron';
 import { IpcChannel } from '../../common/ipcChannels.js';
 
-const debug = debugModule('main.bw.auxiliary');
+const debug = debugModule('bulkwhois.auxiliary');
 
 /*
   resetUiCounters

--- a/app/ts/main/bulkwhois/export.ts
+++ b/app/ts/main/bulkwhois/export.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import * as conversions from '../../common/conversions.js';
 import debugModule from 'debug';
-const debug = debugModule('main.bw.export');
+const debug = debugModule('bulkwhois.export');
 import JSZip from 'jszip';
 import { formatString } from '../../common/stringformat.js';
 

--- a/app/ts/main/bulkwhois/fileinput.ts
+++ b/app/ts/main/bulkwhois/fileinput.ts
@@ -1,6 +1,6 @@
 import electron from 'electron';
 import debugModule from 'debug';
-const debug = debugModule('main.bw.fileinput');
+const debug = debugModule('bulkwhois.fileinput');
 
 const { app, BrowserWindow, Menu, ipcMain, dialog } = electron;
 import { formatString } from '../../common/stringformat.js';

--- a/app/ts/main/bulkwhois/process.ts
+++ b/app/ts/main/bulkwhois/process.ts
@@ -1,7 +1,7 @@
 import electron from 'electron';
 import type { IpcMainInvokeEvent, IpcMainEvent } from 'electron';
 import debugModule from 'debug';
-const debug = debugModule('main.bw.process');
+const debug = debugModule('bulkwhois.process');
 import defaultBulkWhois from './process.defaults.js';
 
 import type { BulkWhois, DomainSetup } from './types.js';

--- a/app/ts/main/bulkwhois/queue.ts
+++ b/app/ts/main/bulkwhois/queue.ts
@@ -3,7 +3,7 @@ import { formatString } from '../../common/stringformat.js';
 import type { Settings } from '../settings-main.js';
 import type { DomainSetup } from './types.js';
 
-const debug = debugModule('main.bw.queue');
+const debug = debugModule('bulkwhois.queue');
 
 function randomWithin(min: number, max: number): number {
   if (min > max) {

--- a/app/ts/main/bulkwhois/resultHandler.ts
+++ b/app/ts/main/bulkwhois/resultHandler.ts
@@ -11,7 +11,7 @@ import type { IpcMainEvent } from 'electron';
 import { addEntry as addHistoryEntry } from '../../common/history.js';
 import { IpcChannel } from '../../common/ipcChannels.js';
 
-const debug = debugModule('main.bw.resultHandler');
+const debug = debugModule('bulkwhois.resultHandler');
 
 export async function processData(
   bulkWhois: BulkWhois,

--- a/app/ts/main/bulkwhois/scheduler.ts
+++ b/app/ts/main/bulkwhois/scheduler.ts
@@ -11,7 +11,7 @@ import { processData } from './resultHandler.js';
 import type { IpcMainEvent } from 'electron';
 import { IpcChannel } from '../../common/ipcChannels.js';
 
-const debug = debugModule('main.bw.scheduler');
+const debug = debugModule('bulkwhois.scheduler');
 
 export function processDomain(
   bulkWhois: BulkWhois,

--- a/app/ts/main/bulkwhois/wordlistinput.ts
+++ b/app/ts/main/bulkwhois/wordlistinput.ts
@@ -1,6 +1,6 @@
 import electron from 'electron';
 import debugModule from 'debug';
-const debug = debugModule('main.bw.wordlistinput');
+const debug = debugModule('bulkwhois.wordlistinput');
 
 const { app, BrowserWindow, Menu, ipcMain, dialog, remote } = electron;
 import { IpcChannel } from '../../common/ipcChannels.js';

--- a/app/ts/renderer/bulkwhois.ts
+++ b/app/ts/renderer/bulkwhois.ts
@@ -6,5 +6,5 @@ import './bulkwhois/export.js'; // Export processing
 
 import { debugFactory } from '../common/logger.js';
 
-const debug = debugFactory('renderer.bw');
+const debug = debugFactory('bulkwhois');
 debug('loaded');

--- a/app/ts/renderer/bulkwhois/auxiliary.ts
+++ b/app/ts/renderer/bulkwhois/auxiliary.ts
@@ -2,7 +2,7 @@ import { resetObject } from '../../common/resetObject.js';
 import $ from '../../../vendor/jquery.js';
 import { debugFactory } from '../../common/logger.js';
 
-const debug = debugFactory('renderer.bw.auxiliary');
+const debug = debugFactory('bulkwhois.auxiliary');
 debug('loaded');
 
 /*
@@ -52,7 +52,7 @@ function setExportOptions(preset: string): void {
     // Export available only
     case 'availableonly':
       unlockFields();
-      //$('#bweSelectFiletype').val('csv');
+      //$('#bweSelectFiletype').val('csv'); // force CSV for bulk export presets
       $('#bwExportSelectDomains').val('available');
       $('#bwExportSelectErrors').val('no');
       $('#bwExportSelectInformation').val('domain');
@@ -61,7 +61,7 @@ function setExportOptions(preset: string): void {
     // All results but no reply nor debug
     case 'allbutnoreply':
       unlockFields();
-      //$('#bweSelectFiletype').val('csv');
+      //$('#bweSelectFiletype').val('csv'); // enforce CSV output
       $('#bwExportSelectDomains').val('both');
       $('#bwExportSelectErrors').val('yes');
       $('#bwExportSelectInformation').val('domain+basic');

--- a/app/ts/renderer/bulkwhois/export.defaults.ts
+++ b/app/ts/renderer/bulkwhois/export.defaults.ts
@@ -1,7 +1,7 @@
 // Default export options values
 import { debugFactory } from '../../common/logger.js';
 
-const debug = debugFactory('renderer.bw.export.defaults');
+const debug = debugFactory('bulkwhois.export.defaults');
 debug('loaded');
 
 const defaultExportOptions = {

--- a/app/ts/renderer/bulkwhois/export.ts
+++ b/app/ts/renderer/bulkwhois/export.ts
@@ -9,7 +9,7 @@ const electron = (window as any).electron as {
   on: (channel: string, listener: (...args: any[]) => void) => void;
 };
 
-const debug = debugFactory('renderer.bw.export');
+const debug = debugFactory('bulkwhois.export');
 debug('loaded');
 import { resetObject } from '../../common/resetObject.js';
 import { getExportOptions, setExportOptions, setExportOptionsEx } from './auxiliary.js';

--- a/app/ts/renderer/bulkwhois/fileinput.ts
+++ b/app/ts/renderer/bulkwhois/fileinput.ts
@@ -1,7 +1,7 @@
 import * as conversions from '../../common/conversions.js';
 import type { FileStats } from '../../common/fileStats.js';
 import { debugFactory } from '../../common/logger.js';
-const debug = debugFactory('renderer.bw.fileinput');
+const debug = debugFactory('bulkwhois.fileinput');
 debug('loaded');
 
 const electron = (window as any).electron as {
@@ -182,7 +182,7 @@ async function handleFileConfirmation(
       String(bwFileStats.humansize) + formatString(' ({0} line(s))', String(bwFileStats.linecount))
     );
     $('#bwFileTdFilepreview').text(String(bwFileStats.filepreview) + '...');
-    //$('#bwTableMaxEstimate').text(bwFileStats['maxestimate']);
+    //$('#bwTableMaxEstimate').text(bwFileStats['maxestimate']); // show estimated bulk lookup time
     debug('cont:' + bwFileContents);
 
     debug(bwFileStats.linecount);

--- a/app/ts/renderer/bulkwhois/process.ts
+++ b/app/ts/renderer/bulkwhois/process.ts
@@ -10,7 +10,7 @@ const electron = (window as any).electron as {
 };
 import $ from '../../../vendor/jquery.js';
 
-const debug = debugFactory('renderer.bw.process');
+const debug = debugFactory('bulkwhois.process');
 debug('loaded');
 
 import { formatString } from '../../common/stringformat.js';

--- a/app/ts/renderer/bulkwhois/wordlistinput.ts
+++ b/app/ts/renderer/bulkwhois/wordlistinput.ts
@@ -10,7 +10,7 @@ const electron = (window as any).electron as {
 import { tableReset } from './auxiliary.js';
 import $ from '../../../vendor/jquery.js';
 
-const debug = debugFactory('renderer.bw.wordlistinput');
+const debug = debugFactory('bulkwhois.wordlistinput');
 debug('loaded');
 
 import { formatString } from '../../common/stringformat.js';

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -152,7 +152,7 @@ async function handleFileConfirmation(
       );
       $('#bwaFileTdFilepreview').text(String(bwaFileStats.filepreview) + '...');
       $('#bwaFileTextareaErrors').text(String(bwaFileStats.errors || 'No errors'));
-      //$('#bwTableMaxEstimate').text(bwFileStats['maxestimate']);
+      //$('#bwTableMaxEstimate').text(bwFileStats['maxestimate']); // show estimated bulk lookup time
       if (chosenPath) {
         bwaFileWatcher = await electron.bwaWatch(chosenPath, { persistent: false }, (evt: string) => {
           if (evt === 'change') void refreshBwaFile(chosenPath);


### PR DESCRIPTION
## Summary
- use `bulkwhois` for all debug namespaces
- clarify bw-related comments

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: better-sqlite3 NODE_MODULE_VERSION mismatch and failing rendererOptions.test)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686a73436f48832599edf3341021571b