### PR TITLE
fix: update test selectors

### DIFF
--- a/test/e2e/run.js
+++ b/test/e2e/run.js
@@ -126,8 +126,8 @@ const debug = debugModule('test:e2e');
     await browser.execute(() => document.querySelector('#navButtonOp')?.click());
     await browser.pause(500);
     await browser.execute(() => {
-      const dark = document.getElementById('settings.theme.darkMode');
-      const sys = document.getElementById('settings.theme.followSystem');
+      const dark = document.getElementById('appSettings.theme.darkMode');
+      const sys = document.getElementById('appSettings.theme.followSystem');
       if (sys) {
         sys.value = 'false';
         sys.dispatchEvent(new Event('change', { bubbles: true }));

--- a/test/rendererOptions.test.ts
+++ b/test/rendererOptions.test.ts
@@ -17,7 +17,7 @@ beforeEach(() => {
   document.body.innerHTML = `
     <div id="settingsEntry">
       <div class="field">
-        <select id="settings.theme.darkMode">
+        <select id="appSettings.theme.darkMode">
           <option value="true">true</option>
           <option value="false">false</option>
         </select>
@@ -63,7 +63,7 @@ test('changing setting updates configuration', async () => {
 
   await new Promise((r) => setTimeout(r, 0));
 
-  jQuery('#settings\\.theme\\.darkMode').val('true').trigger('change');
+  jQuery('#appSettings\\.theme\\.darkMode').val('true').trigger('change');
 
   await Promise.resolve();
   expect(settings.theme.darkMode).toBe(true);


### PR DESCRIPTION
## Summary
- update selectors in rendererOptions and e2e tests

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: better-sqlite3 binary mismatch)*
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686a734578e4832597f0738457f339bc