### PR TITLE
refactor: unify debug logging

### DIFF
--- a/app/ts/ai/availabilityModel.ts
+++ b/app/ts/ai/availabilityModel.ts
@@ -1,9 +1,9 @@
 import fs from 'fs';
 import path from 'path';
-import debugModule from 'debug';
+import { debugFactory } from '../common/logger.js';
 import { settings, getUserDataPath } from '../common/settings.js';
 
-const debug = debugModule('ai.availabilityModel');
+const debug = debugFactory('ai.availabilityModel');
 
 export type Label = 'available' | 'unavailable';
 

--- a/app/ts/ai/modelDownloader.ts
+++ b/app/ts/ai/modelDownloader.ts
@@ -1,10 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 import https from 'https';
-import debugModule from 'debug';
+import { debugFactory } from '../common/logger.js';
 import { settings, getUserDataPath } from '../common/settings.js';
 
-const debug = debugModule('ai.modelDownloader');
+const debug = debugFactory('ai.modelDownloader');
 
 export async function downloadModel(url: string, dest: string): Promise<void> {
   const baseDir = path.resolve(getUserDataPath(), settings.ai.dataPath);

--- a/app/ts/ai/openaiSuggest.ts
+++ b/app/ts/ai/openaiSuggest.ts
@@ -1,7 +1,7 @@
-import debugModule from 'debug';
+import { debugFactory } from '../common/logger.js';
 import { settings } from '../common/settings.js';
 
-const debug = debugModule('ai.openaiSuggest');
+const debug = debugFactory('ai.openaiSuggest');
 
 async function ensureFetch(): Promise<void> {
   if (typeof globalThis.fetch === 'undefined') {

--- a/app/ts/cli.ts
+++ b/app/ts/cli.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import JSZip from 'jszip';
-import debugModule from 'debug';
+import { debugFactory } from './common/logger.js';
 import { lookup as whoisLookup } from './common/lookup.js';
 import { settings } from './common/settings.js';
 import { RequestCache } from './common/requestCache.js';
@@ -15,7 +15,7 @@ import { suggestWords } from './ai/openaiSuggest.js';
 
 const requestCache = new RequestCache();
 
-const debug = debugModule('cli');
+const debug = debugFactory('cli');
 
 export interface CliOptions {
   domains: string[];

--- a/app/ts/common/dnsLookup.ts
+++ b/app/ts/common/dnsLookup.ts
@@ -1,12 +1,12 @@
 import dns from 'dns/promises';
 import psl from 'psl';
-import debugModule from 'debug';
+import { debugFactory } from './logger.js';
 import { convertDomain } from './lookup.js';
 import { settings, Settings } from './settings.js';
 import { RequestCache, CacheOptions } from './requestCache.js';
 import { DnsLookupError, Result } from './errors.js';
 
-const debug = debugModule('common.dnsLookup');
+const debug = debugFactory('common.dnsLookup');
 
 const requestCache = new RequestCache();
 

--- a/app/ts/common/history.ts
+++ b/app/ts/common/history.ts
@@ -3,9 +3,9 @@ import type { Database as DatabaseType } from 'better-sqlite3';
 import fs from 'fs';
 import path from 'path';
 import { getUserDataPath } from './settings.js';
-import debugModule from 'debug';
+import { debugFactory } from './logger.js';
 
-const debug = debugModule('common.history');
+const debug = debugFactory('common.history');
 
 let db: DatabaseType | undefined;
 

--- a/app/ts/common/lookup.ts
+++ b/app/ts/common/lookup.ts
@@ -2,12 +2,12 @@ import psl from 'psl';
 import { toASCII } from 'punycode/punycode.js';
 import uts46 from 'idna-uts46';
 import whois from 'whois';
-import debugModule from 'debug';
+import { debugFactory } from './logger.js';
 import { settings, Settings } from './settings.js';
 import { RequestCache, CacheOptions } from './requestCache.js';
 import { getProxy } from './proxy.js';
 
-const debug = debugModule('common.whoisWrapper');
+const debug = debugFactory('common.whoisWrapper');
 
 const requestCache = new RequestCache();
 

--- a/app/ts/common/requestCache.ts
+++ b/app/ts/common/requestCache.ts
@@ -3,9 +3,9 @@ import type { Database as DatabaseType } from 'better-sqlite3';
 import fs from 'fs';
 import path from 'path';
 import { settings, getUserDataPath } from './settings.js';
-import debugModule from 'debug';
+import { debugFactory } from './logger.js';
 
-const debug = debugModule('common.requestCache');
+const debug = debugFactory('common.requestCache');
 
 export interface CacheOptions {
   enabled?: boolean;

--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const baseDir = path.dirname(__filename);
-import debugModule from 'debug';
+import { debugFactory } from './common/logger.js';
 import { loadSettings, settings as store } from './main/settings-main.js';
 import type { Settings as BaseSettings } from './main/settings-main.js';
 import { formatString } from './common/stringformat.js';
@@ -16,8 +16,8 @@ import {
 } from '@electron/remote/main/index.js';
 import type { IpcMainEvent } from 'electron';
 
-const debug = debugModule('main');
-const debugb = debugModule('renderer');
+const debug = debugFactory('main');
+const debugb = debugFactory('renderer');
 
 const requestCache = new RequestCache();
 

--- a/app/ts/main/ai.ts
+++ b/app/ts/main/ai.ts
@@ -1,10 +1,10 @@
 import { ipcMain } from 'electron';
-import debugModule from 'debug';
+import { debugFactory } from '../common/logger.js';
 import { settings } from './settings-main.js';
 import { downloadModel } from '../ai/modelDownloader.js';
 import { suggestWords } from '../ai/openaiSuggest.js';
 
-const debug = debugModule('main.ai');
+const debug = debugFactory('main.ai');
 
 ipcMain.handle('ai:download-model', async () => {
   const url = settings.ai.modelURL;

--- a/app/ts/main/bulkwhois.ts
+++ b/app/ts/main/bulkwhois.ts
@@ -1,6 +1,6 @@
 import electron from 'electron';
-import debugModule from 'debug';
-const debug = debugModule('bulkwhois');
+import { debugFactory } from '../common/logger.js';
+const debug = debugFactory('bulkwhois');
 
 const { app, BrowserWindow, Menu, ipcMain, dialog, remote } = electron;
 

--- a/app/ts/main/bulkwhois/auxiliary.ts
+++ b/app/ts/main/bulkwhois/auxiliary.ts
@@ -1,8 +1,8 @@
-import debugModule from 'debug';
+import { debugFactory } from '../../common/logger.js';
 import type { IpcMainEvent } from 'electron';
 import { IpcChannel } from '../../common/ipcChannels.js';
 
-const debug = debugModule('bulkwhois.auxiliary');
+const debug = debugFactory('bulkwhois.auxiliary');
 
 /*
   resetUiCounters

--- a/app/ts/main/bulkwhois/export.ts
+++ b/app/ts/main/bulkwhois/export.ts
@@ -2,8 +2,8 @@ import electron from 'electron';
 import fs from 'fs';
 import path from 'path';
 import * as conversions from '../../common/conversions.js';
-import debugModule from 'debug';
-const debug = debugModule('bulkwhois.export');
+import { debugFactory } from '../../common/logger.js';
+const debug = debugFactory('bulkwhois.export');
 import JSZip from 'jszip';
 import { formatString } from '../../common/stringformat.js';
 

--- a/app/ts/main/bulkwhois/fileinput.ts
+++ b/app/ts/main/bulkwhois/fileinput.ts
@@ -1,6 +1,6 @@
 import electron from 'electron';
-import debugModule from 'debug';
-const debug = debugModule('bulkwhois.fileinput');
+import { debugFactory } from '../../common/logger.js';
+const debug = debugFactory('bulkwhois.fileinput');
 
 const { app, BrowserWindow, Menu, ipcMain, dialog } = electron;
 import { formatString } from '../../common/stringformat.js';

--- a/app/ts/main/bulkwhois/process.ts
+++ b/app/ts/main/bulkwhois/process.ts
@@ -1,7 +1,7 @@
 import electron from 'electron';
 import type { IpcMainInvokeEvent, IpcMainEvent } from 'electron';
-import debugModule from 'debug';
-const debug = debugModule('bulkwhois.process');
+import { debugFactory } from '../../common/logger.js';
+const debug = debugFactory('bulkwhois.process');
 import defaultBulkWhois from './process.defaults.js';
 
 import type { BulkWhois, DomainSetup } from './types.js';

--- a/app/ts/main/bulkwhois/queue.ts
+++ b/app/ts/main/bulkwhois/queue.ts
@@ -1,9 +1,9 @@
-import debugModule from 'debug';
+import { debugFactory } from '../../common/logger.js';
 import { formatString } from '../../common/stringformat.js';
 import type { Settings } from '../settings-main.js';
 import type { DomainSetup } from './types.js';
 
-const debug = debugModule('bulkwhois.queue');
+const debug = debugFactory('bulkwhois.queue');
 
 function randomWithin(min: number, max: number): number {
   if (min > max) {

--- a/app/ts/main/bulkwhois/resultHandler.ts
+++ b/app/ts/main/bulkwhois/resultHandler.ts
@@ -1,4 +1,4 @@
-import debugModule from 'debug';
+import { debugFactory } from '../../common/logger.js';
 import { isDomainAvailable, getDomainParameters } from '../../common/availability.js';
 import { toJSON } from '../../common/parser.js';
 import { performance } from 'perf_hooks';
@@ -11,7 +11,7 @@ import type { IpcMainEvent } from 'electron';
 import { addEntry as addHistoryEntry } from '../../common/history.js';
 import { IpcChannel } from '../../common/ipcChannels.js';
 
-const debug = debugModule('bulkwhois.resultHandler');
+const debug = debugFactory('bulkwhois.resultHandler');
 
 export async function processData(
   bulkWhois: BulkWhois,

--- a/app/ts/main/bulkwhois/scheduler.ts
+++ b/app/ts/main/bulkwhois/scheduler.ts
@@ -1,4 +1,4 @@
-import debugModule from 'debug';
+import { debugFactory } from '../../common/logger.js';
 import { performance } from 'perf_hooks';
 import { lookup as whoisLookup } from '../../common/lookup.js';
 import * as dns from '../../common/dnsLookup.js';
@@ -11,7 +11,7 @@ import { processData } from './resultHandler.js';
 import type { IpcMainEvent } from 'electron';
 import { IpcChannel } from '../../common/ipcChannels.js';
 
-const debug = debugModule('bulkwhois.scheduler');
+const debug = debugFactory('bulkwhois.scheduler');
 
 export function processDomain(
   bulkWhois: BulkWhois,

--- a/app/ts/main/bulkwhois/wordlistinput.ts
+++ b/app/ts/main/bulkwhois/wordlistinput.ts
@@ -1,6 +1,6 @@
 import electron from 'electron';
-import debugModule from 'debug';
-const debug = debugModule('bulkwhois.wordlistinput');
+import { debugFactory } from '../../common/logger.js';
+const debug = debugFactory('bulkwhois.wordlistinput');
 
 const { app, BrowserWindow, Menu, ipcMain, dialog, remote } = electron;
 import { IpcChannel } from '../../common/ipcChannels.js';

--- a/app/ts/main/bwa/analyser.ts
+++ b/app/ts/main/bwa/analyser.ts
@@ -1,6 +1,6 @@
 import electron from 'electron';
-import debugModule from 'debug';
-const debug = debugModule('main.bwa.analyser');
+import { debugFactory } from '../../common/logger.js';
+const debug = debugFactory('main.bwa.analyser');
 
 const { app, BrowserWindow, Menu, ipcMain, dialog } = electron;
 import { IpcChannel } from '../../common/ipcChannels.js';

--- a/app/ts/main/bwa/fileinput.ts
+++ b/app/ts/main/bwa/fileinput.ts
@@ -1,6 +1,6 @@
 import electron from 'electron';
-import debugModule from 'debug';
-const debug = debugModule('main.bwa.fileinput');
+import { debugFactory } from '../../common/logger.js';
+const debug = debugFactory('main.bwa.fileinput');
 
 const { app, BrowserWindow, Menu, ipcMain, dialog } = electron;
 import { formatString } from '../../common/stringformat.js';

--- a/app/ts/main/cache.ts
+++ b/app/ts/main/cache.ts
@@ -1,8 +1,8 @@
 import { ipcMain } from 'electron';
-import debugModule from 'debug';
+import { debugFactory } from '../common/logger.js';
 import { RequestCache } from '../common/requestCache.js';
 
-const debug = debugModule('main.cache');
+const debug = debugFactory('main.cache');
 
 const requestCache = new RequestCache();
 

--- a/app/ts/main/history.ts
+++ b/app/ts/main/history.ts
@@ -1,8 +1,8 @@
 import { ipcMain } from 'electron';
-import debugModule from 'debug';
+import { debugFactory } from '../common/logger.js';
 import { getHistory, clearHistory } from '../common/history.js';
 
-const debug = debugModule('main.history');
+const debug = debugFactory('main.history');
 
 ipcMain.handle('history:get', () => {
   const entries = getHistory();

--- a/app/ts/main/singlewhois.ts
+++ b/app/ts/main/singlewhois.ts
@@ -5,8 +5,8 @@ import * as url from 'url';
 import { lookup as whoisLookup } from '../common/lookup.js';
 import { isDomainAvailable } from '../common/availability.js';
 import { addEntry as addHistoryEntry } from '../common/history.js';
-import debugModule from 'debug';
-const debug = debugModule('main.singlewhois');
+import { debugFactory } from '../common/logger.js';
+const debug = debugFactory('main.singlewhois');
 
 const { app, Menu, ipcMain, dialog, remote, clipboard, shell } = electron;
 import { formatString } from '../common/stringformat.js';

--- a/app/ts/main/to.ts
+++ b/app/ts/main/to.ts
@@ -1,11 +1,11 @@
 import electron from 'electron';
 import fs from 'fs';
-import debugModule from 'debug';
+import { debugFactory } from '../common/logger.js';
 import { processLines, ProcessOptions } from '../common/tools.js';
 import { IpcChannel } from '../common/ipcChannels.js';
 
 const { ipcMain, dialog } = electron;
-const debug = debugModule('main.to');
+const debug = debugFactory('main.to');
 
 /*
   ipcMain.on('to:input.file', function(event) {...});

--- a/app/ts/server/index.ts
+++ b/app/ts/server/index.ts
@@ -1,9 +1,9 @@
 import express, { Request, Response } from 'express';
 import { lookup } from '../common/lookup.js';
 import { lookupDomains, CliOptions } from '../cli.js';
-import debugModule from 'debug';
+import { debugFactory } from '../common/logger.js';
 
-const debug = debugModule('server');
+const debug = debugFactory('server');
 
 export function createServer() {
   const app = express();

--- a/scripts/logger.js
+++ b/scripts/logger.js
@@ -1,0 +1,13 @@
+export function debugFactory(namespace) {
+  return (...args) => {
+    const message = `[${namespace}] ${args.map(String).join(' ')}`;
+    console.debug(message);
+  };
+}
+
+export function errorFactory(namespace) {
+  return (...args) => {
+    const message = `[${namespace}] ${args.map(String).join(' ')}`;
+    console.error(message);
+  };
+}

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -3,14 +3,14 @@ import path from 'path';
 import { spawnSync } from 'child_process';
 import { copyRecursiveSync } from './copyRecursive.js';
 import { precompileTemplates } from './precompileTemplates.js';
-import debugModule from 'debug';
+import { debugFactory } from './logger.js';
 import { dirnameCompat } from './dirnameCompat.js';
 import { fileURLToPath, pathToFileURL } from 'url';
 import Handlebars from 'handlebars/runtime.js';
 import './create-esm-links.js';
 
 const baseDir = dirnameCompat();
-const debug = debugModule('postbuild');
+const debug = debugFactory('postbuild');
 
 const folders = [
   'html',

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -2,13 +2,13 @@ import fs from 'fs';
 import path from 'path';
 import { spawnSync } from 'child_process';
 import { createRequire } from 'module';
-import debugModule from 'debug';
+import { debugFactory } from './logger.js';
 import { precompileTemplates } from './precompileTemplates.js';
 import { dirnameCompat } from './dirnameCompat.js';
 import { regenerateVendor } from './regenerateVendor.mjs';
 
 const baseDir = dirnameCompat();
-const debug = debugModule('prebuild');
+const debug = debugFactory('prebuild');
 
 const rootDir = path.join(baseDir, '..');
 const modulesPath = path.join(rootDir, 'node_modules');

--- a/scripts/watch-assets.js
+++ b/scripts/watch-assets.js
@@ -3,10 +3,10 @@ import path from 'path';
 import watchboy from 'watchboy';
 import { copyRecursiveSync } from './copyRecursive.js';
 import { precompileTemplates } from './precompileTemplates.js';
-import debugModule from 'debug';
+import { debugFactory } from './logger.js';
 
 const rootDir = process.cwd();
-const debug = debugModule('watch-assets');
+const debug = debugFactory('watch-assets');
 
 const folders = [
   'html',

--- a/test/e2e/run.js
+++ b/test/e2e/run.js
@@ -5,12 +5,12 @@ import assert from 'assert';
 import { spawn } from 'child_process';
 import net from 'net';
 import { remote } from 'webdriverio';
-import debugModule from 'debug';
+import { debugFactory } from '../../scripts/logger.js';
 import { dirnameCompat } from '../../scripts/dirnameCompat.js';
 import electron from 'electron';
 
 const baseDir = dirnameCompat();
-const debug = debugModule('test:e2e');
+const debug = debugFactory('test:e2e');
 
 (async () => {
   const electronPath = electron;


### PR DESCRIPTION
## Summary
- introduce shared `scripts/logger.js`
- replace `debugModule` uses with `debugFactory`
- remove unused `debug` imports

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Module did not self-register)*
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686adc7edd308325b2062a87aef82781