### PR TITLE
refactor: clean unused electron imports

### DIFF
--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Menu, ipcMain, dialog } from 'electron';
+import { app, BrowserWindow, ipcMain, dialog } from 'electron';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 

--- a/app/ts/main/bulkwhois.ts
+++ b/app/ts/main/bulkwhois.ts
@@ -1,9 +1,3 @@
-import electron from 'electron';
-import { debugFactory } from '../common/logger.js';
-const debug = debugFactory('bulkwhois');
-
-const { app, BrowserWindow, Menu, ipcMain, dialog, remote } = electron;
-
 import './bulkwhois/fileinput.js'; // File input
 import './bulkwhois/wordlistinput.js'; // Wordlist input
 import './bulkwhois/process.js'; // Process stage

--- a/app/ts/main/bulkwhois/export.ts
+++ b/app/ts/main/bulkwhois/export.ts
@@ -1,13 +1,10 @@
-import electron from 'electron';
+import { ipcMain, dialog, shell } from 'electron';
 import fs from 'fs';
-import path from 'path';
 import * as conversions from '../../common/conversions.js';
 import { debugFactory } from '../../common/logger.js';
 const debug = debugFactory('bulkwhois.export');
 import JSZip from 'jszip';
 import { formatString } from '../../common/stringformat.js';
-
-const { app, BrowserWindow, Menu, ipcMain, dialog, remote, shell } = electron;
 
 import { getSettings } from '../settings-main.js';
 import { generateFilename } from '../../cli/export.js';

--- a/app/ts/main/bulkwhois/fileinput.ts
+++ b/app/ts/main/bulkwhois/fileinput.ts
@@ -1,8 +1,6 @@
-import electron from 'electron';
+import { ipcMain, dialog } from 'electron';
 import { debugFactory } from '../../common/logger.js';
 const debug = debugFactory('bulkwhois.fileinput');
-
-const { app, BrowserWindow, Menu, ipcMain, dialog } = electron;
 import { formatString } from '../../common/stringformat.js';
 import { IpcChannel } from '../../common/ipcChannels.js';
 

--- a/app/ts/main/bulkwhois/process.ts
+++ b/app/ts/main/bulkwhois/process.ts
@@ -1,4 +1,4 @@
-import electron from 'electron';
+import { ipcMain } from 'electron';
 import type { IpcMainInvokeEvent, IpcMainEvent } from 'electron';
 import { debugFactory } from '../../common/logger.js';
 const debug = debugFactory('bulkwhois.process');
@@ -11,8 +11,6 @@ import { resetObject } from '../../common/resetObject.js';
 import { resetUiCounters } from './auxiliary.js';
 
 import { getSettings } from '../settings-main.js';
-
-const { app, BrowserWindow, Menu, ipcMain, dialog, remote } = electron;
 import { formatString } from '../../common/stringformat.js';
 import { IpcChannel } from '../../common/ipcChannels.js';
 

--- a/app/ts/main/bulkwhois/wordlistinput.ts
+++ b/app/ts/main/bulkwhois/wordlistinput.ts
@@ -1,8 +1,6 @@
-import electron from 'electron';
+import { ipcMain } from 'electron';
 import { debugFactory } from '../../common/logger.js';
 const debug = debugFactory('bulkwhois.wordlistinput');
-
-const { app, BrowserWindow, Menu, ipcMain, dialog, remote } = electron;
 import { IpcChannel } from '../../common/ipcChannels.js';
 
 /*

--- a/app/ts/main/bwa/analyser.ts
+++ b/app/ts/main/bwa/analyser.ts
@@ -1,8 +1,6 @@
-import electron from 'electron';
+import { ipcMain } from 'electron';
 import { debugFactory } from '../../common/logger.js';
 const debug = debugFactory('main.bwa.analyser');
-
-const { app, BrowserWindow, Menu, ipcMain, dialog } = electron;
 import { IpcChannel } from '../../common/ipcChannels.js';
 
 /*

--- a/app/ts/main/bwa/fileinput.ts
+++ b/app/ts/main/bwa/fileinput.ts
@@ -1,8 +1,6 @@
-import electron from 'electron';
+import { ipcMain, dialog } from 'electron';
 import { debugFactory } from '../../common/logger.js';
 const debug = debugFactory('main.bwa.fileinput');
-
-const { app, BrowserWindow, Menu, ipcMain, dialog } = electron;
 import { formatString } from '../../common/stringformat.js';
 import { IpcChannel } from '../../common/ipcChannels.js';
 

--- a/app/ts/main/singlewhois.ts
+++ b/app/ts/main/singlewhois.ts
@@ -1,14 +1,10 @@
-import electron from 'electron';
+import { ipcMain, clipboard, shell } from 'electron';
 import type { IpcMainEvent } from 'electron';
-import * as path from 'path';
-import * as url from 'url';
 import { lookup as whoisLookup } from '../common/lookup.js';
 import { isDomainAvailable } from '../common/availability.js';
 import { addEntry as addHistoryEntry } from '../common/history.js';
 import { debugFactory } from '../common/logger.js';
 const debug = debugFactory('main.singlewhois');
-
-const { app, Menu, ipcMain, dialog, remote, clipboard, shell } = electron;
 import { formatString } from '../common/stringformat.js';
 
 import { settings } from './settings-main.js';

--- a/app/ts/main/to.ts
+++ b/app/ts/main/to.ts
@@ -1,10 +1,8 @@
-import electron from 'electron';
+import { ipcMain, dialog } from 'electron';
 import fs from 'fs';
 import { debugFactory } from '../common/logger.js';
 import { processLines, ProcessOptions } from '../common/tools.js';
 import { IpcChannel } from '../common/ipcChannels.js';
-
-const { ipcMain, dialog } = electron;
 const debug = debugFactory('main.to');
 
 /*


### PR DESCRIPTION
## Summary
- remove unused destructured imports from Electron main process files
- switch to named imports
- drop unused `Menu`, `app` and `remote` variables

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Module compiled against different Node.js version)*
- `npm run test:e2e` *(fails: WebDriverError session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686ae1a4f25c832582d48824c3af131d