### PR TITLE
fix: validate CLI arguments

### DIFF
--- a/app/ts/cli.ts
+++ b/app/ts/cli.ts
@@ -44,6 +44,25 @@ export function parseArgs(argv: string[]): CliOptions {
     .option('download-model', { type: 'boolean' })
     .option('suggest', { type: 'string' })
     .option('suggest-count', { type: 'number', default: 5 })
+    .check((args) => {
+      if (
+        !args.domain &&
+        !args.wordlist &&
+        !args.suggest &&
+        !args['download-model'] &&
+        !args['purge-cache'] &&
+        !args['clear-cache']
+      ) {
+        throw new Error('Either --domain or --wordlist must be provided');
+      }
+      if (
+        args['suggest-count'] !== undefined &&
+        (!Number.isInteger(args['suggest-count']) || args['suggest-count'] <= 0)
+      ) {
+        throw new Error('--suggest-count must be a positive integer');
+      }
+      return true;
+    })
     .parseSync();
   return {
     domains: args.domain ?? [],

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -69,4 +69,14 @@ describe('cli utility', () => {
     expect(content).toContain('example.com');
     fs.unlinkSync(file);
   });
+
+  test('parseArgs requires domain or wordlist', () => {
+    expect(() => parseArgs([])).toThrow('Either --domain or --wordlist must be provided');
+  });
+
+  test('parseArgs validates suggest-count', () => {
+    expect(() => parseArgs(['--suggest', 'idea', '--suggest-count', '0'])).toThrow(
+      'positive integer'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- enforce required `--domain` or `--wordlist` in CLI unless using other commands
- validate that `--suggest-count` is a positive integer
- test new validations

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: better-sqlite3 binary mismatch)*
- `npm run test:e2e` *(fails: webdriver session error)*

------
https://chatgpt.com/codex/tasks/task_e_686b426286e48325a20b8798a1cc2f51