### PR TITLE
Fix Handlebars partial registration

### DIFF
--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -89,8 +89,8 @@ for (const file of fs.readdirSync(partialDir)) {
   if (file === 'mainPanel.js' || !file.endsWith('.js')) continue;
   const specPath = path.join(partialDir, file);
   const spec = (await import(pathToFileURL(specPath).href)).default;
-  const alias = path.basename(file, '.js').replace('bulkwhois', 'bw');
-  Handlebars.registerPartial(alias, Handlebars.template(spec));
+  const partialName = path.basename(file, '.js');
+  Handlebars.registerPartial(partialName, Handlebars.template(spec));
 }
 
 const mainSpecPath = path.join(partialDir, 'mainPanel.js');


### PR DESCRIPTION
## Summary
- register bulkwhois partials with their original names in postbuild script

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: better-sqlite3 binary mismatch)*
- `npm run test:e2e` *(fails: WebDriverError: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686c0d5d9dc88325afc7eb054b8f9ec9