### PR TITLE
fix: remove await from performance.now

### DIFF
--- a/app/ts/main/bulkwhois/scheduler.ts
+++ b/app/ts/main/bulkwhois/scheduler.ts
@@ -40,7 +40,7 @@ export function processDomain(
     stats.domains.waiting++;
     sender.send(IpcChannel.BulkwhoisStatusUpdate, 'domains.waiting', stats.domains.waiting);
 
-    reqtime[domainSetup.index!] = await performance.now();
+    reqtime[domainSetup.index!] = performance.now();
 
     debug(formatString('Looking up domain: {0}', domainSetup.domain));
 


### PR DESCRIPTION
## Summary
- remove redundant `await` when capturing request time

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: better-sqlite3 module version mismatch)*
- `npm run test:e2e` *(fails to create WebDriver session)*

------
https://chatgpt.com/codex/tasks/task_e_686d4e0ac858832598fdac34a65e4f73