### PR TITLE
Refactor random int helper

### DIFF
--- a/app/ts/cli/export.ts
+++ b/app/ts/cli/export.ts
@@ -1,3 +1,5 @@
+import { randomInt } from '../utils/random.js';
+
 export function generateFilename(ext: string): string {
   function pad(n: number): string {
     return String(n).padStart(2, '0');
@@ -10,8 +12,6 @@ export function generateFilename(ext: string): string {
     pad(d.getHours()) +
     pad(d.getMinutes()) +
     pad(d.getSeconds());
-  const hex = Math.floor(Math.random() * 0xffffff)
-    .toString(16)
-    .padStart(6, '0');
+  const hex = randomInt(0, 0xffffff).toString(16).padStart(6, '0');
   return `bulkwhois-export-${datetime}-${hex}${ext}`;
 }

--- a/app/ts/common/lookup.ts
+++ b/app/ts/common/lookup.ts
@@ -6,6 +6,7 @@ import { debugFactory } from './logger.js';
 import { settings, Settings } from './settings.js';
 import { RequestCache, CacheOptions } from './requestCache.js';
 import { getProxy } from './proxy.js';
+import { randomInt } from '../utils/random.js';
 
 const debug = debugFactory('common.whoisWrapper');
 
@@ -110,30 +111,23 @@ function getWhoisParameters(parameter: string): number | undefined {
         `Follow depth, 'random': ${follow.randomize}, 'maximum': ${follow.maximumDepth}, 'minimum': ${follow.minimumDepth}, 'default': ${general.follow}`
       );
       return follow.randomize
-        ? getRandomInt(follow.minimumDepth, follow.maximumDepth)
+        ? randomInt(follow.minimumDepth, follow.maximumDepth)
         : general.follow;
     case 'timeout':
       debug(
         `Timeout, 'random': ${timeout.randomize}, 'maximum': ${timeout.maximum}, 'minimum': ${timeout.minimum}, 'default': ${general.timeout}`
       );
-      return timeout.randomize ? getRandomInt(timeout.minimum, timeout.maximum) : general.timeout;
+      return timeout.randomize ? randomInt(timeout.minimum, timeout.maximum) : general.timeout;
     case 'timebetween':
       debug(
         `Timebetween, 'random': ${timeBetween.randomize}, 'maximum': ${timeBetween.maximum}, 'minimum': ${timeBetween.minimum}, 'default': ${general.timeBetween}`
       );
       return timeBetween.randomize
-        ? getRandomInt(timeBetween.minimum, timeBetween.maximum)
+        ? randomInt(timeBetween.minimum, timeBetween.maximum)
         : general.timeBetween;
     default:
       return undefined;
   }
-}
-
-function getRandomInt(min: number, max: number): number {
-  min = Math.floor(min);
-  max = Math.floor(max);
-  if (min > max) [min, max] = [max, min];
-  return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
 export default {

--- a/app/ts/common/proxy.ts
+++ b/app/ts/common/proxy.ts
@@ -1,5 +1,6 @@
 import { settings } from './settings.js';
 import { isIP } from 'net';
+import { randomInt } from '../utils/random.js';
 
 export interface ProxyInfo {
   ipaddress: string;
@@ -33,7 +34,7 @@ export function getProxy(): ProxyInfo | undefined {
   let entry: string;
   switch (proxy.multimode) {
     case 'random':
-      entry = list[Math.floor(Math.random() * list.length)];
+      entry = list[randomInt(0, list.length - 1)];
       break;
     case 'ascending':
       index = (index + 1) % list.length;

--- a/app/ts/common/wordlist.ts
+++ b/app/ts/common/wordlist.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from 'fs';
+import { randomInt } from '../utils/random.js';
 
 export async function concatFiles(...files: string[]): Promise<string[]> {
   const lines: string[] = [];
@@ -84,7 +85,7 @@ export function sortLinesReverse(lines: string[]): string[] {
 export function shuffleLines(lines: string[]): string[] {
   const arr = [...lines];
   for (let i = arr.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
+    const j = randomInt(0, i);
     [arr[i], arr[j]] = [arr[j], arr[i]];
   }
   return arr;

--- a/app/ts/main/bulkwhois/queue.ts
+++ b/app/ts/main/bulkwhois/queue.ts
@@ -1,16 +1,10 @@
 import { debugFactory } from '../../common/logger.js';
 import { formatString } from '../../common/stringformat.js';
+import { randomInt } from '../../utils/random.js';
 import type { Settings } from '../settings-main.js';
 import type { DomainSetup } from './types.js';
 
 const debug = debugFactory('bulkwhois.queue');
-
-function randomWithin(min: number, max: number): number {
-  if (min > max) {
-    [min, max] = [max, min];
-  }
-  return Math.floor(Math.random() * (max - min + 1)) + min;
-}
 
 export function compileQueue(domains: string[], tlds: string[], separator: string): string[] {
   const queue: string[] = [];
@@ -58,22 +52,19 @@ export function getDomainSetup(
 
   return {
     timebetween: isRandom.timeBetween
-      ? randomWithin(
+      ? randomInt(
           settings.lookupRandomizeTimeBetween.minimum,
           settings.lookupRandomizeTimeBetween.maximum
         )
       : settings.lookupGeneral.timeBetween,
     follow: isRandom.followDepth
-      ? randomWithin(
+      ? randomInt(
           settings.lookupRandomizeFollow.minimumDepth,
           settings.lookupRandomizeFollow.maximumDepth
         )
       : settings.lookupGeneral.follow,
     timeout: isRandom.timeout
-      ? randomWithin(
-          settings.lookupRandomizeTimeout.minimum,
-          settings.lookupRandomizeTimeout.maximum
-        )
+      ? randomInt(settings.lookupRandomizeTimeout.minimum, settings.lookupRandomizeTimeout.maximum)
       : settings.lookupGeneral.timeout
   };
 }

--- a/app/ts/utils/random.ts
+++ b/app/ts/utils/random.ts
@@ -1,0 +1,8 @@
+export function randomInt(min: number, max: number): number {
+  min = Math.floor(min);
+  max = Math.floor(max);
+  if (min > max) [min, max] = [max, min];
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+export default { randomInt };


### PR DESCRIPTION
## Summary
- add utility for generating random ints
- use `randomInt()` across project instead of inline helpers

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: better_sqlite3 module mismatch)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686d6e3132d88325b3914c249ecfbe87