### PR TITLE
refactor: update bulkwhois lookup event type

### DIFF
--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -28,7 +28,7 @@ declare module 'electron' {
   }
   export const Menu: any;
   export interface IpcMainEvent {}
-  export interface IpcMainInvokeEvent {}
+  export interface IpcMainInvokeEvent extends IpcMainEvent {}
   export interface IpcRendererEvent {}
 
   interface RendererToMainIpc {
@@ -71,7 +71,7 @@ declare module 'electron' {
     ): void;
     handle<C extends keyof RendererToMainIpc>(
       channel: C,
-      listener: (event: IpcMainInvokeEvent, ...args: RendererToMainIpc[C]) => any
+      listener: (event: IpcMainEvent, ...args: RendererToMainIpc[C]) => any
     ): void;
   }
 


### PR DESCRIPTION
## Summary
- update bulkwhois lookup handler to receive `IpcMainEvent`
- remove cast inside handler
- adjust custom electron typings to use `IpcMainEvent`

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: better-sqlite3 native module mismatch)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686d6cf3ba5083258f080bcfde23014f