### PR TITLE
Refactor bulkwhois setup helpers

### DIFF
--- a/app/ts/main/bulkwhois/helpers.ts
+++ b/app/ts/main/bulkwhois/helpers.ts
@@ -1,0 +1,52 @@
+import type { WebContents } from 'electron';
+import { IpcChannel } from '../../common/ipcChannels.js';
+import type { BulkWhois, BulkWhoisStats, DomainSetup } from './types.js';
+import { compileQueue, getDomainSetup } from './queue.js';
+import type { Settings } from '../settings-main.js';
+
+export function compileDomains(
+  bulk: BulkWhois,
+  domains: string[],
+  tlds: string[],
+  sender: WebContents
+): void {
+  const { input, stats } = bulk;
+  input.domains = domains;
+  input.tlds = tlds;
+  stats.domains.total = domains.length * tlds.length;
+  sender.send(IpcChannel.BulkwhoisStatusUpdate, 'domains.total', stats.domains.total);
+  input.domainsPending.push(...compileQueue(domains, tlds, input.tldSeparator));
+}
+
+export function createDomainSetup(settings: Settings, domain: string, index: number): DomainSetup {
+  const setup = getDomainSetup(settings, {
+    timeBetween: settings.lookupRandomizeTimeBetween.randomize,
+    followDepth: settings.lookupRandomizeFollow.randomize,
+    timeout: settings.lookupRandomizeTimeout.randomize
+  });
+  setup.timebetween =
+    settings.lookupGeneral.type === 'dns' && settings.lookupGeneral.dnsTimeBetweenOverride
+      ? settings.lookupGeneral.dnsTimeBetween
+      : setup.timebetween;
+  setup.domain = domain;
+  setup.index = index;
+  return setup;
+}
+
+export function updateProgress(
+  sender: WebContents,
+  stats: BulkWhoisStats,
+  processed: number
+): void {
+  stats.domains.processed = processed;
+  sender.send(IpcChannel.BulkwhoisStatusUpdate, 'domains.processed', stats.domains.processed);
+}
+
+export function setRemainingCounter(settings: Settings, stats: BulkWhoisStats): void {
+  stats.time.remainingcounter = settings.lookupRandomizeTimeBetween.randomize
+    ? stats.domains.total * settings.lookupRandomizeTimeBetween.maximum
+    : stats.domains.total * settings.lookupGeneral.timeBetween;
+  stats.time.remainingcounter += settings.lookupRandomizeTimeout.randomize
+    ? settings.lookupRandomizeTimeout.maximum
+    : settings.lookupGeneral.timeout;
+}

--- a/test/processHelpers.test.ts
+++ b/test/processHelpers.test.ts
@@ -1,0 +1,67 @@
+import defaultBulkWhois from '../app/ts/main/bulkwhois/process.defaults';
+import {
+  compileDomains,
+  createDomainSetup,
+  updateProgress,
+  setRemainingCounter
+} from '../app/ts/main/bulkwhois/helpers';
+import { settings } from '../app/ts/main/settings-main';
+import { IpcChannel } from '../app/ts/common/ipcChannels';
+
+describe('process helpers', () => {
+  test('compileDomains populates queue and totals', () => {
+    const bulk = JSON.parse(JSON.stringify(defaultBulkWhois));
+    const sender = { send: jest.fn() } as any;
+    compileDomains(bulk, ['foo'], ['com'], sender);
+    expect(bulk.input.domains).toEqual(['foo']);
+    expect(bulk.input.tlds).toEqual(['com']);
+    expect(bulk.stats.domains.total).toBe(1);
+    expect(bulk.input.domainsPending).toEqual(['foo.' + 'com']);
+    expect(sender.send).toHaveBeenCalledWith(IpcChannel.BulkwhoisStatusUpdate, 'domains.total', 1);
+  });
+
+  test('createDomainSetup returns static settings', () => {
+    const backup = JSON.parse(JSON.stringify(settings));
+    settings.lookupGeneral.timeBetween = 10;
+    settings.lookupGeneral.follow = 1;
+    settings.lookupGeneral.timeout = 100;
+    settings.lookupGeneral.type = 'whois';
+    settings.lookupRandomizeTimeBetween.randomize = false;
+    settings.lookupRandomizeFollow.randomize = false;
+    settings.lookupRandomizeTimeout.randomize = false;
+    const setup = createDomainSetup(settings, 'foo.com', 0);
+    expect(setup).toEqual({
+      domain: 'foo.com',
+      index: 0,
+      timebetween: 10,
+      follow: 1,
+      timeout: 100
+    });
+    Object.assign(settings, backup);
+  });
+
+  test('updateProgress updates stats and sends', () => {
+    const bulk = JSON.parse(JSON.stringify(defaultBulkWhois));
+    const sender = { send: jest.fn() } as any;
+    updateProgress(sender, bulk.stats, 5);
+    expect(bulk.stats.domains.processed).toBe(5);
+    expect(sender.send).toHaveBeenCalledWith(
+      IpcChannel.BulkwhoisStatusUpdate,
+      'domains.processed',
+      5
+    );
+  });
+
+  test('setRemainingCounter uses defaults', () => {
+    const backup = JSON.parse(JSON.stringify(settings));
+    const bulk = JSON.parse(JSON.stringify(defaultBulkWhois));
+    bulk.stats.domains.total = 2;
+    settings.lookupGeneral.timeBetween = 5;
+    settings.lookupRandomizeTimeBetween.randomize = false;
+    settings.lookupGeneral.timeout = 1;
+    settings.lookupRandomizeTimeout.randomize = false;
+    setRemainingCounter(settings, bulk.stats);
+    expect(bulk.stats.time.remainingcounter).toBe(2 * 5 + 1);
+    Object.assign(settings, backup);
+  });
+});


### PR DESCRIPTION
## Summary
- add helper utilities for compiling domains and updating progress
- refactor BulkwhoisLookup handler to use new helpers
- expose helpers for unit testing
- add corresponding unit tests

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: The module '/workspace/whoisdigger/node_modules/better-sqlite3/build/Release/better_sqlite3.node' was compiled against a different Node.js version)*
- `npm run test:e2e` *(fails: WebDriverError: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686da9c639c0832590680d9afe33e5de