### PR TITLE
fix: store bulk whois timings as numbers

### DIFF
--- a/app/ts/main/bulkwhois/resultHandler.ts
+++ b/app/ts/main/bulkwhois/resultHandler.ts
@@ -36,28 +36,32 @@ export async function processData(
     reqtimes.minimum = reqtime[index];
     sender.send(IpcChannel.BulkwhoisStatusUpdate, 'reqtimes.minimum', reqtimes.minimum);
   }
-  if (Number(reqtimes.maximum) < reqtime[index]) {
-    reqtimes.maximum = reqtime[index].toFixed(2);
+  if (reqtimes.maximum === null || reqtimes.maximum < reqtime[index]) {
+    reqtimes.maximum = parseFloat(reqtime[index].toFixed(2));
     sender.send(IpcChannel.BulkwhoisStatusUpdate, 'reqtimes.maximum', reqtimes.maximum);
   }
 
-  reqtimes.last = reqtime[index].toFixed(2);
+  reqtimes.last = parseFloat(reqtime[index].toFixed(2));
   sender.send(IpcChannel.BulkwhoisStatusUpdate, 'reqtimes.last', reqtimes.last);
 
   if (settings.lookupMisc.asfOverride) {
     lastweight = Number(
       ((stats.domains.sent - stats.domains.waiting) / stats.domains.processed).toFixed(2)
     );
-    reqtimes.average = (
-      Number(reqtimes.average) * lastweight +
-      (1 - lastweight) * reqtime[index]
-    ).toFixed(2);
+    reqtimes.average = parseFloat(
+      (
+        (reqtimes.average ?? reqtime[index]) * lastweight +
+        (1 - lastweight) * reqtime[index]
+      ).toFixed(2)
+    );
   } else {
-    reqtimes.average = reqtimes.average || reqtime[index].toFixed(2);
-    reqtimes.average = (
-      reqtime[index] * settings.lookupMisc.averageSmoothingFactor +
-      (1 - settings.lookupMisc.averageSmoothingFactor) * Number(reqtimes.average)
-    ).toFixed(2);
+    reqtimes.average = reqtimes.average ?? reqtime[index];
+    reqtimes.average = parseFloat(
+      (
+        reqtime[index] * settings.lookupMisc.averageSmoothingFactor +
+        (1 - settings.lookupMisc.averageSmoothingFactor) * reqtimes.average
+      ).toFixed(2)
+    );
   }
 
   if (isError) {

--- a/app/ts/main/bulkwhois/types.ts
+++ b/app/ts/main/bulkwhois/types.ts
@@ -21,9 +21,9 @@ export interface BulkWhoisStats {
   };
   reqtimes: {
     minimum: number;
-    average: string | null;
-    maximum: string | null;
-    last: string | null;
+    average: number | null;
+    maximum: number | null;
+    last: number | null;
   };
   status: {
     available: number;

--- a/app/ts/renderer/bulkwhois/process.ts
+++ b/app/ts/renderer/bulkwhois/process.ts
@@ -98,16 +98,24 @@ electron.on(IpcChannel.BulkwhoisStatusUpdate, function (event, stat, value) {
       $('#bwProcessingSpanTimeremaining').text(formatString('{0}', value));
       break;
     case 'reqtimes.maximum': // maximum request reply time
-      $('#bwProcessingSpanReqtimemax').text(formatString('{0}ms', value));
+      $('#bwProcessingSpanReqtimemax').text(
+        formatString('{0}ms', typeof value === 'number' ? value.toFixed(2) : value)
+      );
       break;
     case 'reqtimes.minimum': // minimum request reply time
-      $('#bwProcessingSpanReqtimemin').text(formatString('{0}ms', value));
+      $('#bwProcessingSpanReqtimemin').text(
+        formatString('{0}ms', typeof value === 'number' ? value.toFixed(2) : value)
+      );
       break;
     case 'reqtimes.last': // last request reply time
-      $('#bwProcessingSpanReqtimelast').text(formatString('{0}ms', value));
+      $('#bwProcessingSpanReqtimelast').text(
+        formatString('{0}ms', typeof value === 'number' ? value.toFixed(2) : value)
+      );
       break;
     case 'reqtimes.average': // Average request reply time
-      $('#bwProcessingSpanReqtimeavg').text(formatString('{0}ms', value));
+      $('#bwProcessingSpanReqtimeavg').text(
+        formatString('{0}ms', typeof value === 'number' ? value.toFixed(2) : value)
+      );
       break;
     case 'status.available': // Domains available
       percent =

--- a/test/resultHandler.test.ts
+++ b/test/resultHandler.test.ts
@@ -59,9 +59,9 @@ describe('processData', () => {
     await processData(bulk, reqtime, event, 'example.com', 0, 'data', false);
 
     expect(bulk.stats.reqtimes.minimum).toBe(50);
-    expect(bulk.stats.reqtimes.maximum).toBe('50.00');
-    expect(bulk.stats.reqtimes.last).toBe('50.00');
-    expect(bulk.stats.reqtimes.average).toBe('50.00');
+    expect(bulk.stats.reqtimes.maximum).toBe(50);
+    expect(bulk.stats.reqtimes.last).toBe(50);
+    expect(bulk.stats.reqtimes.average).toBe(50);
     expect(bulk.stats.status.available).toBe(1);
     expect(bulk.stats.domains.waiting).toBe(0);
     expect(bulk.results.domain[0]).toBe('example.com');


### PR DESCRIPTION
## Summary
- keep bulk whois request timing stats numeric
- update renderer to format numbers when displaying
- adjust result handler calculations
- update tests for numeric request time values

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Module did not self-register '/workspace/whoisdigger/node_modules/better-sqlite3/build/Release/better_sqlite3.node')*
- `npm run test:e2e` *(fails: WebDriverError: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686e57ae8a8c83258185b075f5429803