### PR TITLE
feat: centralize renderer file watchers

### DIFF
--- a/app/ts/utils/fileWatcher.ts
+++ b/app/ts/utils/fileWatcher.ts
@@ -1,0 +1,23 @@
+export type WatchFn = (
+  prefix: string,
+  path: string,
+  opts: any,
+  cb: (evt: string) => void
+) => Promise<{ close: () => void }>;
+
+export class FileWatcherManager {
+  private watcher: { close: () => void } | undefined;
+  constructor(private readonly watchFn: WatchFn) {}
+
+  async watch(prefix: string, path: string, opts: any, cb: (evt: string) => void): Promise<void> {
+    this.close();
+    this.watcher = await this.watchFn(prefix, path, opts, cb);
+  }
+
+  close(): void {
+    if (this.watcher) {
+      this.watcher.close();
+      this.watcher = undefined;
+    }
+  }
+}

--- a/test/fileWatcherManager.test.ts
+++ b/test/fileWatcherManager.test.ts
@@ -1,0 +1,18 @@
+import { FileWatcherManager } from '../app/ts/utils/fileWatcher';
+
+test('replaces existing watcher', async () => {
+  const closeFirst = jest.fn();
+  const closeSecond = jest.fn();
+  const watchFn = jest
+    .fn()
+    .mockResolvedValueOnce({ close: closeFirst })
+    .mockResolvedValueOnce({ close: closeSecond });
+
+  const mgr = new FileWatcherManager(watchFn);
+  await mgr.watch('a', '/tmp/1', {}, () => {});
+  await mgr.watch('a', '/tmp/2', {}, () => {});
+
+  expect(closeFirst).toHaveBeenCalled();
+  mgr.close();
+  expect(closeSecond).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add `FileWatcherManager` utility for managing a single watcher
- use `FileWatcherManager` in bulk WHOIS and BWA file inputs
- add unit test for the manager

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Module did not self-register)*
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686e5810f4508325851842d8605f093e