### PR TITLE
refactor logger with debug package

### DIFF
--- a/app/ts/common/logger.ts
+++ b/app/ts/common/logger.ts
@@ -1,27 +1,10 @@
+import debug from 'debug';
+
 export function debugFactory(namespace: string) {
-  return (...args: unknown[]): void => {
-    const message = `[${namespace}] ${args.map(String).join(' ')}`;
-    if (
-      typeof window !== 'undefined' &&
-      (window as any)?.electron?.send instanceof Function
-    ) {
-      (window as any).electron.send('app:debug', message);
-    } else {
-      console.debug(message);
-    }
-  };
+  return debug(namespace);
 }
 
 export function errorFactory(namespace: string) {
-  return (...args: unknown[]): void => {
-    const message = `[${namespace}] ${args.map(String).join(' ')}`;
-    if (
-      typeof window !== 'undefined' &&
-      (window as any)?.electron?.send instanceof Function
-    ) {
-      (window as any).electron.send('app:error', message);
-    } else {
-      console.error(message);
-    }
-  };
+  return debug(`${namespace}:error`);
 }
+

--- a/app/ts/renderer/bulkwhois/export.ts
+++ b/app/ts/renderer/bulkwhois/export.ts
@@ -28,7 +28,7 @@ let options: any;
     rcvResults
  */
 electron.on(IpcChannel.BulkwhoisResultReceive, function (_event, rcvResults) {
-  electron.send('app:debug', formatString('Results are ready for export {0}', rcvResults));
+  debug(formatString('Results are ready for export {0}', rcvResults));
 
   results = rcvResults;
 

--- a/app/ts/renderer/bulkwhois/fileinput.ts
+++ b/app/ts/renderer/bulkwhois/fileinput.ts
@@ -1,7 +1,8 @@
 import * as conversions from '../../common/conversions.js';
 import type { FileStats } from '../../common/fileStats.js';
-import { debugFactory } from '../../common/logger.js';
+import { debugFactory, errorFactory } from '../../common/logger.js';
 const debug = debugFactory('bulkwhois.fileinput');
+const error = errorFactory('bulkwhois.fileinput');
 debug('loaded');
 
 const electron = (window as any).electron as {
@@ -79,7 +80,7 @@ async function refreshBwFile(pathToFile: string): Promise<void> {
     );
     $('#bwFileTdFilepreview').text(String(bwFileStats.filepreview) + '...');
   } catch (e) {
-    electron.send('app:error', `Failed to reload file: ${e}`);
+    error(`Failed to reload file: ${e}`);
   }
 }
 
@@ -123,7 +124,7 @@ async function handleFileConfirmation(
         $('#bwFileSpanInfo').text('Loading file contents...');
         bwFileContents = await electron.bwFileRead(filePath as string);
       } catch (e) {
-        electron.send('app:error', `Failed to read file: ${e}`);
+        error(`Failed to read file: ${e}`);
         $('#bwFileSpanInfo').text('Failed to load file');
         return;
       }
@@ -138,7 +139,7 @@ async function handleFileConfirmation(
         $('#bwFileSpanInfo').text('Loading file contents...');
         bwFileContents = await electron.bwFileRead((filePath as string[])[0]);
       } catch (e) {
-        electron.send('app:error', `Failed to read file: ${e}`);
+        error(`Failed to read file: ${e}`);
         $('#bwFileSpanInfo').text('Failed to load file');
         return;
       }
@@ -291,7 +292,7 @@ $(document).on('click', '#bwFileButtonConfirm', function () {
       event.preventDefault();
       for (const f of Array.from(event.dataTransfer!.files)) {
         const file = f as any;
-        electron.send('app:debug', `File(s) you dragged here: ${file.path}`);
+        debug(`File(s) you dragged here: ${file.path}`);
         electron.send('ondragstart', file.path);
       }
       return false;
@@ -307,7 +308,7 @@ $('#bulkwhoisMainContainer').on('drop', function (event) {
   event.preventDefault();
   for (const f of Array.from((event as any).originalEvent.dataTransfer.files)) {
     const file = f as any;
-    electron.send('app:debug', `File(s) you dragged here: ${file.path}`);
+    debug(`File(s) you dragged here: ${file.path}`);
     electron.send('ondragstart', file.path);
   }
 

--- a/app/ts/renderer/bulkwhois/process.ts
+++ b/app/ts/renderer/bulkwhois/process.ts
@@ -57,7 +57,7 @@ export { bulkResults };
     value
  */
 electron.on(IpcChannel.BulkwhoisStatusUpdate, function (event, stat, value) {
-  electron.send('app:debug', formatString('{0}, value update to {1}', stat, value)); // status update
+  debug(formatString('{0}, value update to {1}', stat, value)); // status update
   let percent;
   switch (stat) {
     case 'start':
@@ -200,7 +200,7 @@ function setPauseButton() {
     Trigger Bulk whois Stop modal
  */
 $(document).on('click', '#bwProcessingButtonStop', function () {
-  electron.send('app:debug', 'Pausing whois & opening stop modal');
+  debug('Pausing whois & opening stop modal');
   $('#bwProcessingButtonPause').text().includes('Pause')
     ? $('#bwProcessingButtonPause').click()
     : false;
@@ -214,7 +214,7 @@ $(document).on('click', '#bwProcessingButtonStop', function () {
     Close modal and allow continue
  */
 $(document).on('click', '#bwProcessingModalStopButtonContinue', function () {
-  electron.send('app:debug', 'Closing Stop modal & continue');
+  debug('Closing Stop modal & continue');
   $('#bwProcessingModalStop').removeClass('is-active');
 
   return;
@@ -225,7 +225,7 @@ $(document).on('click', '#bwProcessingModalStopButtonContinue', function () {
     Stop bulk whois entirely and scrape everything
  */
 $(document).on('click', '#bwProcessingModalStopButtonStop', function () {
-  electron.send('app:debug', 'Closing Stop modal & going back to start');
+  debug('Closing Stop modal & going back to start');
   $('#bwProcessingModalStop').removeClass('is-active');
   $('#bwProcessing').addClass('is-hidden');
   setPauseButton();
@@ -239,7 +239,7 @@ $(document).on('click', '#bwProcessingModalStopButtonStop', function () {
     Stop bulk whois entirely and save/export
  */
 $(document).on('click', '#bwProcessingModalStopButtonStopsave', function () {
-  electron.send('app:debug', 'Closing Stop modal & exporting');
+  debug('Closing Stop modal & exporting');
   electron.send(IpcChannel.BulkwhoisLookupStop);
   $('#bwProcessingModalStop').removeClass('is-active');
   $('#bwProcessing').addClass('is-hidden');

--- a/app/ts/renderer/bulkwhois/wordlistinput.ts
+++ b/app/ts/renderer/bulkwhois/wordlistinput.ts
@@ -1,6 +1,6 @@
 import * as conversions from '../../common/conversions.js';
 import { settings } from '../settings-renderer.js';
-import { debugFactory } from '../../common/logger.js';
+import { debugFactory, errorFactory } from '../../common/logger.js';
 
 const electron = (window as any).electron as {
   send: (channel: string, ...args: any[]) => void;
@@ -11,6 +11,7 @@ import { tableReset } from './auxiliary.js';
 import $ from '../../../vendor/jquery.js';
 
 const debug = debugFactory('bulkwhois.wordlistinput');
+const error = errorFactory('bulkwhois.wordlistinput');
 debug('loaded');
 
 import { formatString } from '../../common/stringformat.js';
@@ -30,7 +31,7 @@ $(document).on('click', '#bwSuggestButton', async () => {
       textarea.val(current + prefix + words.join('\n'));
     }
   } catch (e) {
-    electron.send('app:error', `Suggestion failed: ${e}`);
+    error(`Suggestion failed: ${e}`);
   }
 });
 

--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -33,7 +33,7 @@ export function renderAnalyser(contents: any): void {
     Bulk whois analyser close button
  */
 $('#bwaAnalyserButtonClose').click(function () {
-  electron.send('app:debug', '#bwaAnalyserButtonClose clicked');
+  debug('#bwaAnalyserButtonClose clicked');
   $('#bwaAnalyserModalClose').addClass('is-active');
 
   return;

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -3,7 +3,7 @@ import type { FileStats } from '../../common/fileStats.js';
 import $ from '../../../vendor/jquery.js';
 import '../../../vendor/datatables.js';
 import { settings } from '../settings-renderer.js';
-import { debugFactory } from '../../common/logger.js';
+import { debugFactory, errorFactory } from '../../common/logger.js';
 
 const electron = (window as any).electron as {
   send: (channel: string, ...args: any[]) => void;
@@ -21,6 +21,7 @@ const electron = (window as any).electron as {
 };
 
 const debug = debugFactory('renderer.bwa.fileinput');
+const error = errorFactory('renderer.bwa.fileinput');
 debug('loaded');
 
 import { formatString } from '../../common/stringformat.js';
@@ -63,7 +64,7 @@ async function refreshBwaFile(pathToFile: string): Promise<void> {
     $('#bwaFileTdFilepreview').text(String(bwaFileStats.filepreview) + '...');
     $('#bwaFileTextareaErrors').text(String(bwaFileStats.errors || 'No errors'));
   } catch (e) {
-    electron.send('app:error', `Failed to reload file: ${e}`);
+    error(`Failed to reload file: ${e}`);
   }
 }
 
@@ -108,7 +109,7 @@ async function handleFileConfirmation(
             (await electron.bwaFileRead(filePath as string)).toString()
           );
         } catch (e) {
-          electron.send('app:error', `Failed to read file: ${e}`);
+          error(`Failed to read file: ${e}`);
           $('#bwaFileSpanInfo').text('Failed to load file');
           return;
         }
@@ -126,7 +127,7 @@ async function handleFileConfirmation(
             (await electron.bwaFileRead((filePath as string[])[0])).toString()
           );
         } catch (e) {
-          electron.send('app:error', `Failed to read file: ${e}`);
+          error(`Failed to read file: ${e}`);
           $('#bwaFileSpanInfo').text('Failed to load file');
           return;
         }
@@ -247,7 +248,7 @@ $('#bwafButtonConfirm').click(function() {
   holder.ondrop = function(event) {
     event.preventDefault();
     for (const file of event.dataTransfer.files) {
-      electron.send('app:debug', `File(s) you dragged here: ${file.path}`);
+      debug(`File(s) you dragged here: ${file.path}`);
       electron.send('ondragstart', file.path);
     }
     return false;

--- a/app/ts/renderer/logger.ts
+++ b/app/ts/renderer/logger.ts
@@ -1,11 +1,12 @@
-const electron = (window as any).electron as {
-  send: (channel: string, ...args: any[]) => void;
-};
+import { debugFactory, errorFactory } from '../common/logger.js';
+
+const debug = debugFactory('renderer');
+const error = errorFactory('renderer');
 
 export function sendDebug(message: string): void {
-  electron.send('app:debug', message);
+  debug(message);
 }
 
 export function sendError(message: string): void {
-  electron.send('app:error', message);
+  error(message);
 }

--- a/app/ts/renderer/navigation.ts
+++ b/app/ts/renderer/navigation.ts
@@ -21,7 +21,7 @@ const electron = (window as any).electron as {
     event (object)
  */
 $(document).on('drop', function (event) {
-  electron.send('app:debug', 'Preventing drag and drop redirect');
+  debug('Preventing drag and drop redirect');
   event.preventDefault();
 
   return false;
@@ -45,7 +45,7 @@ $(document).on('dragover', function (event) {
  */
 $(document).on('click', '#navButtonDevtools', function () {
   void electron.invoke('app:toggleDevtools');
-  electron.send('app:debug', '#navButtonDevtools was clicked');
+  debug('#navButtonDevtools was clicked');
 
   return;
 });
@@ -67,7 +67,7 @@ $(document).on('click', 'section.tabs ul li', function () {
       populateInputs();
     }
   }
-  electron.send('app:debug', formatString('#section.tabs switched to data tab, {0}', tabName));
+  debug(formatString('#section.tabs switched to data tab, {0}', tabName));
 
   return;
 });
@@ -77,7 +77,7 @@ $(document).on('click', 'section.tabs ul li', function () {
     On click: Delete open notifications
  */
 $(document).on('click', '.delete', function () {
-  electron.send('app:debug', '.delete (notifications) was clicked');
+  debug('.delete (notifications) was clicked');
   const notificationId = $(this).attr('data-notif');
 
   $('#' + notificationId).addClass('is-hidden');
@@ -91,7 +91,7 @@ $(document).on('click', '.delete', function () {
  */
 $(document).keyup(function (event) {
   if (event.keyCode === 27) {
-    electron.send('app:debug', formatString('Hotkey, Used [ESC] key, {0}', event.keyCode));
+    debug(formatString('Hotkey, Used [ESC] key, {0}', event.keyCode));
     if ($('#appModalExit').hasClass('is-active')) {
       $('#appModalExitButtonNo').click();
       return;
@@ -99,7 +99,7 @@ $(document).keyup(function (event) {
     switch (true) {
       // Single whois tab is active
       case $('#navButtonSinglewhois').hasClass('is-active'):
-        electron.send('app:debug', 'Hotkey, Single whois tab is active');
+        debug('Hotkey, Single whois tab is active');
         switch (true) {
           case $('#singlewhoisDomainCopied').hasClass('is-active'):
             $('#singlewhoisDomainCopiedClose').click();
@@ -124,7 +124,7 @@ $(document).keyup(function (event) {
 
       // Bulk whois tab is active
       case $('#navButtonBulkwhois').hasClass('is-active'):
-        electron.send('app:debug', 'Hotkey, Bulk whois tab is active');
+        debug('Hotkey, Bulk whois tab is active');
         switch (true) {
           // Bulk whois, is Stop dialog open
           case $('#bwProcessingModalStop').hasClass('is-active'):
@@ -143,7 +143,7 @@ $(document).keyup(function (event) {
     Button/Toggle special menu items
  */
 $(document).on('click', '#navButtonExtendedmenu', function () {
-  electron.send('app:debug', '#navButtonExtendedmenu was clicked');
+  debug('#navButtonExtendedmenu was clicked');
   $('#navButtonExtendedmenu').toggleClass('is-active');
   $('.is-specialmenu').toggleClass('is-hidden');
 
@@ -155,7 +155,7 @@ $(document).on('click', '#navButtonExtendedmenu', function () {
     On click: Minimize window button
  */
 $(document).on('click', '#navButtonMinimize', function () {
-  electron.send('app:debug', '#navButtonMinimize was clicked');
+  debug('#navButtonMinimize was clicked');
   void electron.invoke('app:minimize');
 
   return;
@@ -166,7 +166,7 @@ $(document).on('click', '#navButtonMinimize', function () {
     On click: Close main window button
  */
 $(document).on('click', '#navButtonExit', function () {
-  electron.send('app:debug', '#navButtonExit was clicked');
+  debug('#navButtonExit was clicked');
   if (settings.ui?.confirmExit) {
     $('#appModalExit').addClass('is-active');
   } else {
@@ -177,13 +177,13 @@ $(document).on('click', '#navButtonExit', function () {
 });
 
 $(document).on('click', '#appModalExitButtonYes', function () {
-  electron.send('app:debug', '#appModalExitButtonYes was clicked');
+  debug('#appModalExitButtonYes was clicked');
   $('#appModalExit').removeClass('is-active');
   electron.send('app:exit-confirmed');
 });
 
 $(document).on('click', '#appModalExitButtonNo, #appModalExit .delete', function () {
-  electron.send('app:debug', '#appModalExitButtonNo was clicked');
+  debug('#appModalExitButtonNo was clicked');
   $('#appModalExit').removeClass('is-active');
 });
 

--- a/app/ts/renderer/singlewhois.ts
+++ b/app/ts/renderer/singlewhois.ts
@@ -12,9 +12,10 @@ import { formatString } from '../common/stringformat.js';
 
 import $ from '../../vendor/jquery.js';
 (window as any).$ = (window as any).jQuery = $;
-import { debugFactory } from '../common/logger.js';
+import { debugFactory, errorFactory } from '../common/logger.js';
 
 const debug = debugFactory('renderer.singlewhois');
+const error = errorFactory('renderer.singlewhois');
 debug('loaded');
 
 interface SingleWhois {
@@ -149,11 +150,11 @@ $(document).on('click', '#singlewhoisSearchButtonSearch', function () {
   let { domain } = input;
 
   if ($(this).hasClass('is-loading')) return true;
-  electron.send('app:debug', '#singlewhoisSearchButtonSearch was clicked');
+  debug('#singlewhoisSearchButtonSearch was clicked');
 
   domain = $('#singlewhoisSearchInputDomain').val() as string;
 
-  electron.send('app:debug', formatString('Looking up for {0}', domain));
+  debug(formatString('Looking up for {0}', domain));
 
   $('#singlewhoisSearchButtonSearch').addClass('is-loading');
   $('#singlewhoisSearchInputDomain').attr('readonly', '');
@@ -165,7 +166,7 @@ $(document).on('click', '#singlewhoisSearchButtonSearch', function () {
       const result = await electron.invoke(IpcChannel.SingleWhoisLookup, domain);
       await handleResults(result);
     } catch (e) {
-      electron.send('app:error', `Lookup failed: ${e}`);
+      error(`Lookup failed: ${e}`);
       $('#singlewhoisSearchButtonSearch').removeClass('is-loading');
       $('#singlewhoisSearchInputDomain').removeAttr('readonly');
     }
@@ -178,7 +179,7 @@ $(document).on('click', '#singlewhoisSearchButtonSearch', function () {
     On click: Single whois lookup modal open click
  */
 $(document).on('click', '.singlewhoisMessageWhoisOpen', function () {
-  electron.send('app:debug', 'Opening whois reply');
+  debug('Opening whois reply');
   $('#singlewhoisMessageWhois').addClass('is-active');
 
   return;
@@ -189,7 +190,7 @@ $(document).on('click', '.singlewhoisMessageWhoisOpen', function () {
     On click: Single whois lookup modal close click
  */
 $(document).on('click', '#singlewhoisMessageWhoisClose', function () {
-  electron.send('app:debug', 'Closing whois reply');
+  debug('Closing whois reply');
   $('#singlewhoisMessageWhois').removeClass('is-active');
 
   return;
@@ -200,7 +201,7 @@ $(document).on('click', '#singlewhoisMessageWhoisClose', function () {
     On click: Domain copied close click
  */
 $(document).on('click', '#singlewhoisDomainCopiedClose', function () {
-  electron.send('app:debug', 'Closing domain copied');
+  debug('Closing domain copied');
   $('#singlewhoisDomainCopied').removeClass('is-active');
 
   return;
@@ -211,7 +212,7 @@ $(document).on('click', '#singlewhoisDomainCopiedClose', function () {
     Resets registry table contents
  */
 function tableReset() {
-  electron.send('app:debug', 'Resetting whois result table');
+  debug('Resetting whois result table');
   $('#singlewhoisTdDomain').attr('href', '#');
   $('#singlewhoisTdDomain').text('n/a');
   $('#singlewhoisTdUpdate').text('n/a');

--- a/app/ts/renderer/to.ts
+++ b/app/ts/renderer/to.ts
@@ -1,11 +1,12 @@
 // In the renderer process we access IPC methods exposed from the preload script
 // via the `window.electron` bridge instead of importing from 'electron'.
-const { invoke, send } = (window as any).electron;
+const { invoke } = (window as any).electron;
 import { IpcChannel } from '../common/ipcChannels.js';
 import $ from '../../vendor/jquery.js';
-import { debugFactory } from '../common/logger.js';
+import { debugFactory, errorFactory } from '../common/logger.js';
 
 const debug = debugFactory('renderer.to');
+const error = errorFactory('renderer.to');
 debug('loaded');
 
 let filePath: string | null = null;
@@ -33,7 +34,7 @@ $(document).on('click', '#toButtonProcess', async function () {
     const result = await invoke(IpcChannel.ToProcess, filePath, options);
     $('#toOutput').text(result);
   } catch (e) {
-    send('app:error', `Processing failed: ${e}`);
+    error(`Processing failed: ${e}`);
   }
 });
 

--- a/scripts/logger.js
+++ b/scripts/logger.js
@@ -1,13 +1,9 @@
+import debug from 'debug';
+
 export function debugFactory(namespace) {
-  return (...args) => {
-    const message = `[${namespace}] ${args.map(String).join(' ')}`;
-    console.debug(message);
-  };
+  return debug(namespace);
 }
 
 export function errorFactory(namespace) {
-  return (...args) => {
-    const message = `[${namespace}] ${args.map(String).join(' ')}`;
-    console.error(message);
-  };
+  return debug(`${namespace}:error`);
 }

--- a/test/navigation.test.ts
+++ b/test/navigation.test.ts
@@ -2,6 +2,11 @@
 
 import jQuery from 'jquery';
 
+const debugMock = jest.fn();
+jest.mock('../app/ts/common/logger.ts', () => ({
+  debugFactory: () => debugMock
+}));
+
 declare global {
   interface Window {
     electron: {
@@ -21,6 +26,7 @@ beforeEach(() => {
   (window as any).$ = (window as any).jQuery = jQuery;
   sendMock = jest.fn();
   invokeMock = jest.fn();
+  debugMock.mockClear();
   (window as any).electron = {
     getBaseDir: () => Promise.resolve(__dirname),
     send: sendMock,
@@ -48,7 +54,7 @@ test('drop event prevents default and logs debug', () => {
   document.dispatchEvent(dropEvent);
 
   expect(dropEvent.preventDefault).toHaveBeenCalled();
-  expect(sendMock).toHaveBeenCalledWith('app:debug', 'Preventing drag and drop redirect');
+  expect(debugMock).toHaveBeenCalledWith('Preventing drag and drop redirect');
 });
 
 test('dragover event prevents default', () => {
@@ -67,5 +73,5 @@ test('devtools button triggers ipc calls', () => {
   jQuery('#navButtonDevtools').trigger('click');
 
   expect(invokeMock).toHaveBeenCalledWith('app:toggleDevtools');
-  expect(sendMock).toHaveBeenCalledWith('app:debug', '#navButtonDevtools was clicked');
+  expect(debugMock).toHaveBeenCalledWith('#navButtonDevtools was clicked');
 });


### PR DESCRIPTION
## Summary
- use the `debug` package for logging
- update renderer modules to use new logger
- update Node scripts to use new logger
- adjust navigation tests for new logger

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format:check`
- `npm test` *(fails: Module did not self-register / better-sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_686e77e683508325b73b88265aaed447