### PR TITLE
feat: centralize fetch compatibility

### DIFF
--- a/app/ts/ai/openaiSuggest.ts
+++ b/app/ts/ai/openaiSuggest.ts
@@ -1,14 +1,8 @@
 import { debugFactory } from '../common/logger.js';
 import { settings } from '../common/settings.js';
+import { ensureFetch } from '../utils/fetchCompat.js';
 
 const debug = debugFactory('ai.openaiSuggest');
-
-async function ensureFetch(): Promise<void> {
-  if (typeof globalThis.fetch === 'undefined') {
-    const { default: fetchImpl } = await import('node-fetch');
-    (globalThis as any).fetch = fetchImpl as unknown as typeof fetch;
-  }
-}
 
 export async function suggestWords(prompt: string, count: number): Promise<string[]> {
   await ensureFetch();

--- a/app/ts/utils/fetchCompat.ts
+++ b/app/ts/utils/fetchCompat.ts
@@ -1,0 +1,8 @@
+export async function ensureFetch(): Promise<void> {
+  if (typeof globalThis.fetch === 'undefined') {
+    const { default: fetchImpl } = await import('node-fetch');
+    (globalThis as any).fetch = fetchImpl as unknown as typeof fetch;
+  }
+}
+
+export default { ensureFetch };


### PR DESCRIPTION
## Summary
- add `utils/fetchCompat` for Node/Electron `fetch`
- update OpenAI suggestion module to use the new helper

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: better_sqlite3.node mismatch)*
- `npm run test:e2e` *(fails: WebDriverError about user-data-dir)*

------
https://chatgpt.com/codex/tasks/task_e_686ed32ee9a08325856f8c88c8431c75