### PR TITLE
Introduce BulkWhoisManager class

### DIFF
--- a/app/ts/main/bulkwhois/auxiliary.ts
+++ b/app/ts/main/bulkwhois/auxiliary.ts
@@ -1,5 +1,5 @@
 import { debugFactory } from '../../common/logger.js';
-import type { IpcMainEvent } from 'electron';
+import type { IpcMainEvent, IpcMainInvokeEvent } from 'electron';
 import { IpcChannel } from '../../common/ipcChannels.js';
 
 const debug = debugFactory('bulkwhois.auxiliary');
@@ -11,7 +11,7 @@ const debug = debugFactory('bulkwhois.auxiliary');
     event (object) - renderer object
  */
 
-function resetUiCounters(event: IpcMainEvent): void {
+function resetUiCounters(event: IpcMainEvent | IpcMainInvokeEvent): void {
   const { sender } = event;
 
   debug('Resetting bulk whois UI counters');

--- a/app/ts/main/bulkwhois/resultHandler.ts
+++ b/app/ts/main/bulkwhois/resultHandler.ts
@@ -7,7 +7,7 @@ import { formatString } from '../../common/stringformat.js';
 import type { BulkWhois, ProcessedResult } from './types.js';
 import * as dns from '../../common/dnsLookup.js';
 import { Result, DnsLookupError } from '../../common/errors.js';
-import type { IpcMainEvent } from 'electron';
+import type { IpcMainEvent, IpcMainInvokeEvent } from 'electron';
 import { addEntry as addHistoryEntry } from '../../common/history.js';
 import { IpcChannel } from '../../common/ipcChannels.js';
 
@@ -16,7 +16,7 @@ const debug = debugFactory('bulkwhois.resultHandler');
 export async function processData(
   bulkWhois: BulkWhois,
   reqtime: number[],
-  event: IpcMainEvent,
+  event: IpcMainEvent | IpcMainInvokeEvent,
   domain: string,
   index: number,
   data: string | Result<boolean, DnsLookupError> | null = null,

--- a/app/ts/main/bulkwhois/scheduler.ts
+++ b/app/ts/main/bulkwhois/scheduler.ts
@@ -8,7 +8,7 @@ import { msToHumanTime } from '../../common/conversions.js';
 import { getSettings } from '../settings-main.js';
 import type { BulkWhois, DomainSetup } from './types.js';
 import { processData } from './resultHandler.js';
-import type { IpcMainEvent } from 'electron';
+import type { IpcMainEvent, IpcMainInvokeEvent } from 'electron';
 import { IpcChannel } from '../../common/ipcChannels.js';
 
 const debug = debugFactory('bulkwhois.scheduler');
@@ -17,7 +17,7 @@ export function processDomain(
   bulkWhois: BulkWhois,
   reqtime: number[],
   domainSetup: DomainSetup,
-  event: IpcMainEvent,
+  event: IpcMainEvent | IpcMainInvokeEvent,
   delay: number
 ): void {
   debug(
@@ -69,7 +69,11 @@ export function processDomain(
   debug(formatString('Delay: {0}', delay));
 }
 
-export function counter(bulkWhois: BulkWhois, event: IpcMainEvent, start = true): void {
+export function counter(
+  bulkWhois: BulkWhois,
+  event: IpcMainEvent | IpcMainInvokeEvent,
+  start = true
+): void {
   const { results, stats } = bulkWhois;
   const { sender } = event;
 


### PR DESCRIPTION
## Summary
- manage bulk WHOIS state with a new `BulkWhoisManager` class
- update scheduler and helpers to accept invoke events
- wire IPC handlers to class methods

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: better-sqlite3 module not compiled)*
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686ee59dd6448325b33b071f5ac9aaf2