### PR TITLE
feat(settings): typed window preferences

### DIFF
--- a/app/ts/common/settings-base.ts
+++ b/app/ts/common/settings-base.ts
@@ -1,4 +1,58 @@
+export interface AppWindowSettings {
+  frame: boolean;
+  show: boolean;
+  height: number;
+  width: number;
+  icon: string;
+  center: boolean;
+  minimizable: boolean;
+  maximizable: boolean;
+  movable: boolean;
+  resizable: boolean;
+  closable: boolean;
+  focusable: boolean;
+  alwaysOnTop: boolean;
+  fullscreen: boolean;
+  fullscreenable: boolean;
+  kiosk: boolean;
+  darkTheme: boolean;
+  thickFrame: boolean;
+}
+
+export interface WebPreferencesSettings {
+  nodeIntegration: boolean;
+  contextIsolation: boolean;
+  zoomFactor: number;
+  images: boolean;
+  experimentalFeatures: boolean;
+  backgroundThrottling: boolean;
+  offscreen: boolean;
+  spellcheck: boolean;
+  enableRemoteModule: boolean;
+}
+
+export interface AppUrlSettings {
+  pathname: string;
+  protocol: string;
+  slashes: boolean;
+}
+
+export interface StartupSettings {
+  developerTools: boolean;
+}
+
+export interface NavigationSettings {
+  developerTools: boolean;
+  extendedCollapsed: boolean;
+  enableExtendedMenu: boolean;
+}
+
 export interface Settings {
+  appWindow: AppWindowSettings;
+  appWindowWebPreferences: WebPreferencesSettings;
+  appWindowUrl: AppUrlSettings;
+  appWindowNavigation: NavigationSettings;
+  startup: StartupSettings;
   lookupConversion: { enabled: boolean; algorithm: string };
   lookupGeneral: {
     type: 'dns' | 'whois';

--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -51,15 +51,15 @@ export async function load(): Promise<Settings> {
         const parsed = JSON.parse(raw) as Partial<Settings>;
         try {
           setSettings(mergeDefaults(parsed));
-          if ((settings as any).appWindowWebPreferences) {
-            (settings as any).appWindowWebPreferences.contextIsolation = true;
+          if (settings.appWindowWebPreferences) {
+            settings.appWindowWebPreferences.contextIsolation = true;
           }
           setCustomSettingsLoaded(true);
           debug(`Loaded custom configuration at ${filePath}`);
         } catch (mergeError) {
           setSettings(JSON.parse(JSON.stringify(defaultSettings)));
-          if ((settings as any).appWindowWebPreferences) {
-            (settings as any).appWindowWebPreferences.contextIsolation = true;
+          if (settings.appWindowWebPreferences) {
+            settings.appWindowWebPreferences.contextIsolation = true;
           }
           setCustomSettingsLoaded(false);
           debug(`Failed to merge custom configuration with error: ${mergeError}`);
@@ -71,17 +71,17 @@ export async function load(): Promise<Settings> {
     } catch (e) {
       debug(`Failed to load custom configuration with error: ${e}`);
       setCustomSettingsLoaded(false);
-      if ((settings as any).appWindowWebPreferences) {
-        (settings as any).appWindowWebPreferences.contextIsolation = true;
+      if (settings.appWindowWebPreferences) {
+        settings.appWindowWebPreferences.contextIsolation = true;
       }
       // Silently ignore loading errors
     }
   }
 
   if (!customSettingsLoaded) setCustomSettingsLoaded(false);
-  if ((settings as any).appWindowWebPreferences) {
+  if (settings.appWindowWebPreferences) {
     // Enforce context isolation regardless of loaded configuration
-    (settings as any).appWindowWebPreferences.contextIsolation = true;
+    settings.appWindowWebPreferences.contextIsolation = true;
   }
   return settings;
 }

--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -54,6 +54,7 @@ interface WebPreferencesSettings {
   backgroundThrottling: boolean;
   offscreen: boolean;
   spellcheck: boolean;
+  enableRemoteModule: boolean;
 }
 
 interface AppUrlSettings {

--- a/app/ts/main/settings-main.ts
+++ b/app/ts/main/settings-main.ts
@@ -43,15 +43,15 @@ function watchConfig(): void {
       const parsed = JSON.parse(raw) as Partial<Settings>;
       try {
         const merged = mergeDefaults(parsed);
-        if ((merged as any).appWindowWebPreferences) {
-          (merged as any).appWindowWebPreferences.contextIsolation = true;
+        if (merged.appWindowWebPreferences) {
+          merged.appWindowWebPreferences.contextIsolation = true;
         }
         setSettings(merged);
         debug(`Reloaded custom configuration at ${cfg}`);
       } catch (mergeError) {
         const defaults = JSON.parse(JSON.stringify(defaultSettings));
-        if ((defaults as any).appWindowWebPreferences) {
-          (defaults as any).appWindowWebPreferences.contextIsolation = true;
+        if (defaults.appWindowWebPreferences) {
+          defaults.appWindowWebPreferences.contextIsolation = true;
         }
         setSettings(defaults);
         debug(`Failed to merge configuration with error: ${mergeError}`);


### PR DESCRIPTION
## Summary
- type browser window preferences
- enforce proper typing in settings load flow
- update main process types

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: better_sqlite3 module mismatch)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686ee7ccb66c83258ba6eb7ad8fa0229