### PR TITLE
Refactor export logic with helpers

### DIFF
--- a/app/ts/main/bulkwhois/export-helpers.ts
+++ b/app/ts/main/bulkwhois/export-helpers.ts
@@ -1,0 +1,136 @@
+import fs from 'fs';
+import { shell } from 'electron';
+import JSZip from 'jszip';
+import { formatString } from '../../common/stringformat.js';
+import type { BulkWhoisResults } from './types.js';
+
+export interface ExportOptions {
+  filetype: string;
+  domains: string;
+  errors: string;
+  information: string;
+  whoisreply: string;
+}
+
+export interface ExportSettings {
+  separator: string;
+  enclosure: string;
+  linebreak: string;
+  filetypeText: string;
+  filetypeCsv: string;
+  filetypeZip: string;
+  openAfterExport: boolean;
+}
+
+export function buildExportIndices(
+  results: BulkWhoisResults,
+  options: Pick<ExportOptions, 'domains' | 'errors'>
+): number[] {
+  const indices: number[] = [];
+  for (let i = 0; i < results.id.length; i++) {
+    const status = results.status[i];
+    switch (options.domains) {
+      case 'available':
+        if (status === 'available') indices.push(i);
+        break;
+      case 'unavailable':
+        if (status === 'unavailable') indices.push(i);
+        break;
+      case 'both':
+        if (status === 'available' || status === 'unavailable') indices.push(i);
+        break;
+    }
+  }
+  for (let i = 0; i < results.id.length; i++) {
+    const status = results.status[i];
+    if (options.errors === 'yes' && typeof status === 'string' && status.includes('error')) {
+      indices.push(i);
+    }
+  }
+  return indices;
+}
+
+export function generateContent(
+  results: BulkWhoisResults,
+  indices: number[],
+  options: ExportOptions,
+  settings: ExportSettings
+): { content?: string; zip: JSZip } {
+  const {
+    separator: s,
+    enclosure: e,
+    linebreak: l,
+    filetypeText: txt,
+    filetypeCsv: csv
+  } = settings;
+  const zip = new JSZip();
+  if (options.filetype === 'txt') {
+    for (const i of indices) {
+      zip.file(results.domain[i] + txt, results.whoisreply[i] ?? '');
+    }
+    return { zip };
+  }
+
+  let header = formatString('{0}Domain{0}{1}{0}Status{0}', e, s);
+  if (options.information.includes('basic')) {
+    header += formatString(
+      '{1}{0}Registrar{0}{1}{0}Company{0}{1}{0}Creation Date{0}{1}{0}Update Date{0}{1}{0}Expiry Date{0}',
+      e,
+      s
+    );
+  }
+  if (options.information.includes('debug')) {
+    header += formatString('{1}{0}ID{0}{1}{0}Request Time{0}', e, s);
+  }
+  if (options.whoisreply.includes('yes+inline')) {
+    header += formatString('{1}{0}Whois Reply{0}', e, s);
+  }
+
+  let body = '';
+  for (const i of indices) {
+    body += formatString('{2}{0}{3}{0}{1}{0}{4}{0}', e, s, l, results.domain[i], results.status[i]);
+    if (options.information.includes('basic')) {
+      body += formatString(
+        '{1}{0}{2}{0}{1}{0}{3}{0}{1}{0}{4}{0}{1}{0}{5}{0}{1}{0}{6}{0}',
+        e,
+        s,
+        results.registrar[i],
+        results.company[i],
+        results.creationdate[i],
+        results.updatedate[i],
+        results.expirydate[i]
+      );
+    }
+    if (options.information.includes('debug')) {
+      body += formatString('{1}{0}{2}{0}{1}{0}{3}{0}', e, s, results.id[i], results.requesttime[i]);
+    }
+    switch (options.whoisreply) {
+      case 'yes+inline':
+        body += formatString('{1}{0}{2}{0}', e, s, results.whoisreply[i]);
+        break;
+      case 'yes+inlineseparate':
+        zip.file(results.domain[i] + csv, results.whoisjson[i] ?? '');
+        break;
+      case 'yes+block':
+        zip.file(results.domain[i] + txt, results.whoisreply[i] ?? '');
+        break;
+    }
+  }
+
+  return { content: header + body, zip };
+}
+
+export async function writeZipArchive(
+  zip: JSZip,
+  filePath: string,
+  zipExt: string,
+  open: boolean
+): Promise<void> {
+  const genType = JSZip.support.uint8array ? 'uint8array' : 'string';
+  const content = await zip.generateAsync({ type: genType });
+  const target = filePath.endsWith(zipExt) ? filePath : filePath + zipExt;
+  await fs.promises.writeFile(target, content);
+  if (open) {
+    await shell.openPath(target);
+  }
+}

--- a/app/ts/main/bulkwhois/export.ts
+++ b/app/ts/main/bulkwhois/export.ts
@@ -1,14 +1,19 @@
 import { ipcMain, dialog, shell } from 'electron';
 import fs from 'fs';
-import * as conversions from '../../common/conversions.js';
 import { debugFactory } from '../../common/logger.js';
 const debug = debugFactory('bulkwhois.export');
-import JSZip from 'jszip';
 import { formatString } from '../../common/stringformat.js';
 
 import { getSettings } from '../settings-main.js';
 import { generateFilename } from '../../cli/export.js';
 import { IpcChannel } from '../../common/ipcChannels.js';
+import {
+  buildExportIndices,
+  generateContent,
+  writeZipArchive,
+  type ExportOptions,
+  type ExportSettings
+} from './export-helpers.js';
 
 /*
   ipcMain.on('bulkwhois:export', function(...) {...});
@@ -20,43 +25,20 @@ import { IpcChannel } from '../../common/ipcChannels.js';
  */
 ipcMain.handle(IpcChannel.BulkwhoisExport, async function (event, results, options) {
   const { lookupExport: resExports } = getSettings();
+  const sender = event.sender;
 
-  const { sender } = event;
-
-  const s = resExports.separator, // Field separation char
-    e = resExports.enclosure, // Field enclosing char
-    l = resExports.linebreak, // Line break char
-    txt = resExports.filetypeText, // Text file
-    csv = resExports.filetypeCsv, // CSV file
-    zip = resExports.filetypeZip; // Zip file
   let filters;
-
-  debug(formatString('options: \n {0}', JSON.stringify(options)));
-  debug(formatString('results: \n {0}', JSON.stringify(results)));
-
   switch (options.filetype) {
     case 'txt':
       filters = [
-        {
-          name: 'All files',
-          extensions: ['*']
-        },
-        {
-          name: 'Plain text files',
-          extensions: ['txt']
-        }
+        { name: 'All files', extensions: ['*'] },
+        { name: 'Plain text files', extensions: ['txt'] }
       ];
       break;
     case 'csv':
       filters = [
-        {
-          name: 'All files',
-          extensions: ['*']
-        },
-        {
-          name: 'Comma-separated values',
-          extensions: ['csv']
-        }
+        { name: 'All files', extensions: ['*'] },
+        { name: 'Comma-separated values', extensions: ['csv'] }
       ];
       break;
   }
@@ -65,7 +47,11 @@ ipcMain.handle(IpcChannel.BulkwhoisExport, async function (event, results, optio
     options.filetype === 'txt' ||
     (options.filetype === 'csv' &&
       (options.whoisreply === 'yes+inlineseparate' || options.whoisreply === 'yes+block'));
-  const ext = isZip ? zip : options.filetype === 'csv' ? csv : txt;
+  const ext = isZip
+    ? resExports.filetypeZip
+    : options.filetype === 'csv'
+      ? resExports.filetypeCsv
+      : resExports.filetypeText;
   const filePath = dialog.showSaveDialogSync({
     title: 'Save export file',
     buttonLabel: 'Save',
@@ -73,144 +59,40 @@ ipcMain.handle(IpcChannel.BulkwhoisExport, async function (event, results, optio
     defaultPath: resExports.autoGenerateFilename ? generateFilename(ext) : undefined
   });
 
-  if (filePath === undefined || filePath == '' || filePath === null) {
-    debug(formatString('Using selected file at {0}', filePath));
+  if (!filePath) {
     sender.send(IpcChannel.BulkwhoisExportCancel);
-  } else {
-    let contentsExport = '',
-      contentsHeader = '',
-      contentsCompile;
-    const toProcess = [];
-
-    // Add domains to queue
-    for (let i = 0; i < results.id.length; i++) {
-      switch (options.domains) {
-        case 'available':
-          if (results.status[i] == 'available') {
-            toProcess.push(i);
-          }
-          break;
-        case 'unavailable':
-          if (results.status[i] == 'unavailable') {
-            toProcess.push(i);
-          }
-          break;
-        case 'both':
-          if (results.status[i] == 'available' || results.status[i] == 'unavailable') {
-            toProcess.push(i);
-          }
-          break;
-      }
-    }
-    debug(formatString('Available + Unavailable, {0}', toProcess));
-
-    // Add errors to queue
-    for (let i = 0; i < results.id.length; i++) {
-      if (options.errors == 'yes' && results.status[i].includes('error')) {
-        toProcess.push(i);
-      }
-    }
-    debug(formatString('Available + Unavailable + Errors, {0}', toProcess));
-
-    const contentZip = new JSZip();
-
-    if (options.filetype == 'txt') {
-      for (let i = 0; i < toProcess.length; i++)
-        contentZip.file(results.domain[toProcess[i]] + txt, results.whoisreply[toProcess[i]]);
-    } else {
-      // Make contentsHeader
-      contentsHeader += formatString('{0}Domain{0}{1}{0}Status{0}', e, s);
-      if (options.information.includes('basic') === true) {
-        contentsHeader += formatString(
-          '{1}{0}Registrar{0}{1}{0}Company{0}{1}{0}Creation Date{0}{1}{0}Update Date{0}{1}{0}Expiry Date{0}',
-          e,
-          s
-        );
-      }
-      if (options.information.includes('debug') === true) {
-        contentsHeader += formatString('{1}{0}ID{0}{1}{0}Request Time{0}', e, s);
-      }
-      if (options.whoisreply.includes('yes+inline') === true) {
-        contentsHeader += formatString('{1}{0}Whois Reply{0}', e, s);
-      }
-      // Process information for CSV
-      for (let i = 0; i < toProcess.length; i++) {
-        contentsExport += formatString(
-          '{2}{0}{3}{0}{1}{0}{4}{0}',
-          e,
-          s,
-          l,
-          results.domain[toProcess[i]],
-          results.status[toProcess[i]]
-        );
-
-        if (options.information.includes('basic') === true) {
-          contentsExport += formatString(
-            '{1}{0}{2}{0}{1}{0}{3}{0}{1}{0}{4}{0}{1}{0}{5}{0}{1}{0}{6}{0}',
-            e,
-            s,
-            results.registrar[toProcess[i]],
-            results.company[toProcess[i]],
-            results.creationdate[toProcess[i]],
-            results.updatedate[toProcess[i]],
-            results.expirydate[toProcess[i]]
-          );
-        }
-
-        if (options.information.includes('debug') === true)
-          contentsExport += formatString(
-            '{1}{0}{2}{0}{1}{0}{3}{0}',
-            e,
-            s,
-            results.id[toProcess[i]],
-            results.requesttime[toProcess[i]]
-          );
-
-        switch (options.whoisreply) {
-          case 'yes+inline':
-            contentsExport += formatString('{1}{0}{2}{0}', e, s, results.whoisreply[toProcess[i]]);
-            break;
-          case 'yes+inlineseparate':
-            contentZip.file(results.domain[toProcess[i]] + csv, results.whoisjson[toProcess[i]]);
-            break;
-          case 'yes+block':
-            contentZip.file(results.domain[toProcess[i]] + txt, results.whoisreply[toProcess[i]]);
-            break;
-        }
-      }
-
-      contentsCompile = contentsHeader + contentsExport;
-      try {
-        await fs.promises.writeFile(filePath, contentsCompile);
-        debug(formatString('File was saved, {0}', filePath));
-      } catch (err) {
-        debug(err);
-        throw err;
-      }
-    }
-
-    switch (true) {
-      case options.whoisreply == 'yes+inlineseparate' && options.filetype == 'csv':
-      case options.whoisreply == 'yes+block' && options.filetype == 'csv':
-      case options.filetype == 'txt':
-        try {
-          const genType = JSZip.support.uint8array ? 'uint8array' : 'string';
-          const content = await contentZip.generateAsync({ type: genType });
-          const target = filePath.endsWith(zip) ? filePath : filePath + zip;
-          await fs.promises.writeFile(target, content);
-          debug(formatString('Zip saved, {0}', target));
-          if (resExports.openAfterExport) {
-            await shell.openPath(target);
-          }
-        } catch (err) {
-          debug(formatString('Error, {0}', err));
-          throw err;
-        }
-        break;
-    }
-    if (!isZip && resExports.openAfterExport) {
-      await shell.openPath(filePath);
-    }
+    return;
   }
+
+  const exportSettings: ExportSettings = {
+    separator: resExports.separator,
+    enclosure: resExports.enclosure,
+    linebreak: resExports.linebreak,
+    filetypeText: resExports.filetypeText,
+    filetypeCsv: resExports.filetypeCsv,
+    filetypeZip: resExports.filetypeZip,
+    openAfterExport: resExports.openAfterExport
+  };
+
+  const indices = buildExportIndices(results, options as ExportOptions);
+  debug(formatString('Indices to export: {0}', indices));
+
+  const { content, zip } = generateContent(
+    results,
+    indices,
+    options as ExportOptions,
+    exportSettings
+  );
+  if (content) {
+    await fs.promises.writeFile(filePath, content);
+    debug(formatString('File was saved, {0}', filePath));
+  }
+
+  if (isZip) {
+    await writeZipArchive(zip, filePath, resExports.filetypeZip, resExports.openAfterExport);
+  } else if (resExports.openAfterExport) {
+    await shell.openPath(filePath);
+  }
+
   sender.send(IpcChannel.BulkwhoisExportCancel);
 });

--- a/test/exportHelpers.test.ts
+++ b/test/exportHelpers.test.ts
@@ -1,0 +1,70 @@
+import fs from 'fs';
+import JSZip from 'jszip';
+import { shell } from 'electron';
+
+jest.mock('electron', () => ({ shell: { openPath: jest.fn() } }));
+import {
+  buildExportIndices,
+  generateContent,
+  writeZipArchive,
+  ExportSettings,
+  ExportOptions
+} from '../app/ts/main/bulkwhois/export-helpers';
+import { settings } from '../app/ts/main/settings-main';
+
+describe('export helpers', () => {
+  const results = {
+    id: [1, 2],
+    domain: ['a.com', 'b.net'],
+    status: ['available', 'unavailable'],
+    registrar: ['reg1', 'reg2'],
+    company: ['c1', 'c2'],
+    creationdate: ['c', 'c2'],
+    updatedate: ['u', 'u2'],
+    expirydate: ['e', 'e2'],
+    whoisreply: ['reply1', 'reply2'],
+    whoisjson: ['json1', 'json2'],
+    requesttime: [1, 2]
+  };
+
+  const exportSettings: ExportSettings = {
+    separator: settings.lookupExport.separator,
+    enclosure: settings.lookupExport.enclosure,
+    linebreak: settings.lookupExport.linebreak,
+    filetypeText: settings.lookupExport.filetypeText,
+    filetypeCsv: settings.lookupExport.filetypeCsv,
+    filetypeZip: settings.lookupExport.filetypeZip,
+    openAfterExport: false
+  };
+
+  test('buildExportIndices filters available', () => {
+    const indices = buildExportIndices(results, {
+      domains: 'available',
+      errors: 'no'
+    } as ExportOptions);
+    expect(indices).toEqual([0]);
+  });
+
+  test('generateContent creates csv', () => {
+    const opts: ExportOptions = {
+      filetype: 'csv',
+      domains: 'available',
+      errors: 'no',
+      information: 'domain',
+      whoisreply: 'no'
+    };
+    const { content, zip } = generateContent(results, [0], opts, exportSettings);
+    expect(content).toContain('a.com');
+    expect(Object.keys(zip.files).length).toBe(0);
+  });
+
+  test('writeZipArchive writes zip and opens when requested', async () => {
+    const zip = new JSZip();
+    zip.file('test.txt', 'data');
+    jest.spyOn(fs.promises, 'writeFile').mockResolvedValueOnce();
+    const open = jest.spyOn(shell, 'openPath').mockResolvedValueOnce('');
+    await writeZipArchive(zip, '/tmp/out', '.zip', true);
+    expect(fs.promises.writeFile).toHaveBeenCalled();
+    expect(open).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- extract helper functions for bulk export
- simplify IPC handler to delegate to helpers
- cover helpers with unit tests

## Testing
- `npm run lint`
- `npm run format`
- `npx tsc --noEmit`
- `npm test` *(fails: Module did not self-register, better_sqlite3.node)*

------
https://chatgpt.com/codex/tasks/task_e_686ef61e5e608325b4163046a8bc0536