### PR TITLE
feat: add enum for whois options

### DIFF
--- a/app/ts/common/lookup.ts
+++ b/app/ts/common/lookup.ts
@@ -8,6 +8,12 @@ import { RequestCache, CacheOptions } from './requestCache.js';
 import { getProxy } from './proxy.js';
 import { randomInt } from '../utils/random.js';
 
+export enum WhoisOption {
+  Follow,
+  Timeout,
+  TimeBetween
+}
+
 const debug = debugFactory('common.whoisWrapper');
 
 const requestCache = new RequestCache();
@@ -81,13 +87,11 @@ export function convertDomain(domain: string, mode?: string): string {
 export function getWhoisOptions(): Record<string, unknown> {
   const { lookupGeneral: general } = getSettings();
 
-  const options: Record<string, unknown> = {},
-    follow = 'follow',
-    timeout = 'timeout';
+  const options: Record<string, unknown> = {};
 
   options.server = general.server;
-  options.follow = getWhoisParameters(follow);
-  options.timeout = getWhoisParameters(timeout);
+  options.follow = getWhoisParameters(WhoisOption.Follow);
+  options.timeout = getWhoisParameters(WhoisOption.Timeout);
   options.verbose = general.verbose;
   const proxy = getProxy();
   if (proxy) {
@@ -97,7 +101,7 @@ export function getWhoisOptions(): Record<string, unknown> {
   return options;
 }
 
-function getWhoisParameters(parameter: string): number | undefined {
+function getWhoisParameters(parameter: WhoisOption): number | undefined {
   const {
     lookupRandomizeFollow: follow,
     lookupRandomizeTimeout: timeout,
@@ -106,19 +110,19 @@ function getWhoisParameters(parameter: string): number | undefined {
   } = getSettings();
 
   switch (parameter) {
-    case 'follow':
+    case WhoisOption.Follow:
       debug(
         `Follow depth, 'random': ${follow.randomize}, 'maximum': ${follow.maximumDepth}, 'minimum': ${follow.minimumDepth}, 'default': ${general.follow}`
       );
       return follow.randomize
         ? randomInt(follow.minimumDepth, follow.maximumDepth)
         : general.follow;
-    case 'timeout':
+    case WhoisOption.Timeout:
       debug(
         `Timeout, 'random': ${timeout.randomize}, 'maximum': ${timeout.maximum}, 'minimum': ${timeout.minimum}, 'default': ${general.timeout}`
       );
       return timeout.randomize ? randomInt(timeout.minimum, timeout.maximum) : general.timeout;
-    case 'timebetween':
+    case WhoisOption.TimeBetween:
       debug(
         `Timebetween, 'random': ${timeBetween.randomize}, 'maximum': ${timeBetween.maximum}, 'minimum': ${timeBetween.minimum}, 'default': ${general.timeBetween}`
       );

--- a/test/whoiswrapper.test.ts
+++ b/test/whoiswrapper.test.ts
@@ -1,7 +1,7 @@
 import '../test/electronMock';
 
 import whois from 'whois';
-import { lookup } from '../app/ts/common/lookup';
+import { lookup, getWhoisOptions, WhoisOption } from '../app/ts/common/lookup';
 import { toJSON } from '../app/ts/common/parser';
 
 describe('whoiswrapper', () => {
@@ -31,5 +31,12 @@ describe('whoiswrapper', () => {
   test('toJSON returns "timeout" for timeout strings', () => {
     const result = toJSON('lookup: timeout');
     expect(result).toBe('timeout');
+  });
+
+  test('getWhoisOptions uses enum parameters', () => {
+    const opts = getWhoisOptions();
+    expect(typeof opts.follow).toBe('number');
+    expect(typeof opts.timeout).toBe('number');
+    expect(Object.values(WhoisOption)).toContain(WhoisOption.Follow);
   });
 });


### PR DESCRIPTION
## Summary
- introduce `WhoisOption` enum and refactor `getWhoisParameters` to use it
- update `getWhoisOptions` and tests to match new enum

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Module did not self-register)*
- `npm run test:e2e` *(fails: WebDriverError about user-data-dir)*

------
https://chatgpt.com/codex/tasks/task_e_686efedfd8708325b447e073595aeb1f