### PR TITLE
feat: add escapeRegex helper

### DIFF
--- a/app/ts/common/wordlist.ts
+++ b/app/ts/common/wordlist.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs';
 import { randomInt } from '../utils/random.js';
+import { escapeRegex } from '../utils/regex.js';
 
 export async function concatFiles(...files: string[]): Promise<string[]> {
   const lines: string[] = [];
@@ -133,7 +134,7 @@ export function deleteLinesContaining(lines: string[], str: string): string[] {
 }
 
 export function deleteString(lines: string[], str: string): string[] {
-  const regex = new RegExp(str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
+  const regex = new RegExp(escapeRegex(str), 'g');
   return lines.map((l) => l.replace(regex, ''));
 }
 
@@ -177,7 +178,7 @@ export function toUtf8Lines(lines: string[]): string[] {
 }
 
 export function replaceString(lines: string[], search: string, replacement: string): string[] {
-  const regex = new RegExp(search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
+  const regex = new RegExp(escapeRegex(search), 'g');
   return lines.map((l) => l.replace(regex, replacement));
 }
 

--- a/app/ts/utils/regex.ts
+++ b/app/ts/utils/regex.ts
@@ -1,0 +1,5 @@
+export function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export default { escapeRegex };

--- a/test/escapeRegex.test.ts
+++ b/test/escapeRegex.test.ts
@@ -1,0 +1,10 @@
+const { escapeRegex } = require('../app/ts/utils/regex');
+
+describe('escapeRegex', () => {
+  test('escapes special regex characters', () => {
+    const input = 'a+b*c?d.e^f$g(h)i|j[k]l\\m';
+    const escaped = escapeRegex(input);
+    const regex = new RegExp(escaped, 'g');
+    expect(regex.test(input)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce `escapeRegex` helper
- switch wordlist helpers to use `escapeRegex`
- test the new helper

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: better-sqlite3 module version mismatch)*
- `npm run test:e2e` *(fails: WebDriverError session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686f07da5d80832593918e04bb4f8dbc