### PR TITLE
Add tests for path IPC handlers

### DIFF
--- a/test/pathIpc.test.ts
+++ b/test/pathIpc.test.ts
@@ -1,0 +1,33 @@
+const ipcMainHandlers: Record<string, (...args: any[]) => any> = {};
+
+jest.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, listener: (...args: any[]) => any) => {
+      ipcMainHandlers[channel] = listener;
+    }
+  },
+  app: undefined,
+  BrowserWindow: class {},
+  Menu: {}
+}));
+
+import path from 'path';
+import '../app/ts/main/pathIpc';
+import { IpcChannel } from '../app/ts/common/ipcChannels';
+
+const getHandler = (c: string) => ipcMainHandlers[c];
+
+describe('path IPC handlers', () => {
+  test('path:join returns joined path', async () => {
+    const handler = getHandler(IpcChannel.PathJoin);
+    const result = await handler({}, '/tmp', 'foo', 'bar');
+    expect(result).toBe(path.join('/tmp', 'foo', 'bar'));
+  });
+
+  test('path:basename returns basename', async () => {
+    const handler = getHandler(IpcChannel.PathBasename);
+    const input = '/tmp/foo/bar.txt';
+    const result = await handler({}, input);
+    expect(result).toBe(path.basename(input));
+  });
+});


### PR DESCRIPTION
## Summary
- test `path:join` and `path:basename` IPC handlers

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: better-sqlite3 native module missing)*
- `npm run test:e2e` *(fails to start WebDriver session)*

------
https://chatgpt.com/codex/tasks/task_e_686f1591f2a48325a8cd800bdf57c84c