### PR TITLE
Add fetchCompat unit tests

### DIFF
--- a/test/fetchCompat.test.ts
+++ b/test/fetchCompat.test.ts
@@ -1,0 +1,30 @@
+import { ensureFetch } from '../app/ts/utils/fetchCompat';
+
+const nodeFetchMock = jest.fn();
+jest.mock('node-fetch', () => ({ __esModule: true, default: nodeFetchMock }), { virtual: true });
+
+describe('ensureFetch', () => {
+  const originalFetch = (global as any).fetch;
+
+  afterEach(() => {
+    if (originalFetch === undefined) {
+      delete (global as any).fetch;
+    } else {
+      (global as any).fetch = originalFetch;
+    }
+    nodeFetchMock.mockClear();
+  });
+
+  test('leaves existing fetch intact', async () => {
+    const customFetch = jest.fn();
+    (global as any).fetch = customFetch;
+    await ensureFetch();
+    expect((global as any).fetch).toBe(customFetch);
+  });
+
+  test('assigns node-fetch when fetch missing', async () => {
+    delete (global as any).fetch;
+    await ensureFetch();
+    expect((global as any).fetch).toBe(nodeFetchMock);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests ensuring `ensureFetch` uses node-fetch if needed

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: better-sqlite3 and others not built for this Node)*
- `npm run test:e2e` *(fails: WebDriver session error)*

------
https://chatgpt.com/codex/tasks/task_e_686f1574082883259360e263269d7a06