### PR TITLE
Add path IPC tests

### DIFF
--- a/app/ts/cli.ts
+++ b/app/ts/cli.ts
@@ -64,6 +64,7 @@ export function parseArgs(argv: string[]): CliOptions {
       }
       return true;
     })
+    .exitProcess(false)
     .parseSync();
   return {
     domains: args.domain ?? [],

--- a/app/ts/common/whoiswrapper/patterns.ts
+++ b/app/ts/common/whoiswrapper/patterns.ts
@@ -232,6 +232,14 @@ function compileSpec(spec: PatternSpec, defaultResult: string): CompiledPattern 
 }
 
 export function buildPatterns(): void {
+  // Update pattern results based on current settings
+  (patterns.special as any)[1].result = appSettings.lookupAssumptions.uniregistry
+    ? 'unavailable'
+    : 'error:ratelimiting';
+  const uniq1 = (patterns.available as any).unique?.[1];
+  if (Array.isArray(uniq1) && uniq1[0]) {
+    (uniq1[0] as any).result = appSettings.lookupAssumptions.expired ? 'expired' : 'available';
+  }
   builtPatterns.special = [];
   builtPatterns.available = [];
   builtPatterns.unavailable = [];

--- a/test/pathIpc.test.ts
+++ b/test/pathIpc.test.ts
@@ -1,0 +1,31 @@
+const ipcMainHandlers: Record<string, (...args: any[]) => any> = {};
+
+jest.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, listener: (...args: any[]) => any) => {
+      ipcMainHandlers[channel] = listener;
+    }
+  },
+  app: undefined,
+  BrowserWindow: class {},
+  Menu: {}
+}));
+
+import path from 'path';
+import '../app/ts/main/pathIpc';
+
+const handler = (channel: string) => ipcMainHandlers[channel];
+
+describe('path IPC handlers', () => {
+  test('path:join matches path.join', async () => {
+    const args = ['/foo', 'bar', 'baz.txt'];
+    const result = await handler('path:join')({} as any, ...args);
+    expect(result).toBe(path.join(...args));
+  });
+
+  test('path:basename matches path.basename', async () => {
+    const p = '/foo/bar/baz.txt';
+    const result = await handler('path:basename')({} as any, p);
+    expect(result).toBe(path.basename(p));
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for pathIpc handlers
- update patterns builder to honour current settings
- prevent CLI from exiting process during tests

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686f157738808325907ea53d2d302c1f