### PR TITLE
test: add logger utilities test

### DIFF
--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -1,0 +1,44 @@
+const debugMock = jest.fn((namespace: string) => {
+  const fn = jest.fn();
+  (fn as any).namespace = namespace;
+  return fn;
+});
+
+jest.mock('debug', () => ({
+  __esModule: true,
+  default: (ns: string) => debugMock(ns)
+}));
+
+describe('logger utilities', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    debugMock.mockClear();
+  });
+
+  test('debugFactory returns function with namespace', () => {
+    const { debugFactory } = require('../app/ts/common/logger.ts');
+    const fn = debugFactory('x');
+    expect(debugMock).toHaveBeenCalledWith('x');
+    expect(typeof fn).toBe('function');
+    expect((fn as any).namespace).toBe('x');
+  });
+
+  test('errorFactory appends :error', () => {
+    const { errorFactory } = require('../app/ts/common/logger.ts');
+    const fn = errorFactory('x');
+    expect(debugMock).toHaveBeenCalledWith('x:error');
+    expect((fn as any).namespace).toBe('x:error');
+  });
+
+  test('renderer logger functions call debug functions', () => {
+    const { sendDebug, sendError } = require('../app/ts/renderer/logger.ts');
+    expect(debugMock).toHaveBeenCalledWith('renderer');
+    expect(debugMock).toHaveBeenCalledWith('renderer:error');
+    const debugFn = debugMock.mock.results[0].value;
+    const errorFn = debugMock.mock.results[1].value;
+    sendDebug('dmsg');
+    expect(debugFn).toHaveBeenCalledWith('dmsg');
+    sendError('emsg');
+    expect(errorFn).toHaveBeenCalledWith('emsg');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for logger factories

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Module did not self-register for better-sqlite3)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686f18623ce48325a13d9242847ae6db