### PR TITLE
test: cover server error cases

### DIFF
--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -12,6 +12,9 @@ import { createServer } from '../app/ts/server/index';
 import { lookup } from '../app/ts/common/lookup';
 import { lookupDomains } from '../app/ts/cli';
 
+const mockLookup = lookup as jest.Mock;
+const mockLookupDomains = lookupDomains as jest.Mock;
+
 const app = createServer();
 
 describe('server endpoints', () => {
@@ -22,6 +25,19 @@ describe('server endpoints', () => {
     expect(lookup).toHaveBeenCalledWith('example.com');
   });
 
+  test('POST /lookup without domain returns 400', async () => {
+    const res = await request(app).post('/lookup').send({});
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'domain required' });
+  });
+
+  test('POST /lookup handles errors', async () => {
+    mockLookup.mockRejectedValueOnce(new Error('fail'));
+    const res = await request(app).post('/lookup').send({ domain: 'bad.com' });
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'fail' });
+  });
+
   test('POST /bulk-lookup returns data', async () => {
     const res = await request(app)
       .post('/bulk-lookup')
@@ -29,5 +45,12 @@ describe('server endpoints', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ result: ['bulk-data'] });
     expect(lookupDomains).toHaveBeenCalled();
+  });
+
+  test('POST /bulk-lookup handles errors', async () => {
+    mockLookupDomains.mockRejectedValueOnce(new Error('fail'));
+    const res = await request(app).post('/bulk-lookup').send({ domains: [] });
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'fail' });
   });
 });


### PR DESCRIPTION
## Summary
- improve server endpoint tests to check error handling

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm test` *(fails: better-sqlite3 module mismatch)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_686f2495ebd08325a4899d7337d2790f