### PR TITLE
fix: improve bulk whois result typing

### DIFF
--- a/app/ts/main/bulkwhois/export-helpers.ts
+++ b/app/ts/main/bulkwhois/export-helpers.ts
@@ -109,7 +109,10 @@ export function generateContent(
         body += formatString('{1}{0}{2}{0}', e, s, results.whoisreply[i]);
         break;
       case 'yes+inlineseparate':
-        zip.file(results.domain[i] + csv, results.whoisjson[i] ?? '');
+        zip.file(
+          results.domain[i] + csv,
+          results.whoisjson[i] ? JSON.stringify(results.whoisjson[i]) : ''
+        );
         break;
       case 'yes+block':
         zip.file(results.domain[i] + txt, results.whoisreply[i] ?? '');

--- a/app/ts/main/bulkwhois/resultHandler.ts
+++ b/app/ts/main/bulkwhois/resultHandler.ts
@@ -164,6 +164,6 @@ export async function processData(
   results.updatedate[index] = resultFilter.updatedate;
   results.expirydate[index] = resultFilter.expirydate;
   results.whoisreply[index] = resultFilter.whoisreply;
-  results.whoisjson[index] = resultFilter.whoisjson as any;
+  results.whoisjson[index] = resultFilter.whoisjson;
   results.requesttime[index] = resultFilter.requesttime;
 }

--- a/app/ts/main/bulkwhois/types.ts
+++ b/app/ts/main/bulkwhois/types.ts
@@ -50,7 +50,7 @@ export interface BulkWhoisResults {
   creationdate: (string | null)[];
   expirydate: (string | null)[];
   whoisreply: (string | null)[];
-  whoisjson: (string | null)[];
+  whoisjson: (Record<string, unknown> | null)[];
   requesttime: (string | number | null)[];
 }
 

--- a/test/exportError.test.ts
+++ b/test/exportError.test.ts
@@ -25,7 +25,7 @@ describe('bw export error handling', () => {
     updatedate: ['u'],
     expirydate: ['e'],
     whoisreply: ['reply'],
-    whoisjson: ['json'],
+    whoisjson: [{ foo: 'bar' }],
     requesttime: [1]
   };
 

--- a/test/exportHelpers.test.ts
+++ b/test/exportHelpers.test.ts
@@ -23,7 +23,7 @@ describe('export helpers', () => {
     updatedate: ['u', 'u2'],
     expirydate: ['e', 'e2'],
     whoisreply: ['reply1', 'reply2'],
-    whoisjson: ['json1', 'json2'],
+    whoisjson: [{ foo: 'bar1' }, { foo: 'bar2' }],
     requesttime: [1, 2]
   };
 

--- a/test/exportOptions.test.ts
+++ b/test/exportOptions.test.ts
@@ -15,7 +15,7 @@ const results = {
   updatedate: ['u'],
   expirydate: ['e'],
   whoisreply: ['reply'],
-  whoisjson: ['json'],
+  whoisjson: [{ foo: 'bar' }],
   requesttime: [1]
 };
 


### PR DESCRIPTION
## Summary
- type whoisjson results as parsed objects
- drop unnecessary cast
- store JSON in export zip
- update unit tests

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: better_sqlite3.node binary mismatch)*
- `npm run test:e2e` *(fails to start webdriver)*

------
https://chatgpt.com/codex/tasks/task_e_686fff79634883258f5e59464db5cc3d