### PR TITLE
feat: introduce DomainStatus enum

### DIFF
--- a/app/ts/cli.ts
+++ b/app/ts/cli.ts
@@ -8,6 +8,7 @@ import { lookup as whoisLookup } from './common/lookup.js';
 import { settings } from './common/settings.js';
 import { RequestCache } from './common/requestCache.js';
 import { isDomainAvailable, getDomainParameters, WhoisResult } from './common/availability.js';
+import DomainStatus from './common/status.js';
 import { toJSON } from './common/parser.js';
 import { generateFilename } from './cli/export.js';
 import { downloadModel } from './ai/modelDownloader.js';
@@ -108,7 +109,7 @@ export async function lookupDomains(opts: CliOptions): Promise<WhoisResult[]> {
       const params = getDomainParameters(domain, status, data, json);
       results.push(params);
     } catch {
-      results.push({ domain, status: 'error', whoisreply: '' });
+      results.push({ domain, status: DomainStatus.Error, whoisreply: '' });
     }
   }
   return results;

--- a/app/ts/common/dnsLookup.ts
+++ b/app/ts/common/dnsLookup.ts
@@ -5,6 +5,7 @@ import { convertDomain } from './lookup.js';
 import { settings, Settings } from './settings.js';
 import { RequestCache, CacheOptions } from './requestCache.js';
 import { DnsLookupError, Result } from './errors.js';
+import DomainStatus from './status.js';
 
 const debug = debugFactory('common.dnsLookup');
 
@@ -81,13 +82,13 @@ export async function hasNsServers(host: string): Promise<Result<boolean, DnsLoo
   .returns
     result (string) - Availability status
  */
-export function isDomainAvailable(data: Result<boolean, DnsLookupError>): string {
-  let result: string;
+export function isDomainAvailable(data: Result<boolean, DnsLookupError>): DomainStatus {
+  let result: DomainStatus;
 
   if (data.ok) {
-    result = data.value ? 'unavailable' : 'available';
+    result = data.value ? DomainStatus.Unavailable : DomainStatus.Available;
   } else {
-    result = 'error';
+    result = DomainStatus.Error;
   }
 
   debug(`Checked for availability from data ${JSON.stringify(data)} with result: ${result}`);

--- a/app/ts/common/status.ts
+++ b/app/ts/common/status.ts
@@ -1,0 +1,17 @@
+export enum DomainStatus {
+  Available = 'available',
+  Unavailable = 'unavailable',
+  Expired = 'expired',
+  Error = 'error',
+  ErrorNoContent = 'error:nocontent',
+  ErrorUnauthorized = 'error:unauthorized',
+  ErrorRateLimiting = 'error:ratelimiting',
+  ErrorUnretrievable = 'error:unretrivable',
+  ErrorForbidden = 'error:forbidden',
+  ErrorReservedByRegulator = 'error:reservedbyregulator',
+  ErrorUnregistrable = 'error:unregistrable',
+  ErrorReplyError = 'error:replyerror',
+  ErrorUnparsable = 'error:unparsable'
+}
+
+export default DomainStatus;

--- a/app/ts/main/singlewhois.ts
+++ b/app/ts/main/singlewhois.ts
@@ -2,6 +2,7 @@ import { ipcMain, clipboard, shell } from 'electron';
 import type { IpcMainEvent } from 'electron';
 import { lookup as whoisLookup } from '../common/lookup.js';
 import { isDomainAvailable } from '../common/availability.js';
+import DomainStatus from '../common/status.js';
 import { addEntry as addHistoryEntry } from '../common/history.js';
 import { debugFactory } from '../common/logger.js';
 const debug = debugFactory('main.singlewhois');
@@ -23,12 +24,12 @@ ipcMain.handle(IpcChannel.SingleWhoisLookup, async (_event, domain) => {
       const status = isDomainAvailable(data);
       addHistoryEntry(domain, status);
     } catch {
-      addHistoryEntry(domain, 'error');
+      addHistoryEntry(domain, DomainStatus.Error);
     }
     return data;
   } catch (err) {
     debug('Whois lookup threw an error');
-    addHistoryEntry(domain, 'error');
+    addHistoryEntry(domain, DomainStatus.Error);
     throw err;
   }
 });

--- a/app/ts/main/utils.ts
+++ b/app/ts/main/utils.ts
@@ -1,6 +1,7 @@
 import { ipcMain, shell } from 'electron';
 import Papa from 'papaparse';
 import { isDomainAvailable, getDomainParameters } from '../common/availability.js';
+import DomainStatus from '../common/status.js';
 import { IpcChannel } from '../common/ipcChannels.js';
 import { toJSON } from '../common/parser.js';
 import { getUserDataPath } from '../common/settings.js';
@@ -18,7 +19,7 @@ ipcMain.handle(
   async (
     _e,
     domain: string | null,
-    status: string | null,
+    status: DomainStatus | null,
     text: string,
     json?: Record<string, unknown>
   ) => {

--- a/app/ts/renderer/singlewhois.ts
+++ b/app/ts/renderer/singlewhois.ts
@@ -13,6 +13,7 @@ import { formatString } from '../common/stringformat.js';
 import $ from '../../vendor/jquery.js';
 (window as any).$ = (window as any).jQuery = $;
 import { debugFactory, errorFactory } from '../common/logger.js';
+import DomainStatus from '../common/status.js';
 
 const debug = debugFactory('renderer.singlewhois');
 const error = errorFactory('renderer.singlewhois');
@@ -67,7 +68,7 @@ async function handleResults(domainResults: string) {
   const { domain, updateDate, registrar, creationDate, company, expiryDate } = resultFilter;
 
   switch (domainStatus) {
-    case 'unavailable':
+    case DomainStatus.Unavailable:
       $('#singlewhoisMessageUnavailable').removeClass('is-hidden');
       $('#singlewhoisMessageWhoisResults').text(domainResults);
 
@@ -82,7 +83,7 @@ async function handleResults(domainResults: string) {
       $('#singlewhoisTableWhoisinfo.is-hidden').removeClass('is-hidden');
       break;
 
-    case 'available':
+    case DomainStatus.Available:
       $('#singlewhoisMessageWhoisResults').text(domainResults);
       $('#singlewhoisMessageAvailable').removeClass('is-hidden');
       break;

--- a/test/availabilityModel.test.ts
+++ b/test/availabilityModel.test.ts
@@ -4,6 +4,7 @@ import '../test/electronMock';
 import { loadModel, predict } from '../app/ts/ai/availabilityModel';
 import { settings, getUserDataPath } from '../app/ts/common/settings';
 import { trainFromSamples } from '../scripts/train-ai';
+import DomainStatus from '../app/ts/common/status';
 
 const modelDir = 'ai-test-model';
 
@@ -30,6 +31,6 @@ describe('availabilityModel', () => {
 
     await loadModel(settings.ai.modelPath);
     const res = predict('Domain Status:ok');
-    expect(res).toBe('available');
+    expect(res).toBe(DomainStatus.Available);
   });
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { parseArgs, lookupDomains, exportResults, CliOptions } from '../app/ts/cli';
+import DomainStatus from '../app/ts/common/status';
 import { lookup as whoisLookup } from '../app/ts/common/lookup';
 
 jest.mock('../app/ts/common/lookup', () => ({ lookup: jest.fn() }));
@@ -43,7 +44,7 @@ describe('cli utility', () => {
     mockLookup.mockRejectedValueOnce(new Error('fail'));
     const opts: CliOptions = { domains: ['bad.com'], tlds: ['com'], format: 'txt' };
     const results = await lookupDomains(opts);
-    expect(results).toEqual([{ domain: 'bad.com', status: 'error', whoisreply: '' }]);
+    expect(results).toEqual([{ domain: 'bad.com', status: DomainStatus.Error, whoisreply: '' }]);
   });
 
   test('exportResults writes csv output', async () => {

--- a/test/dnsLookup.test.ts
+++ b/test/dnsLookup.test.ts
@@ -2,6 +2,7 @@ import '../test/electronMock';
 
 import dns from 'dns/promises';
 import { nsLookup, hasNsServers, isDomainAvailable } from '../app/ts/common/dnsLookup';
+import DomainStatus from '../app/ts/common/status';
 import { DnsLookupError } from '../app/ts/common/errors';
 
 describe('dnsLookup', () => {
@@ -43,15 +44,15 @@ describe('dnsLookup', () => {
   });
 
   test('isDomainAvailable returns unavailable for true', () => {
-    expect(isDomainAvailable({ ok: true, value: true })).toBe('unavailable');
+    expect(isDomainAvailable({ ok: true, value: true })).toBe(DomainStatus.Unavailable);
   });
 
   test('isDomainAvailable returns available for false', () => {
-    expect(isDomainAvailable({ ok: true, value: false })).toBe('available');
+    expect(isDomainAvailable({ ok: true, value: false })).toBe(DomainStatus.Available);
   });
 
   test("isDomainAvailable returns 'error' on error result", () => {
     const error = new DnsLookupError('fail');
-    expect(isDomainAvailable({ ok: false, error })).toBe('error');
+    expect(isDomainAvailable({ ok: false, error })).toBe(DomainStatus.Error);
   });
 });

--- a/test/getDomainParameters.test.ts
+++ b/test/getDomainParameters.test.ts
@@ -1,4 +1,5 @@
 import { getDomainParameters } from '../app/ts/common/availability';
+import DomainStatus from '../app/ts/common/status';
 
 describe('getDomainParameters', () => {
   test('returns expected domain info from whois JSON', () => {
@@ -10,10 +11,10 @@ describe('getDomainParameters', () => {
       registryExpiryDate: '2030-01-01'
     };
     const reply = 'Domain: example.com';
-    const result = getDomainParameters('example.com', 'registered', reply, resultsJSON);
+    const result = getDomainParameters('example.com', DomainStatus.Unavailable, reply, resultsJSON);
     expect(result).toEqual({
       domain: 'example.com',
-      status: 'registered',
+      status: DomainStatus.Unavailable,
       registrar: 'Example Registrar',
       company: 'Example Org',
       creationDate: new Date('2000-01-01').toUTCString(),

--- a/test/history.test.ts
+++ b/test/history.test.ts
@@ -1,5 +1,6 @@
 import '../test/electronMock';
 import { getUserDataPath } from '../app/ts/renderer/settings-renderer';
+import DomainStatus from '../app/ts/common/status';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -23,24 +24,24 @@ describe('history module', () => {
   });
 
   test('stores and retrieves an entry', () => {
-    history.addEntry('example.com', 'available');
+    history.addEntry('example.com', DomainStatus.Available);
     const items = history.getHistory(1);
     expect(items[0].domain).toBe('example.com');
-    expect(items[0].status).toBe('available');
+    expect(items[0].status).toBe(DomainStatus.Available);
   });
 
   test('bulk insertion works', () => {
     history.clearHistory();
     history.addEntries([
-      { domain: 'a.com', status: 'available' },
-      { domain: 'b.com', status: 'unavailable' }
+      { domain: 'a.com', status: DomainStatus.Available },
+      { domain: 'b.com', status: DomainStatus.Unavailable }
     ]);
     const items = history.getHistory(2);
     expect(items.length).toBe(2);
   });
 
   test('clearHistory removes all', () => {
-    history.addEntry('c.com', 'error');
+    history.addEntry('c.com', DomainStatus.Error);
     history.clearHistory();
     expect(history.getHistory().length).toBe(0);
   });

--- a/test/isDomainAvailable.test.ts
+++ b/test/isDomainAvailable.test.ts
@@ -1,29 +1,30 @@
 import '../test/electronMock';
 
 import { isDomainAvailable } from '../app/ts/common/availability';
+import DomainStatus from '../app/ts/common/status';
 
 describe('isDomainAvailable', () => {
   test('detects available domains from no match message', () => {
     const reply = 'No match for domain "example.com".';
-    expect(isDomainAvailable(reply)).toBe('available');
+    expect(isDomainAvailable(reply)).toBe(DomainStatus.Available);
   });
 
   test('detects unavailable domains from whois data', () => {
     const reply = 'Domain Status:ok\nExpiration Date: 2099-01-01';
-    expect(isDomainAvailable(reply)).toBe('unavailable');
+    expect(isDomainAvailable(reply)).toBe(DomainStatus.Unavailable);
   });
 
   test('handles rate limit messages', () => {
     const reply = 'Your connection limit exceeded.';
-    expect(isDomainAvailable(reply)).toBe('error:ratelimiting');
+    expect(isDomainAvailable(reply)).toBe(DomainStatus.ErrorRateLimiting);
   });
 
   test('handles not found messages', () => {
     const reply = 'NOT FOUND';
-    expect(isDomainAvailable(reply)).toBe('available');
+    expect(isDomainAvailable(reply)).toBe(DomainStatus.Available);
   });
 
   test('returns error for empty replies', () => {
-    expect(isDomainAvailable('')).toBe('error:nocontent');
+    expect(isDomainAvailable('')).toBe(DomainStatus.ErrorNoContent);
   });
 });

--- a/test/isDomainAvailableAi.test.ts
+++ b/test/isDomainAvailableAi.test.ts
@@ -5,6 +5,7 @@ import { settings, getUserDataPath } from '../app/ts/renderer/settings-renderer'
 import { loadModel } from '../app/ts/ai/availabilityModel';
 import { trainFromSamples } from '../scripts/train-ai';
 import { isDomainAvailable } from '../app/ts/common/availability';
+import DomainStatus from '../app/ts/common/status';
 
 describe('isDomainAvailable with AI', () => {
   const dir = 'ai-int';
@@ -31,6 +32,6 @@ describe('isDomainAvailable with AI', () => {
 
   test('returns ai prediction when enabled', () => {
     const res = isDomainAvailable('Domain Status:ok');
-    expect(res).toBe('available');
+    expect(res).toBe(DomainStatus.Available);
   });
 });

--- a/test/mainUtils.test.ts
+++ b/test/mainUtils.test.ts
@@ -28,6 +28,7 @@ jest.mock('../app/ts/common/parser', () => ({
 import { IpcChannel } from '../app/ts/common/ipcChannels';
 import '../app/ts/main/utils';
 import { isDomainAvailable, getDomainParameters } from '../app/ts/common/availability';
+import DomainStatus from '../app/ts/common/status';
 import { toJSON } from '../app/ts/common/parser';
 import { getUserDataPath } from '../app/ts/common/settings';
 
@@ -52,20 +53,25 @@ describe('main utils IPC handlers', () => {
   });
 
   test('availability check handler calls isDomainAvailable', async () => {
-    (isDomainAvailable as jest.Mock).mockReturnValue('available');
+    (isDomainAvailable as jest.Mock).mockReturnValue(DomainStatus.Available);
     const handler = getHandler(IpcChannel.AvailabilityCheck);
     const result = await handler({}, 'data');
     expect(isDomainAvailable).toHaveBeenCalledWith('data');
-    expect(result).toBe('available');
+    expect(result).toBe(DomainStatus.Available);
   });
 
   test('domain parameters handler falls back to toJSON', async () => {
     (toJSON as jest.Mock).mockReturnValue({ j: 1 });
     (getDomainParameters as jest.Mock).mockReturnValue('params');
     const handler = getHandler(IpcChannel.DomainParameters);
-    const result = await handler({}, 'example.com', 'avail', 'reply');
+    const result = await handler({}, 'example.com', DomainStatus.Available, 'reply');
     expect(toJSON).toHaveBeenCalledWith('reply');
-    expect(getDomainParameters).toHaveBeenCalledWith('example.com', 'avail', 'reply', { j: 1 });
+    expect(getDomainParameters).toHaveBeenCalledWith(
+      'example.com',
+      DomainStatus.Available,
+      'reply',
+      { j: 1 }
+    );
     expect(result).toBe('params');
   });
 

--- a/test/patterns.test.ts
+++ b/test/patterns.test.ts
@@ -3,6 +3,7 @@ import '../test/electronMock';
 import { buildPatterns, checkPatterns } from '../app/ts/common/whoiswrapper/patterns';
 import { builtPatterns } from '../app/ts/common/whoiswrapper/patterns';
 import { settings } from '../app/ts/common/settings';
+import DomainStatus from '../app/ts/common/status';
 
 const electron = (global as any).window.electron;
 
@@ -18,26 +19,26 @@ describe('whois patterns', () => {
 
   test('detects available replies', () => {
     const reply = 'No match for domain "example.com".';
-    expect(checkPatterns(reply)).toBe('available');
+    expect(checkPatterns(reply)).toBe(DomainStatus.Available);
   });
 
   test('detects unavailable replies', () => {
     const reply = 'Domain Status:ok\nExpiration Date: 2099-01-01';
-    expect(checkPatterns(reply)).toBe('unavailable');
+    expect(checkPatterns(reply)).toBe(DomainStatus.Unavailable);
   });
 
   test('detects rate limit errors', () => {
     const reply = 'Your connection limit exceeded.';
-    expect(checkPatterns(reply)).toBe('error:ratelimiting');
+    expect(checkPatterns(reply)).toBe(DomainStatus.ErrorRateLimiting);
   });
 
   test('detects not found replies', () => {
     const reply = 'NOT FOUND';
-    expect(checkPatterns(reply)).toBe('available');
+    expect(checkPatterns(reply)).toBe(DomainStatus.Available);
   });
 
   test('returns error for empty replies', () => {
-    expect(checkPatterns('')).toBe('error:nocontent');
+    expect(checkPatterns('')).toBe(DomainStatus.ErrorNoContent);
   });
 
   test('patterns are built in numeric order', () => {
@@ -56,12 +57,12 @@ describe('whois patterns', () => {
     expect(typeof handler).toBe('function');
 
     const reply = 'Uniregistry - Query limit exceeded';
-    expect(checkPatterns(reply)).toBe('unavailable');
+    expect(checkPatterns(reply)).toBe(DomainStatus.Unavailable);
 
     settings.lookupAssumptions.uniregistry = false;
     handler();
 
-    expect(checkPatterns(reply)).toBe('error:ratelimiting');
+    expect(checkPatterns(reply)).toBe(DomainStatus.ErrorRateLimiting);
 
     settings.lookupAssumptions.uniregistry = true;
     handler();

--- a/test/resultHandler.test.ts
+++ b/test/resultHandler.test.ts
@@ -2,6 +2,7 @@ import { performance } from 'perf_hooks';
 import defaultBulkWhois from '../app/ts/main/bulkwhois/process.defaults';
 import { processData } from '../app/ts/main/bulkwhois/resultHandler';
 import { settings } from '../app/ts/main/settings-main';
+import DomainStatus from '../app/ts/common/status';
 
 jest.mock('../app/ts/common/availability', () => ({
   isDomainAvailable: jest.fn(),
@@ -42,11 +43,11 @@ describe('processData', () => {
 
     jest.spyOn(performance, 'now').mockReturnValue(50);
 
-    (isDomainAvailable as jest.Mock).mockReturnValue('available');
+    (isDomainAvailable as jest.Mock).mockReturnValue(DomainStatus.Available);
     (toJSON as jest.Mock).mockReturnValue({});
     (getDomainParameters as jest.Mock).mockReturnValue({
       domain: 'example.com',
-      status: 'available',
+      status: DomainStatus.Available,
       registrar: 'reg',
       company: 'comp',
       creationDate: 'c',
@@ -65,7 +66,7 @@ describe('processData', () => {
     expect(bulk.stats.status.available).toBe(1);
     expect(bulk.stats.domains.waiting).toBe(0);
     expect(bulk.results.domain[0]).toBe('example.com');
-    expect(bulk.results.status[0]).toBe('available');
+    expect(bulk.results.status[0]).toBe(DomainStatus.Available);
     expect(bulk.results.registrar[0]).toBe('reg');
     expect(bulk.results.requesttime[0]).toBe(50);
 
@@ -103,14 +104,14 @@ describe('processData', () => {
 
     jest.spyOn(performance, 'now').mockReturnValue(30);
 
-    (dnsIsDomainAvailable as jest.Mock).mockReturnValue('unavailable');
+    (dnsIsDomainAvailable as jest.Mock).mockReturnValue(DomainStatus.Unavailable);
 
     await processData(bulk, reqtime, event, 'example.com', 0, { ok: true, value: true }, false);
 
     expect(bulk.stats.reqtimes.minimum).toBe(30);
     expect(bulk.stats.status.unavailable).toBe(1);
     expect(bulk.results.domain[0]).toBe('example.com');
-    expect(bulk.results.status[0]).toBe('unavailable');
+    expect(bulk.results.status[0]).toBe(DomainStatus.Unavailable);
     expect(bulk.results.registrar[0]).toBeNull();
     expect(bulk.results.requesttime[0]).toBe(30);
 

--- a/test/trainAi.test.ts
+++ b/test/trainAi.test.ts
@@ -1,4 +1,5 @@
 import { trainFromSamples, predict } from '../scripts/train-ai';
+import DomainStatus from '../app/ts/common/status';
 
 describe('train-ai', () => {
   test('predicts labels after training', () => {
@@ -7,7 +8,7 @@ describe('train-ai', () => {
       { text: 'Domain Status:ok\nExpiry Date:2030-01-01', label: 'unavailable' }
     ];
     const model = trainFromSamples(samples);
-    expect(predict(model, 'Domain Status:ok')).toBe('unavailable');
-    expect(predict(model, 'No match for domain test')).toBe('available');
+    expect(predict(model, 'Domain Status:ok')).toBe(DomainStatus.Unavailable);
+    expect(predict(model, 'No match for domain test')).toBe(DomainStatus.Available);
   });
 });


### PR DESCRIPTION
## Summary
- add `DomainStatus` enum in common code
- refactor availability and DNS helpers to use the enum
- update main process, CLI and renderer to consume enum values
- update unit tests for new enum

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: better_sqlite3 module not built)*
- `npm run test:e2e` *(fails: better_sqlite3 module not built)*

------
https://chatgpt.com/codex/tasks/task_e_686fff5af9ec83259459db077de8f8ba