### PR TITLE
feat: centralize time estimate calculation

### DIFF
--- a/app/ts/renderer/bulkwhois/estimate.ts
+++ b/app/ts/renderer/bulkwhois/estimate.ts
@@ -1,0 +1,19 @@
+import { msToHumanTime } from '../../common/conversions.js';
+import type { Settings } from '../../common/settings-base.js';
+
+export function getTimeEstimates(
+  lineCount: number,
+  settings: Settings
+): { min: string; max?: string } {
+  if (settings.lookupRandomizeTimeBetween.randomize) {
+    const minMs = lineCount * settings.lookupRandomizeTimeBetween.minimum;
+    const maxMs = lineCount * settings.lookupRandomizeTimeBetween.maximum;
+    return {
+      min: msToHumanTime(minMs),
+      max: msToHumanTime(maxMs)
+    };
+  }
+
+  const ms = lineCount * settings.lookupGeneral.timeBetween;
+  return { min: msToHumanTime(ms) };
+}

--- a/app/ts/renderer/bulkwhois/fileinput.ts
+++ b/app/ts/renderer/bulkwhois/fileinput.ts
@@ -26,6 +26,7 @@ import { formatString } from '../../common/stringformat.js';
 import { settings } from '../settings-renderer.js';
 import { IpcChannel } from '../../common/ipcChannels.js';
 import { FileWatcherManager } from '../../utils/fileWatcher.js';
+import { getTimeEstimates } from './estimate.js';
 
 let bwFileContents: Buffer;
 const watcher = new FileWatcherManager(electron.watch);
@@ -44,14 +45,11 @@ async function refreshBwFile(pathToFile: string): Promise<void> {
     bwFileContents = await electron.bwFileRead(pathToFile);
     bwFileStats.linecount = bwFileContents.toString().split('\n').length;
 
-    if (lookup.randomize.timeBetween.randomize === true) {
-      bwFileStats.minestimate = conversions.msToHumanTime(
-        bwFileStats.linecount! * lookup.randomize.timeBetween.minimum
-      );
-      bwFileStats.maxestimate = conversions.msToHumanTime(
-        bwFileStats.linecount! * lookup.randomize.timeBetween.maximum
-      );
+    const estimate = getTimeEstimates(bwFileStats.linecount!, settings);
+    bwFileStats.minestimate = estimate.min;
+    bwFileStats.maxestimate = estimate.max;
 
+    if (estimate.max) {
       $('#bwFileSpanTimebetweenmin').text(
         formatString('{0}ms ', lookup.randomize.timeBetween.minimum)
       );
@@ -62,9 +60,6 @@ async function refreshBwFile(pathToFile: string): Promise<void> {
         formatString('{0} to {1}', bwFileStats.minestimate, bwFileStats.maxestimate)
       );
     } else {
-      bwFileStats.minestimate = conversions.msToHumanTime(
-        bwFileStats.linecount! * settings.lookupGeneral.timeBetween
-      );
       $('#bwFileSpanTimebetweenminmax').addClass('is-hidden');
       $('#bwFileSpanTimebetweenmin').text(settings.lookupGeneral.timeBetween + 'ms');
       $('#bwFileTdEstimate').text(formatString('> {0}', bwFileStats.minestimate));
@@ -147,14 +142,11 @@ async function handleFileConfirmation(
     $('#bwFileSpanInfo').text('Getting line count...');
     bwFileStats.linecount = bwFileContents.toString().split('\n').length;
 
-    if (lookup.randomize.timeBetween.randomize === true) {
-      bwFileStats.minestimate = conversions.msToHumanTime(
-        bwFileStats.linecount! * lookup.randomize.timeBetween.minimum
-      );
-      bwFileStats.maxestimate = conversions.msToHumanTime(
-        bwFileStats.linecount! * lookup.randomize.timeBetween.maximum
-      );
+    const estimate = getTimeEstimates(bwFileStats.linecount!, settings);
+    bwFileStats.minestimate = estimate.min;
+    bwFileStats.maxestimate = estimate.max;
 
+    if (estimate.max) {
       $('#bwFileSpanTimebetweenmin').text(
         formatString('{0}ms ', lookup.randomize.timeBetween.minimum)
       );
@@ -165,9 +157,6 @@ async function handleFileConfirmation(
         formatString('{0} to {1}', bwFileStats.minestimate, bwFileStats.maxestimate)
       );
     } else {
-      bwFileStats.minestimate = conversions.msToHumanTime(
-        bwFileStats.linecount! * settings.lookupGeneral.timeBetween
-      );
       $('#bwFileSpanTimebetweenminmax').addClass('is-hidden');
       $('#bwFileSpanTimebetweenmin').text(settings.lookupGeneral.timeBetween + 'ms');
       $('#bwFileTdEstimate').text(formatString('> {0}', bwFileStats.minestimate));

--- a/app/ts/renderer/bulkwhois/wordlistinput.ts
+++ b/app/ts/renderer/bulkwhois/wordlistinput.ts
@@ -9,6 +9,7 @@ const electron = (window as any).electron as {
 };
 import { tableReset } from './auxiliary.js';
 import $ from '../../../vendor/jquery.js';
+import { getTimeEstimates } from './estimate.js';
 
 const debug = debugFactory('bulkwhois.wordlistinput');
 const error = errorFactory('bulkwhois.wordlistinput');
@@ -51,13 +52,11 @@ function handleWordlistConfirmation(): void {
     $('#bwWordlistSpanInfo').text('Getting line count...');
     bwFileStats['linecount'] = bwWordlistContents.toString().split('\n').length;
 
-    if (settings.lookupRandomizeTimeBetween.randomize === true) {
-      bwFileStats['minestimate'] = conversions.msToHumanTime(
-        bwFileStats['linecount'] * settings.lookupRandomizeTimeBetween.minimum
-      );
-      bwFileStats['maxestimate'] = conversions.msToHumanTime(
-        bwFileStats['linecount'] * settings.lookupRandomizeTimeBetween.maximum
-      );
+    const estimate = getTimeEstimates(bwFileStats['linecount'], settings);
+    bwFileStats['minestimate'] = estimate.min;
+    bwFileStats['maxestimate'] = estimate.max;
+
+    if (estimate.max) {
       $('#bwWordlistSpanTimebetweenmin').text(
         formatString('{0}ms ', settings.lookupRandomizeTimeBetween.minimum)
       );
@@ -68,9 +67,6 @@ function handleWordlistConfirmation(): void {
         formatString('{0} to {1}', bwFileStats['minestimate'], bwFileStats['maxestimate'])
       );
     } else {
-      bwFileStats['minestimate'] = conversions.msToHumanTime(
-        bwFileStats['linecount'] * settings.lookupGeneral.timeBetween
-      );
       $('#bwWordlistSpanTimebetweenminmax').addClass('is-hidden');
       $('#bwWordlistSpanTimebetweenmin').text(settings.lookupGeneral.timeBetween + 'ms');
       $('#bwWordlistTdEstimate').text(formatString('> {0}', bwFileStats['minestimate']));

--- a/test/estimate.test.ts
+++ b/test/estimate.test.ts
@@ -1,0 +1,21 @@
+import { getTimeEstimates } from '../app/ts/renderer/bulkwhois/estimate';
+import { defaultSettings } from '../app/ts/common/settings-base';
+
+describe('getTimeEstimates', () => {
+  test('returns min and max when randomization enabled', () => {
+    const settings = JSON.parse(JSON.stringify(defaultSettings));
+    settings.lookupRandomizeTimeBetween.randomize = true;
+    settings.lookupRandomizeTimeBetween.minimum = 10;
+    settings.lookupRandomizeTimeBetween.maximum = 20;
+    const est = getTimeEstimates(2, settings);
+    expect(est).toEqual({ min: '20 ms', max: '40 ms' });
+  });
+
+  test('returns only min when randomization disabled', () => {
+    const settings = JSON.parse(JSON.stringify(defaultSettings));
+    settings.lookupRandomizeTimeBetween.randomize = false;
+    settings.lookupGeneral.timeBetween = 15;
+    const est = getTimeEstimates(2, settings);
+    expect(est).toEqual({ min: '30 ms' });
+  });
+});


### PR DESCRIPTION
## Summary
- add `getTimeEstimates` helper to compute bulk lookup time
- use helper in file and word list inputs
- add unit tests for the new helper

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: better_sqlite3 bindings missing)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68718607afb483258e0aea8faf3482f4