### PR TITLE
Refactor file input helpers

### DIFF
--- a/app/ts/renderer/bulkwhois/fileHandlers.ts
+++ b/app/ts/renderer/bulkwhois/fileHandlers.ts
@@ -1,0 +1,39 @@
+import * as conversions from '../../common/conversions.js';
+import type { FileStats } from '../../common/fileStats.js';
+import { settings } from '../settings-renderer.js';
+
+export interface ElectronFs {
+  bwFileRead: (p: string) => Promise<Buffer>;
+  stat: (p: string) => Promise<any>;
+  path: { basename: (p: string) => Promise<string> };
+}
+
+export async function readFileData(
+  electron: ElectronFs,
+  pathToFile: string
+): Promise<{ stats: FileStats; contents: Buffer }> {
+  const misc = settings.lookupMisc;
+  const stats = (await electron.stat(pathToFile)) as FileStats;
+  stats.filename = await electron.path.basename(pathToFile);
+  stats.humansize = conversions.byteToHumanFileSize(stats.size, misc.useStandardSize);
+  const contents = await electron.bwFileRead(pathToFile);
+  stats.linecount = contents.toString().split('\n').length;
+  stats.filepreview = contents.toString().substring(0, 50);
+  return { stats, contents };
+}
+
+export function addEstimates(stats: FileStats): void {
+  const lookup = { randomize: { timeBetween: settings.lookupRandomizeTimeBetween } };
+  if (lookup.randomize.timeBetween.randomize === true) {
+    stats.minestimate = conversions.msToHumanTime(
+      stats.linecount! * lookup.randomize.timeBetween.minimum
+    );
+    stats.maxestimate = conversions.msToHumanTime(
+      stats.linecount! * lookup.randomize.timeBetween.maximum
+    );
+  } else {
+    stats.minestimate = conversions.msToHumanTime(
+      stats.linecount! * settings.lookupGeneral.timeBetween
+    );
+  }
+}

--- a/app/ts/renderer/bulkwhois/ui.ts
+++ b/app/ts/renderer/bulkwhois/ui.ts
@@ -1,0 +1,55 @@
+import $ from '../../../vendor/jquery.js';
+import * as conversions from '../../common/conversions.js';
+import type { FileStats } from '../../common/fileStats.js';
+import { formatString } from '../../common/stringformat.js';
+
+export function renderStats(stats: FileStats): void {
+  $('#bwFileTdName').text(String(stats.filename));
+  $('#bwFileTdLastmodified').text(conversions.getDate(stats.mtime) ?? '');
+  $('#bwFileTdLastaccess').text(conversions.getDate(stats.atime) ?? '');
+  $('#bwFileTdFilesize').text(
+    String(stats.humansize) + formatString(' ({0} line(s))', String(stats.linecount))
+  );
+  $('#bwFileTdFilepreview').text(String(stats.filepreview) + '...');
+}
+
+export function renderEstimates(min: string, max?: string): void {
+  if (max) {
+    $('#bwFileSpanTimebetweenmin').text(min);
+    $('#bwFileSpanTimebetweenmax').text(max);
+    $('#bwFileTdEstimate').text(formatString('{0} to {1}', min, max));
+  } else {
+    $('#bwFileSpanTimebetweenminmax').addClass('is-hidden');
+    $('#bwFileSpanTimebetweenmin').text(min);
+    $('#bwFileTdEstimate').text(formatString('> {0}', min));
+  }
+}
+
+export function initDragAndDrop(electron: {
+  send: (channel: string, ...args: any[]) => void;
+}): void {
+  $(document).ready(() => {
+    const holder = document.getElementById('bulkwhoisMainContainer') as HTMLElement | null;
+    if (!holder) return;
+    holder.ondragover = () => false;
+    holder.ondragleave = () => false;
+    holder.ondragend = () => false;
+    holder.ondrop = (event) => {
+      event.preventDefault();
+      for (const f of Array.from(event.dataTransfer!.files)) {
+        const file = f as any;
+        electron.send('ondragstart', file.path);
+      }
+      return false;
+    };
+  });
+
+  $('#bulkwhoisMainContainer').on('drop', function (event) {
+    event.preventDefault();
+    for (const f of Array.from((event as any).originalEvent.dataTransfer.files)) {
+      const file = f as any;
+      electron.send('ondragstart', file.path);
+    }
+    return false;
+  });
+}


### PR DESCRIPTION
## Summary
- separate file handling and UI helpers in bulkwhois
- keep fileinput focused on event wiring

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: better-sqlite3 node build)*
- `npm run test:e2e` *(fails: WebDriverError session not created)*

------
https://chatgpt.com/codex/tasks/task_e_687186119f288325b7aa738783aeeea9