### PR TITLE
Fix processingIDs type

### DIFF
--- a/app/ts/main/bulkwhois/types.ts
+++ b/app/ts/main/bulkwhois/types.ts
@@ -72,7 +72,7 @@ export interface BulkWhois {
   input: BulkWhoisInput;
   stats: BulkWhoisStats;
   results: BulkWhoisResults;
-  processingIDs: any[];
+  processingIDs: NodeJS.Timeout[];
   domains: string[];
   default: {
     numericstart: number | null;


### PR DESCRIPTION
## Summary
- narrow processingIDs type to NodeJS.Timeout

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: better_sqlite3.node version mismatch)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68719ba6730c83259adf5e8209899fcd