### PR TITLE
refactor: async request cache

### DIFF
--- a/app/ts/cli.ts
+++ b/app/ts/cli.ts
@@ -189,11 +189,11 @@ if (require.main === module) {
     }
     if (opts.purgeCache || opts.clearCache) {
       if (opts.clearCache) {
-        requestCache.clear();
+        await requestCache.clear();
         process.stdout.write('Cache cleared\n');
         debug('Cache cleared');
       } else {
-        const purged = requestCache.purgeExpired();
+        const purged = await requestCache.purgeExpired();
         process.stdout.write(`Purged ${purged} expired entries\n`);
         debug(`Purged ${purged} expired entries`);
       }

--- a/app/ts/common/dnsLookup.ts
+++ b/app/ts/common/dnsLookup.ts
@@ -34,14 +34,14 @@ export async function nsLookup(host: string, cacheOpts: CacheOptions = {}): Prom
     host = clean ? clean.replace(/((\*\.)*)/g, '') : host;
   }
 
-  const cached = requestCache.get('dns', host, cacheOpts);
+  const cached = await requestCache.get('dns', host, cacheOpts);
   if (cached !== undefined) {
     return JSON.parse(cached) as string[];
   }
 
   try {
     result = await dns.resolve(host, 'NS');
-    requestCache.set('dns', host, JSON.stringify(result), cacheOpts);
+    await requestCache.set('dns', host, JSON.stringify(result), cacheOpts);
   } catch (e) {
     debug(`Lookup failed with error ${e}`);
     throw new DnsLookupError((e as Error).message);

--- a/app/ts/common/lookup.ts
+++ b/app/ts/common/lookup.ts
@@ -40,7 +40,7 @@ export async function lookup(
   const { lookupConversion: conversion, lookupGeneral: general } = getSettings();
   let domainResults: string;
 
-  const cached = requestCache.get('whois', domain, cacheOpts);
+  const cached = await requestCache.get('whois', domain, cacheOpts);
   if (cached !== undefined) {
     return cached;
   }
@@ -58,7 +58,7 @@ export async function lookup(
     domainResults = `Whois lookup error, ${e}`;
   }
 
-  requestCache.set('whois', domain, domainResults, cacheOpts);
+  await requestCache.set('whois', domain, domainResults, cacheOpts);
 
   return domainResults;
 }

--- a/app/ts/main/cache.ts
+++ b/app/ts/main/cache.ts
@@ -6,12 +6,12 @@ const debug = debugFactory('main.cache');
 
 const requestCache = new RequestCache();
 
-ipcMain.handle('cache:purge', (_event, opts: { clear?: boolean } = {}) => {
+ipcMain.handle('cache:purge', async (_event, opts: { clear?: boolean } = {}) => {
   if (opts.clear) {
-    requestCache.clear();
+    await requestCache.clear();
     debug('Cleared cache via IPC');
   } else {
-    requestCache.purgeExpired();
+    await requestCache.purgeExpired();
     debug('Purged expired cache entries via IPC');
   }
 });

--- a/test/cacheCommand.test.ts
+++ b/test/cacheCommand.test.ts
@@ -16,10 +16,10 @@ jest.mock('electron', () => ({
 
 jest.mock('../app/ts/common/requestCache', () => ({
   RequestCache: class {
-    purgeExpired() {
+    async purgeExpired() {
       return purgeMock();
     }
-    clear() {
+    async clear() {
       clearMock();
     }
   }
@@ -28,16 +28,16 @@ jest.mock('../app/ts/common/requestCache', () => ({
 import '../app/ts/main/cache';
 
 describe('cache IPC handler', () => {
-  test('purges expired entries', () => {
+  test('purges expired entries', async () => {
     const handler = ipcMainHandlers['cache:purge'];
-    handler({}, { clear: false });
+    await handler({}, { clear: false });
     expect(purgeMock).toHaveBeenCalled();
     expect(clearMock).not.toHaveBeenCalled();
   });
 
-  test('clears all entries when clear flag set', () => {
+  test('clears all entries when clear flag set', async () => {
     const handler = ipcMainHandlers['cache:purge'];
-    handler({}, { clear: true });
+    await handler({}, { clear: true });
     expect(clearMock).toHaveBeenCalled();
   });
 });

--- a/test/requestCache.test.ts
+++ b/test/requestCache.test.ts
@@ -24,25 +24,25 @@ describe('requestCache', () => {
     cache.close();
   });
 
-  test('rejects paths outside user data directory', () => {
+  test('rejects paths outside user data directory', async () => {
     const original = settings.requestCache.database;
     settings.requestCache.database = '../evil.sqlite';
     const evilPath = path.resolve(getUserDataPath(), '../evil.sqlite');
-    cache.set('whois', 'evil.com', 'bad');
+    await cache.set('whois', 'evil.com', 'bad');
     expect(fs.existsSync(evilPath)).toBe(false);
     settings.requestCache.database = original;
   });
 
-  test('stores and retrieves cached value', () => {
-    cache.set('whois', 'example.com', 'cached-data');
-    const res = cache.get('whois', 'example.com');
+  test('stores and retrieves cached value', async () => {
+    await cache.set('whois', 'example.com', 'cached-data');
+    const res = await cache.get('whois', 'example.com');
     expect(res).toBe('cached-data');
   });
 
   test('expires entries after ttl', async () => {
-    cache.set('whois', 'expire.com', 'data');
+    await cache.set('whois', 'expire.com', 'data');
     await new Promise((r) => setTimeout(r, 1100));
-    const res = cache.get('whois', 'expire.com');
+    const res = await cache.get('whois', 'expire.com');
     expect(res).toBeUndefined();
   });
 
@@ -53,18 +53,18 @@ describe('requestCache', () => {
 
   test('purgeExpired removes outdated entries', async () => {
     settings.requestCache.enabled = true;
-    cache.set('whois', 'old.com', 'data');
+    await cache.set('whois', 'old.com', 'data');
     await new Promise((r) => setTimeout(r, 1100));
-    cache.purgeExpired();
-    const res = cache.get('whois', 'old.com');
+    await cache.purgeExpired();
+    const res = await cache.get('whois', 'old.com');
     expect(res).toBeUndefined();
   });
 
-  test('clearCache wipes all entries', () => {
-    cache.set('whois', 'a.com', '1');
-    cache.set('whois', 'b.com', '2');
-    cache.clear();
-    expect(cache.get('whois', 'a.com')).toBeUndefined();
-    expect(cache.get('whois', 'b.com')).toBeUndefined();
+  test('clearCache wipes all entries', async () => {
+    await cache.set('whois', 'a.com', '1');
+    await cache.set('whois', 'b.com', '2');
+    await cache.clear();
+    expect(await cache.get('whois', 'a.com')).toBeUndefined();
+    expect(await cache.get('whois', 'b.com')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- switch request cache to fs.promises and async API
- await cache operations across app
- adjust unit tests for async cache

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: better_sqlite3 module mismatch)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68719d6ba7808325b4ce636d07ca140e