### PR TITLE
refactor(renderer): type bulk results

### DIFF
--- a/app/ts/renderer/bulkwhois/state.ts
+++ b/app/ts/renderer/bulkwhois/state.ts
@@ -1,15 +1,16 @@
 import { IpcChannel } from '../../common/ipcChannels.js';
+import type { BulkWhoisResults } from '../../main/bulkwhois/types.js';
 
-let bulkResults: any;
+let bulkResults: BulkWhoisResults | null = null;
 
 export function registerResultListener(electron: {
   on: (channel: string, listener: (...args: any[]) => void) => void;
 }): void {
-  electron.on(IpcChannel.BulkwhoisResultReceive, (_event, results) => {
+  electron.on(IpcChannel.BulkwhoisResultReceive, (_event, results: BulkWhoisResults) => {
     bulkResults = results;
   });
 }
 
-export function getBulkResults() {
+export function getBulkResults(): BulkWhoisResults | null {
   return bulkResults;
 }


### PR DESCRIPTION
## Summary
- type bulkResults state
- update registerResultListener and getBulkResults types

## Testing
- `npm run lint`
- `npm run format`
- `npx tsc --noEmit`
- `npm test` *(fails: Module did not self-register)*
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68719d7e19748325989242c8aa0a4360