### PR TITLE
Add test for empty bulk whois queue

### DIFF
--- a/test/processHelpers.test.ts
+++ b/test/processHelpers.test.ts
@@ -115,4 +115,28 @@ describe('process helpers', () => {
     );
     Object.assign(settings, backup);
   });
+
+  test('scheduleQueue exits with no pending domains', () => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+    const bulk = JSON.parse(JSON.stringify(defaultBulkWhois));
+    const event = { sender: { send: jest.fn() } } as any;
+    const reqtime: number[] = [];
+    const backup = JSON.parse(JSON.stringify(settings));
+    settings.lookupGeneral.type = 'whois';
+    settings.lookupRandomizeTimeBetween.randomize = false;
+    settings.lookupRandomizeFollow.randomize = false;
+    settings.lookupRandomizeTimeout.randomize = false;
+    settings.lookupGeneral.timeBetween = 1;
+    settings.lookupGeneral.follow = 1;
+    settings.lookupGeneral.timeout = 1;
+
+    scheduleQueue(bulk, reqtime, settings, event);
+
+    expect(processDomain).not.toHaveBeenCalled();
+    expect(jest.getTimerCount()).toBe(0);
+    Object.assign(settings, backup);
+    jest.useRealTimers();
+  });
 });


### PR DESCRIPTION
## Summary
- add a unit test asserting that `scheduleQueue` does nothing when there are no domains pending

## Testing
- `npx jest test/processHelpers.test.ts -t "scheduleQueue exits"`

------
https://chatgpt.com/codex/tasks/task_e_68724579c2388325b1d53f62ac99637c