### PR TITLE
chore: add typed fs options

### DIFF
--- a/app/ts/main/fsIpc.ts
+++ b/app/ts/main/fsIpc.ts
@@ -1,10 +1,13 @@
 import { ipcMain } from 'electron';
 import fs from 'fs';
 
+type ReadFileOpts = BufferEncoding | fs.ReadFileOptions;
+type ReaddirOpts = fs.ReaddirOptions | BufferEncoding | undefined;
+
 const watchers = new Map<number, fs.FSWatcher>();
 let watcherId = 0;
 
-ipcMain.handle('fs:readFile', async (_e, p: string, opts?: any) => {
+ipcMain.handle('fs:readFile', async (_e, p: string, opts?: ReadFileOpts) => {
   return fs.promises.readFile(p, opts);
 });
 
@@ -12,8 +15,8 @@ ipcMain.handle('fs:stat', async (_e, p: string) => {
   return fs.promises.stat(p);
 });
 
-ipcMain.handle('fs:readdir', async (_e, p: string, opts?: any) => {
-  return fs.promises.readdir(p, opts);
+ipcMain.handle('fs:readdir', async (_e, p: string, opts?: ReaddirOpts) => {
+  return fs.promises.readdir(p, opts as any);
 });
 
 ipcMain.handle('fs:unlink', async (_e, p: string) => {

--- a/app/ts/preload.cts
+++ b/app/ts/preload.cts
@@ -20,9 +20,11 @@ const api = {
       listenerMap.delete(listener);
     }
   },
-  readFile: (p: string, opts?: any) => ipcRenderer.invoke('fs:readFile', p, opts),
+  readFile: (p: string, opts?: BufferEncoding | import('fs').ReadFileOptions) =>
+    ipcRenderer.invoke('fs:readFile', p, opts),
   stat: (p: string) => ipcRenderer.invoke('fs:stat', p),
-  readdir: (p: string, opts?: any) => ipcRenderer.invoke('fs:readdir', p, opts),
+  readdir: (p: string, opts?: import('fs').ReaddirOptions) =>
+    ipcRenderer.invoke('fs:readdir', p, opts),
   unlink: (p: string) => ipcRenderer.invoke('fs:unlink', p),
   access: (p: string, mode?: number) => ipcRenderer.invoke('fs:access', p, mode),
   exists: (p: string) => ipcRenderer.invoke('fs:exists', p),
@@ -33,7 +35,12 @@ const api = {
   refreshStats: (id: number) => ipcRenderer.invoke('stats:refresh', id),
   stopStats: (id: number) => ipcRenderer.invoke('stats:stop', id),
   getStats: (cfg: string, dir: string) => ipcRenderer.invoke('stats:get', cfg, dir),
-  watch: async (prefix: string, p: string, opts: any, cb: (evt: string) => void) => {
+  watch: async (
+    prefix: string,
+    p: string,
+    opts: import('fs').WatchOptions,
+    cb: (evt: string) => void
+  ) => {
     const id = await ipcRenderer.invoke('fs:watch', prefix, p, opts);
     const chan = `fs:watch:${prefix}:${id}`;
     const handler = (_e: IpcRendererEvent, ev: string) => cb(ev);

--- a/app/ts/renderer/bulkwhois/fileinput.ts
+++ b/app/ts/renderer/bulkwhois/fileinput.ts
@@ -1,6 +1,7 @@
 import * as conversions from '../../common/conversions.js';
 import type { FileStats } from '../../common/fileStats.js';
 import { debugFactory, errorFactory } from '../../common/logger.js';
+import type * as fs from 'fs';
 const debug = debugFactory('bulkwhois.fileinput');
 const error = errorFactory('bulkwhois.fileinput');
 debug('loaded');
@@ -13,7 +14,7 @@ const electron = (window as any).electron as {
   watch: (
     prefix: string,
     p: string,
-    opts: any,
+    opts: fs.WatchOptions,
     cb: (evt: string) => void
   ) => Promise<{ close: () => void }>;
   stat: (p: string) => Promise<any>;

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -4,6 +4,7 @@ import $ from '../../../vendor/jquery.js';
 import '../../../vendor/datatables.js';
 import { settings } from '../settings-renderer.js';
 import { debugFactory, errorFactory } from '../../common/logger.js';
+import type * as fs from 'fs';
 
 const electron = (window as any).electron as {
   send: (channel: string, ...args: any[]) => void;
@@ -13,7 +14,7 @@ const electron = (window as any).electron as {
   watch: (
     prefix: string,
     p: string,
-    opts: any,
+    opts: fs.WatchOptions,
     cb: (evt: string) => void
   ) => Promise<{ close: () => void }>;
   stat: (p: string) => Promise<any>;

--- a/app/ts/renderer/settings-renderer.ts
+++ b/app/ts/renderer/settings-renderer.ts
@@ -1,7 +1,13 @@
+import type * as fs from 'fs';
+
 const electron = (window as any).electron as {
   invoke: (channel: string, ...args: any[]) => Promise<any>;
-  readFile: (p: string, opts?: any) => Promise<string>;
-  watch: (p: string, opts: any, cb: (event: string) => void) => Promise<{ close: () => void }>;
+  readFile: (p: string, opts?: BufferEncoding | fs.ReadFileOptions) => Promise<string>;
+  watch: (
+    p: string,
+    opts: fs.WatchOptions,
+    cb: (event: string) => void
+  ) => Promise<{ close: () => void }>;
   exists: (p: string) => Promise<boolean>;
   on: (channel: string, listener: (...args: any[]) => void) => void;
   path: { join: (...args: string[]) => string };

--- a/app/ts/renderer/settings.ts
+++ b/app/ts/renderer/settings.ts
@@ -1,16 +1,21 @@
 import $ from '../../vendor/jquery.js';
 import { debugFactory } from '../common/logger.js';
 import { IpcChannel } from '../common/ipcChannels.js';
+import type * as fs from 'fs';
 
 const electron = (window as any).electron as {
   getBaseDir: () => Promise<string>;
-  readFile: (p: string, opts?: any) => Promise<any>;
+  readFile: (p: string, opts?: BufferEncoding | fs.ReadFileOptions) => Promise<any>;
   stat: (p: string) => Promise<any>;
-  readdir: (p: string, opts?: any) => Promise<any>;
+  readdir: (p: string, opts?: fs.ReaddirOptions) => Promise<any>;
   unlink: (p: string) => Promise<any>;
   access: (p: string, mode?: number) => Promise<any>;
   exists: (p: string) => Promise<any>;
-  watch: (p: string, opts: any, cb: (evt: string) => void) => Promise<{ close: () => void }>;
+  watch: (
+    p: string,
+    opts: fs.WatchOptions,
+    cb: (evt: string) => void
+  ) => Promise<{ close: () => void }>;
   path: { join: (...args: string[]) => Promise<string>; basename: (p: string) => Promise<string> };
   send: (channel: string, ...args: any[]) => void;
   invoke: (channel: string, ...args: any[]) => Promise<any>;

--- a/app/ts/utils/fileWatcher.ts
+++ b/app/ts/utils/fileWatcher.ts
@@ -1,7 +1,9 @@
+import type * as fs from 'fs';
+
 export type WatchFn = (
   prefix: string,
   path: string,
-  opts: any,
+  opts: fs.WatchOptions,
   cb: (evt: string) => void
 ) => Promise<{ close: () => void }>;
 
@@ -9,7 +11,12 @@ export class FileWatcherManager {
   private watcher: { close: () => void } | undefined;
   constructor(private readonly watchFn: WatchFn) {}
 
-  async watch(prefix: string, path: string, opts: any, cb: (evt: string) => void): Promise<void> {
+  async watch(
+    prefix: string,
+    path: string,
+    opts: fs.WatchOptions,
+    cb: (evt: string) => void
+  ): Promise<void> {
     this.close();
     this.watcher = await this.watchFn(prefix, path, opts, cb);
   }

--- a/test/electronMock.ts
+++ b/test/electronMock.ts
@@ -31,13 +31,14 @@ if (!(global as any).window) {
   }),
   on: jest.fn(),
   openPath: jest.fn(),
-  readFile: (p: string, opts?: any) => fs.promises.readFile(p, opts),
+  readFile: (p: string, opts?: BufferEncoding | fs.ReadFileOptions) =>
+    fs.promises.readFile(p, opts),
   stat: (p: string) => fs.promises.stat(p),
-  readdir: (p: string, opts?: any) => fs.promises.readdir(p, opts),
+  readdir: (p: string, opts?: fs.ReaddirOptions) => fs.promises.readdir(p, opts),
   unlink: (p: string) => fs.promises.unlink(p),
   access: (p: string, mode?: number) => fs.promises.access(p, mode),
   exists: async (p: string) => fs.existsSync(p),
-  watch: async (p: string, opts: any, cb: (ev: string) => void) => {
+  watch: async (p: string, opts: fs.WatchOptions, cb: (ev: string) => void) => {
     const watcher = fs.watch(p, opts, cb);
     return { close: () => watcher.close() };
   },

--- a/test/fsIpc.test.ts
+++ b/test/fsIpc.test.ts
@@ -1,10 +1,12 @@
+import fs from 'fs';
+
 const ipcMainHandlers: Record<string, (...args: any[]) => any> = {};
 
 const readFileMock = jest.fn();
 const statMock = jest.fn();
 const watchCallbacks: Array<(ev: string) => void> = [];
 const watchCloseMocks: jest.Mock[] = [];
-const watchMock = jest.fn((path: string, opts: any, cb: (ev: string) => void) => {
+const watchMock = jest.fn((path: string, opts: fs.WatchOptions, cb: (ev: string) => void) => {
   watchCallbacks.push(cb);
   const watcher = { close: jest.fn() } as any;
   watchCloseMocks.push(watcher.close);

--- a/types/fs-options.d.ts
+++ b/types/fs-options.d.ts
@@ -1,0 +1,11 @@
+declare module 'fs' {
+  interface ReadFileOptions {
+    encoding?: BufferEncoding | null;
+    flag?: string | number;
+  }
+  interface ReaddirOptions {
+    encoding?: BufferEncoding | null;
+    withFileTypes?: boolean;
+    recursive?: boolean;
+  }
+}


### PR DESCRIPTION
## Summary
- add custom Node fs option interfaces
- refine fs IPC handler signatures
- update renderer and tests for explicit fs option types

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm test` *(fails: better-sqlite3 wrong node version)*

------
https://chatgpt.com/codex/tasks/task_e_68724980b6908325965a5867c0aef4d5