### PR TITLE
Add msToHumanTime tests

### DIFF
--- a/test/conversions.test.ts
+++ b/test/conversions.test.ts
@@ -9,6 +9,23 @@ describe('conversions', () => {
     expect(msToHumanTime(62000)).toBe('1 m 2 s');
   });
 
+  test('msToHumanTime converts hours', () => {
+    expect(msToHumanTime(3600000)).toBe('1 h');
+  });
+
+  test('msToHumanTime converts days', () => {
+    expect(msToHumanTime(172800000)).toBe('2 d');
+  });
+
+  test('msToHumanTime rolls over years after ten', () => {
+    const yearMs = 1000 * 60 * 60 * 24 * 7 * 4 * 12;
+    expect(msToHumanTime(yearMs * 11)).toBe('1 Y');
+  });
+
+  test('msToHumanTime handles sub-second values', () => {
+    expect(msToHumanTime(500)).toBe('500 ms');
+  });
+
   test("msToHumanTime returns '-' for zero duration", () => {
     expect(msToHumanTime(0)).toBe('-');
   });


### PR DESCRIPTION
## Summary
- extend `msToHumanTime` coverage for hours, days, rollover and sub-second

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: better-sqlite3 mismatch)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68725225e65c832589191e33c530030d