### PR TITLE
feat: dynamic partial registration

### DIFF
--- a/app/html/startup.js
+++ b/app/html/startup.js
@@ -1,4 +1,4 @@
 import registerPartials from '../ts/renderer/registerPartials.js';
-registerPartials();
+await registerPartials();
 
 import '../ts/mainPanel.js';

--- a/app/ts/renderer/registerPartials.ts
+++ b/app/ts/renderer/registerPartials.ts
@@ -4,70 +4,36 @@ import { debugFactory } from '../common/logger.js';
 const debug = debugFactory('renderer.registerPartials');
 debug('loaded');
 
-import bwEntry from '../../compiled-templates/bulkwhoisEntry.js';
-import bwExport from '../../compiled-templates/bulkwhoisExport.js';
-import bwExportLoading from '../../compiled-templates/bulkwhoisExportLoading.js';
-import bwFileInputConfirm from '../../compiled-templates/bulkwhoisFileInputConfirm.js';
-import bwFileInputLoading from '../../compiled-templates/bulkwhoisFileInputLoading.js';
-import bwProcessing from '../../compiled-templates/bulkwhoisProcessing.js';
-import bwWordlistConfirm from '../../compiled-templates/bulkwhoisWordlistConfirm.js';
-import bwWordlistInput from '../../compiled-templates/bulkwhoisWordlistInput.js';
-import bwWordlistLoading from '../../compiled-templates/bulkwhoisWordlistLoading.js';
-import bwaAnalyser from '../../compiled-templates/bwaAnalyser.js';
-import bwaEntry from '../../compiled-templates/bwaEntry.js';
-import bwaFileInputLoading from '../../compiled-templates/bwaFileInputLoading.js';
-import bwaFileinputconfirm from '../../compiled-templates/bwaFileinputconfirm.js';
-import bwaProcess from '../../compiled-templates/bwaProcess.js';
-import navBottom from '../../compiled-templates/navBottom.js';
-import navTop from '../../compiled-templates/navTop.js';
-import settingsEntry from '../../compiled-templates/settingsEntry.js';
-import singlewhois from '../../compiled-templates/singlewhois.js';
-import toEntry from '../../compiled-templates/toEntry.js';
-import he from '../../compiled-templates/he.js';
-import modals from '../../compiled-templates/modals.js';
+export async function registerPartials(): Promise<void> {
+  const partials: Record<string, any> = {};
 
-export function registerPartials(): void {
-  const partials: Record<string, any> = {
-    bulkwhoisEntry: Handlebars.template((bwEntry as any).default || (bwEntry as any)),
-    bulkwhoisExport: Handlebars.template((bwExport as any).default || (bwExport as any)),
-    bulkwhoisExportLoading: Handlebars.template(
-      (bwExportLoading as any).default || (bwExportLoading as any)
-    ),
-    bulkwhoisFileInputConfirm: Handlebars.template(
-      (bwFileInputConfirm as any).default || (bwFileInputConfirm as any)
-    ),
-    bulkwhoisFileInputLoading: Handlebars.template(
-      (bwFileInputLoading as any).default || (bwFileInputLoading as any)
-    ),
-    bulkwhoisProcessing: Handlebars.template(
-      (bwProcessing as any).default || (bwProcessing as any)
-    ),
-    bulkwhoisWordlistConfirm: Handlebars.template(
-      (bwWordlistConfirm as any).default || (bwWordlistConfirm as any)
-    ),
-    bulkwhoisWordlistInput: Handlebars.template(
-      (bwWordlistInput as any).default || (bwWordlistInput as any)
-    ),
-    bulkwhoisWordlistLoading: Handlebars.template(
-      (bwWordlistLoading as any).default || (bwWordlistLoading as any)
-    ),
-    bwaAnalyser: Handlebars.template((bwaAnalyser as any).default || (bwaAnalyser as any)),
-    bwaEntry: Handlebars.template((bwaEntry as any).default || (bwaEntry as any)),
-    bwaFileInputLoading: Handlebars.template(
-      (bwaFileInputLoading as any).default || (bwaFileInputLoading as any)
-    ),
-    bwaFileinputconfirm: Handlebars.template(
-      (bwaFileinputconfirm as any).default || (bwaFileinputconfirm as any)
-    ),
-    bwaProcess: Handlebars.template((bwaProcess as any).default || (bwaProcess as any)),
-    navBottom: Handlebars.template((navBottom as any).default || (navBottom as any)),
-    navTop: Handlebars.template((navTop as any).default || (navTop as any)),
-    settingsEntry: Handlebars.template((settingsEntry as any).default || (settingsEntry as any)),
-    singlewhois: Handlebars.template((singlewhois as any).default || (singlewhois as any)),
-    toEntry: Handlebars.template((toEntry as any).default || (toEntry as any)),
-    he: Handlebars.template((he as any).default || (he as any)),
-    modals: Handlebars.template((modals as any).default || (modals as any))
-  };
+  const glob = (import.meta as any).glob || (globalThis as any).__glob;
+  if (glob) {
+    const modules = glob('../../compiled-templates/*.js', { eager: true });
+    for (const [filePath, mod] of Object.entries(modules)) {
+      const file = filePath.split('/').pop() as string;
+      if (file === 'mainPanel.js') continue;
+      const name = file.replace(/\.js$/, '');
+      partials[name] = Handlebars.template((mod as any).default || mod);
+    }
+  } else {
+    const fs = await import('fs');
+    const path = await import('path');
+    const { pathToFileURL, fileURLToPath } = await import('url');
+    const dir = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      '..',
+      '..',
+      'compiled-templates'
+    );
+    for (const file of fs.readdirSync(dir)) {
+      if (!file.endsWith('.js') || file === 'mainPanel.js') continue;
+      const spec = await import(pathToFileURL(path.join(dir, file)).href);
+      const name = file.replace(/\.js$/, '');
+      partials[name] = Handlebars.template(spec.default || spec);
+    }
+  }
+
   for (const [name, template] of Object.entries(partials)) {
     Handlebars.registerPartial(name, template);
   }


### PR DESCRIPTION
## Summary
- load compiled partials dynamically using `import.meta.glob`
- register partials asynchronously and update startup to await
- simplify registerPartials unit test for new loader

## Testing
- `npm run lint`
- `npm test` *(fails: better-sqlite3 module version mismatch)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6873b2cd58548325a8613dde8ab1339f