### PR TITLE
feat(types): add RendererElectronAPI

### DIFF
--- a/app/ts/renderer.ts
+++ b/app/ts/renderer.ts
@@ -7,12 +7,9 @@ import { loadTranslations, registerTranslationHelpers } from './renderer/i18n.js
 import { formatString } from './common/stringformat.js';
 import { sendDebug, sendError } from './renderer/logger.js';
 import { debugFactory } from './common/logger.js';
+import type { RendererElectronAPI } from '../../types/renderer-electron-api.js';
 
-const electron = (window as any).electron as {
-  send: (channel: string, ...args: any[]) => void;
-  invoke: (channel: string, ...args: any[]) => Promise<any>;
-  on: (channel: string, listener: (...args: any[]) => void) => void;
-};
+const electron = (window as any).electron as RendererElectronAPI;
 
 const debug = debugFactory('renderer.entry');
 debug('loaded');

--- a/app/ts/renderer/bulkwhois/export.ts
+++ b/app/ts/renderer/bulkwhois/export.ts
@@ -1,12 +1,9 @@
 import * as conversions from '../../common/conversions.js';
 import defaultExportOptions from './export.defaults.js';
 import { debugFactory } from '../../common/logger.js';
+import type { RendererElectronAPI } from '../../../../types/renderer-electron-api.js';
 
-const electron = (window as any).electron as {
-  send: (channel: string, ...args: any[]) => void;
-  invoke: (channel: string, ...args: any[]) => Promise<any>;
-  on: (channel: string, listener: (...args: any[]) => void) => void;
-};
+const electron = (window as any).electron as RendererElectronAPI;
 
 const debug = debugFactory('bulkwhois.export');
 debug('loaded');
@@ -34,7 +31,7 @@ let options: any;
     event
     rcvResults
  */
-electron.on(IpcChannel.BulkwhoisResultReceive, function (_event, rcvResults) {
+electron.on(IpcChannel.BulkwhoisResultReceive, function (_event: unknown, rcvResults: any) {
   debug(formatString('Results are ready for export {0}', rcvResults));
 
   results = rcvResults;

--- a/app/ts/renderer/bulkwhois/fileinput.ts
+++ b/app/ts/renderer/bulkwhois/fileinput.ts
@@ -2,14 +2,12 @@ import * as conversions from '../../common/conversions.js';
 import type { FileStats } from '../../common/fileStats.js';
 import { debugFactory, errorFactory } from '../../common/logger.js';
 import type * as fs from 'fs';
+import type { RendererElectronAPI } from '../../../../types/renderer-electron-api.js';
 const debug = debugFactory('bulkwhois.fileinput');
 const error = errorFactory('bulkwhois.fileinput');
 debug('loaded');
 
-const electron = (window as any).electron as {
-  send: (channel: string, ...args: any[]) => void;
-  invoke: (channel: string, ...args: any[]) => Promise<any>;
-  on: (channel: string, listener: (...args: any[]) => void) => void;
+const electron = (window as any).electron as RendererElectronAPI & {
   bwFileRead: (p: string) => Promise<Buffer>;
   watch: (
     prefix: string,
@@ -201,7 +199,7 @@ async function handleFileConfirmation(
  */
 electron.on(
   IpcChannel.BulkwhoisFileinputConfirmation,
-  (_event, filePath: string | string[] | null = null, isDragDrop = false) => {
+  (_event: unknown, filePath: string | string[] | null = null, isDragDrop = false) => {
     void handleFileConfirmation(filePath, isDragDrop);
   }
 );

--- a/app/ts/renderer/bulkwhois/process.ts
+++ b/app/ts/renderer/bulkwhois/process.ts
@@ -2,12 +2,9 @@ import { debugFactory } from '../../common/logger.js';
 import { registerResultListener, getBulkResults } from './state.js';
 import { registerStatusUpdates } from './status-handler.js';
 import { bindProcessingEvents } from './event-bindings.js';
+import type { RendererElectronAPI } from '../../../../types/renderer-electron-api.js';
 
-const electron = (window as any).electron as {
-  send: (channel: string, ...args: any[]) => void;
-  invoke: (channel: string, ...args: any[]) => Promise<any>;
-  on: (channel: string, listener: (...args: any[]) => void) => void;
-};
+const electron = (window as any).electron as RendererElectronAPI;
 
 const debug = debugFactory('bulkwhois.process');
 debug('loaded');

--- a/app/ts/renderer/bulkwhois/wordlistinput.ts
+++ b/app/ts/renderer/bulkwhois/wordlistinput.ts
@@ -1,12 +1,9 @@
 import * as conversions from '../../common/conversions.js';
 import { settings } from '../settings-renderer.js';
 import { debugFactory, errorFactory } from '../../common/logger.js';
+import type { RendererElectronAPI } from '../../../../types/renderer-electron-api.js';
 
-const electron = (window as any).electron as {
-  send: (channel: string, ...args: any[]) => void;
-  invoke: (channel: string, ...args: any[]) => Promise<any>;
-  on: (channel: string, listener: (...args: any[]) => void) => void;
-};
+const electron = (window as any).electron as RendererElectronAPI;
 import { tableReset } from './auxiliary.js';
 import $ from '../../../vendor/jquery.js';
 import { getTimeEstimates } from './estimate.js';

--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -2,12 +2,9 @@ import * as conversions from '../../common/conversions.js';
 import $ from '../../../vendor/jquery.js';
 import '../../../vendor/datatables.js';
 import { debugFactory } from '../../common/logger.js';
+import type { RendererElectronAPI } from '../../../../types/renderer-electron-api.js';
 
-const electron = (window as any).electron as {
-  send: (channel: string, ...args: any[]) => void;
-  invoke: (channel: string, ...args: any[]) => Promise<any>;
-  on: (channel: string, listener: (...args: any[]) => void) => void;
-};
+const electron = (window as any).electron as RendererElectronAPI;
 
 const debug = debugFactory('renderer.bwa.analyser');
 debug('loaded');

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -5,11 +5,9 @@ import '../../../vendor/datatables.js';
 import { settings } from '../settings-renderer.js';
 import { debugFactory, errorFactory } from '../../common/logger.js';
 import type * as fs from 'fs';
+import type { RendererElectronAPI } from '../../../../types/renderer-electron-api.js';
 
-const electron = (window as any).electron as {
-  send: (channel: string, ...args: any[]) => void;
-  invoke: (channel: string, ...args: any[]) => Promise<any>;
-  on: (channel: string, listener: (...args: any[]) => void) => void;
+const electron = (window as any).electron as RendererElectronAPI & {
   bwaFileRead: (p: string) => Promise<any>;
   watch: (
     prefix: string,
@@ -156,7 +154,7 @@ async function handleFileConfirmation(
   return;
 }
 
-electron.on('bwa:fileinput.confirmation', (_e, filePath, isDragDrop) => {
+electron.on('bwa:fileinput.confirmation', (_e: unknown, filePath: string | string[] | null, isDragDrop?: boolean) => {
   void handleFileConfirmation(filePath, isDragDrop);
 });
 

--- a/app/ts/renderer/history.ts
+++ b/app/ts/renderer/history.ts
@@ -1,7 +1,6 @@
 import $ from '../../vendor/jquery.js';
-const electron = (window as any).electron as {
-  invoke: (channel: string, ...args: any[]) => Promise<any>;
-};
+import type { RendererElectronAPI } from '../../../types/renderer-electron-api.js';
+const electron = (window as any).electron as RendererElectronAPI;
 import { debugFactory } from '../common/logger.js';
 
 const debug = debugFactory('renderer.history');

--- a/app/ts/renderer/i18n.ts
+++ b/app/ts/renderer/i18n.ts
@@ -1,5 +1,5 @@
-const electron = (window as any).electron as {
-  invoke: (channel: string, ...args: any[]) => Promise<any>;
+import type { RendererElectronAPI } from '../../../types/renderer-electron-api.js';
+const electron = (window as any).electron as RendererElectronAPI & {
   path: { join: (...args: string[]) => Promise<string> };
 };
 import Handlebars from '../../vendor/handlebars.runtime.js';

--- a/app/ts/renderer/navigation.ts
+++ b/app/ts/renderer/navigation.ts
@@ -3,15 +3,12 @@ import { populateInputs } from './settings.js';
 import { settings } from './settings-renderer.js';
 
 import { debugFactory } from '../common/logger.js';
+import type { RendererElectronAPI } from '../../../types/renderer-electron-api.js';
 
 const debug = debugFactory('renderer.navigation');
 debug('loaded');
 
-const electron = (window as any).electron as {
-  send: (channel: string, ...args: any[]) => void;
-  invoke: (channel: string, ...args: any[]) => Promise<any>;
-  on: (channel: string, listener: (...args: any[]) => void) => void;
-};
+const electron = (window as any).electron as RendererElectronAPI;
 
 function qs<T extends Element = HTMLElement>(sel: string): T | null {
   return document.querySelector(sel) as T | null;

--- a/app/ts/renderer/settings-renderer.ts
+++ b/app/ts/renderer/settings-renderer.ts
@@ -1,7 +1,7 @@
 import type * as fs from 'fs';
+import type { RendererElectronAPI } from '../../../types/renderer-electron-api.js';
 
-const electron = (window as any).electron as {
-  invoke: (channel: string, ...args: any[]) => Promise<any>;
+const electron = (window as any).electron as RendererElectronAPI & {
   readFile: (p: string, opts?: BufferEncoding | fs.ReadFileOptions) => Promise<string>;
   watch: (
     p: string,
@@ -9,7 +9,6 @@ const electron = (window as any).electron as {
     cb: (event: string) => void
   ) => Promise<{ close: () => void }>;
   exists: (p: string) => Promise<boolean>;
-  on: (channel: string, listener: (...args: any[]) => void) => void;
   path: { join: (...args: string[]) => string };
 };
 import { debugFactory } from '../common/logger.js';

--- a/app/ts/renderer/settings.ts
+++ b/app/ts/renderer/settings.ts
@@ -2,8 +2,9 @@ import $ from '../../vendor/jquery.js';
 import { debugFactory } from '../common/logger.js';
 import { IpcChannel } from '../common/ipcChannels.js';
 import type * as fs from 'fs';
+import type { RendererElectronAPI } from '../../../types/renderer-electron-api.js';
 
-const electron = (window as any).electron as {
+const electron = (window as any).electron as RendererElectronAPI & {
   getBaseDir: () => Promise<string>;
   readFile: (p: string, opts?: BufferEncoding | fs.ReadFileOptions) => Promise<any>;
   stat: (p: string) => Promise<any>;

--- a/app/ts/renderer/singlewhois.ts
+++ b/app/ts/renderer/singlewhois.ts
@@ -2,11 +2,8 @@ import type { WhoisResult } from '../common/availability.js';
 import { preStringStrip, toJSON } from '../common/parser.js';
 
 import { getDate } from '../common/conversions.js';
-const electron = (window as any).electron as {
-  send: (channel: string, ...args: any[]) => void;
-  invoke: (channel: string, ...args: any[]) => Promise<any>;
-  on: (channel: string, listener: (...args: any[]) => void) => void;
-};
+import type { RendererElectronAPI } from '../../../types/renderer-electron-api.js';
+const electron = (window as any).electron as RendererElectronAPI;
 import { IpcChannel } from '../common/ipcChannels.js';
 import { formatString } from '../common/stringformat.js';
 

--- a/app/ts/renderer/to.ts
+++ b/app/ts/renderer/to.ts
@@ -1,6 +1,7 @@
 // In the renderer process we access IPC methods exposed from the preload script
 // via the `window.electron` bridge instead of importing from 'electron'.
-const { invoke } = (window as any).electron;
+import type { RendererElectronAPI } from '../../../types/renderer-electron-api.js';
+const { invoke } = (window as any).electron as RendererElectronAPI;
 import { IpcChannel } from '../common/ipcChannels.js';
 import $ from '../../vendor/jquery.js';
 import { debugFactory, errorFactory } from '../common/logger.js';

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -1,3 +1,4 @@
+/// <reference path="./renderer-electron-api.d.ts" />
 declare const require: any;
 declare module 'fs' {
   export function existsSync(path: string): boolean;

--- a/types/renderer-electron-api.d.ts
+++ b/types/renderer-electron-api.d.ts
@@ -1,0 +1,11 @@
+export interface RendererElectronAPI<
+  RendererToMain extends Record<string, any[]> = any,
+  MainToRenderer extends Record<string, any[]> = any
+> {
+  send<C extends keyof RendererToMain>(channel: C, ...args: RendererToMain[C]): void;
+  invoke<C extends keyof RendererToMain>(channel: C, ...args: RendererToMain[C]): Promise<any>;
+  on<C extends keyof MainToRenderer>(
+    channel: C,
+    listener: (...args: MainToRenderer[C]) => void
+  ): void;
+}


### PR DESCRIPTION
## Summary
- define `RendererElectronAPI` interface for ipc methods
- reference new interface across renderer modules
- include type file in `custom.d.ts`

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: better-sqlite3, registerPartials)*
- `npm run test:e2e` *(fails: WebDriverError user-data-dir)*

------
https://chatgpt.com/codex/tasks/task_e_68741f48282883258145b3edb5c6d75a