### PR TITLE
feat: add typed file watcher options

### DIFF
--- a/app/ts/main/fsIpc.ts
+++ b/app/ts/main/fsIpc.ts
@@ -1,5 +1,6 @@
 import { ipcMain } from 'electron';
 import fs from 'fs';
+import type { WatchOptions } from '../utils/fileWatcher.js';
 
 type ReadFileOpts = BufferEncoding | fs.ReadFileOptions;
 type ReaddirOpts = fs.ReaddirOptions | BufferEncoding | undefined;
@@ -31,7 +32,7 @@ ipcMain.handle('fs:exists', async (_e, p: string) => {
   return fs.existsSync(p);
 });
 
-ipcMain.handle('fs:watch', (e, prefix: string, p: string, opts?: fs.WatchOptions) => {
+ipcMain.handle('fs:watch', (e, prefix: string, p: string, opts?: WatchOptions) => {
   const id = ++watcherId;
   const sender = e.sender;
   const watcher = fs.watch(p, opts || {}, (event) => {

--- a/app/ts/preload.cts
+++ b/app/ts/preload.cts
@@ -38,7 +38,7 @@ const api = {
   watch: async (
     prefix: string,
     p: string,
-    opts: import('fs').WatchOptions,
+    opts: import('./utils/fileWatcher').WatchOptions,
     cb: (evt: string) => void
   ) => {
     const id = await ipcRenderer.invoke('fs:watch', prefix, p, opts);

--- a/app/ts/renderer/bulkwhois/fileinput.ts
+++ b/app/ts/renderer/bulkwhois/fileinput.ts
@@ -2,6 +2,7 @@ import * as conversions from '../../common/conversions.js';
 import type { FileStats } from '../../common/fileStats.js';
 import { debugFactory, errorFactory } from '../../common/logger.js';
 import type * as fs from 'fs';
+import type { WatchOptions } from '../../utils/fileWatcher.js';
 const debug = debugFactory('bulkwhois.fileinput');
 const error = errorFactory('bulkwhois.fileinput');
 debug('loaded');
@@ -14,7 +15,7 @@ const electron = (window as any).electron as {
   watch: (
     prefix: string,
     p: string,
-    opts: fs.WatchOptions,
+    opts: WatchOptions,
     cb: (evt: string) => void
   ) => Promise<{ close: () => void }>;
   stat: (p: string) => Promise<any>;

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -5,6 +5,7 @@ import '../../../vendor/datatables.js';
 import { settings } from '../settings-renderer.js';
 import { debugFactory, errorFactory } from '../../common/logger.js';
 import type * as fs from 'fs';
+import type { WatchOptions } from '../../utils/fileWatcher.js';
 
 const electron = (window as any).electron as {
   send: (channel: string, ...args: any[]) => void;
@@ -14,7 +15,7 @@ const electron = (window as any).electron as {
   watch: (
     prefix: string,
     p: string,
-    opts: fs.WatchOptions,
+    opts: WatchOptions,
     cb: (evt: string) => void
   ) => Promise<{ close: () => void }>;
   stat: (p: string) => Promise<any>;

--- a/app/ts/renderer/settings-renderer.ts
+++ b/app/ts/renderer/settings-renderer.ts
@@ -1,11 +1,12 @@
 import type * as fs from 'fs';
+import type { WatchOptions } from '../utils/fileWatcher.js';
 
 const electron = (window as any).electron as {
   invoke: (channel: string, ...args: any[]) => Promise<any>;
   readFile: (p: string, opts?: BufferEncoding | fs.ReadFileOptions) => Promise<string>;
   watch: (
     p: string,
-    opts: fs.WatchOptions,
+    opts: WatchOptions,
     cb: (event: string) => void
   ) => Promise<{ close: () => void }>;
   exists: (p: string) => Promise<boolean>;

--- a/app/ts/renderer/settings.ts
+++ b/app/ts/renderer/settings.ts
@@ -2,6 +2,7 @@ import $ from '../../vendor/jquery.js';
 import { debugFactory } from '../common/logger.js';
 import { IpcChannel } from '../common/ipcChannels.js';
 import type * as fs from 'fs';
+import type { WatchOptions } from '../utils/fileWatcher.js';
 
 const electron = (window as any).electron as {
   getBaseDir: () => Promise<string>;
@@ -13,7 +14,7 @@ const electron = (window as any).electron as {
   exists: (p: string) => Promise<any>;
   watch: (
     p: string,
-    opts: fs.WatchOptions,
+    opts: WatchOptions,
     cb: (evt: string) => void
   ) => Promise<{ close: () => void }>;
   path: { join: (...args: string[]) => Promise<string>; basename: (p: string) => Promise<string> };

--- a/app/ts/utils/fileWatcher.ts
+++ b/app/ts/utils/fileWatcher.ts
@@ -1,9 +1,13 @@
-import type * as fs from 'fs';
+export interface WatchOptions {
+  persistent?: boolean;
+  recursive?: boolean;
+  encoding?: BufferEncoding;
+}
 
 export type WatchFn = (
   prefix: string,
   path: string,
-  opts: fs.WatchOptions,
+  opts: WatchOptions,
   cb: (evt: string) => void
 ) => Promise<{ close: () => void }>;
 
@@ -14,7 +18,7 @@ export class FileWatcherManager {
   async watch(
     prefix: string,
     path: string,
-    opts: fs.WatchOptions,
+    opts: WatchOptions,
     cb: (evt: string) => void
   ): Promise<void> {
     this.close();

--- a/test/electronMock.ts
+++ b/test/electronMock.ts
@@ -38,7 +38,11 @@ if (!(global as any).window) {
   unlink: (p: string) => fs.promises.unlink(p),
   access: (p: string, mode?: number) => fs.promises.access(p, mode),
   exists: async (p: string) => fs.existsSync(p),
-  watch: async (p: string, opts: fs.WatchOptions, cb: (ev: string) => void) => {
+  watch: async (
+    p: string,
+    opts: import('../app/ts/utils/fileWatcher').WatchOptions,
+    cb: (ev: string) => void
+  ) => {
     const watcher = fs.watch(p, opts, cb);
     return { close: () => watcher.close() };
   },

--- a/test/fileWatcherManager.test.ts
+++ b/test/fileWatcherManager.test.ts
@@ -1,9 +1,9 @@
-import { FileWatcherManager } from '../app/ts/utils/fileWatcher';
+import { FileWatcherManager, type WatchOptions, type WatchFn } from '../app/ts/utils/fileWatcher';
 
 test('replaces existing watcher', async () => {
   const closeFirst = jest.fn();
   const closeSecond = jest.fn();
-  const watchFn = jest
+  const watchFn: jest.MockedFunction<WatchFn> = jest
     .fn()
     .mockResolvedValueOnce({ close: closeFirst })
     .mockResolvedValueOnce({ close: closeSecond });

--- a/test/fsIpc.test.ts
+++ b/test/fsIpc.test.ts
@@ -6,12 +6,18 @@ const readFileMock = jest.fn();
 const statMock = jest.fn();
 const watchCallbacks: Array<(ev: string) => void> = [];
 const watchCloseMocks: jest.Mock[] = [];
-const watchMock = jest.fn((path: string, opts: fs.WatchOptions, cb: (ev: string) => void) => {
-  watchCallbacks.push(cb);
-  const watcher = { close: jest.fn() } as any;
-  watchCloseMocks.push(watcher.close);
-  return watcher;
-});
+const watchMock = jest.fn(
+  (
+    path: string,
+    opts: import('../app/ts/utils/fileWatcher').WatchOptions,
+    cb: (ev: string) => void
+  ) => {
+    watchCallbacks.push(cb);
+    const watcher = { close: jest.fn() } as any;
+    watchCloseMocks.push(watcher.close);
+    return watcher;
+  }
+);
 
 jest.mock('electron', () => ({
   ipcMain: {


### PR DESCRIPTION
## Summary
- introduce `WatchOptions` interface
- use `WatchOptions` across file watcher implementations
- update tests for new type

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: better-sqlite3 binary mismatch, bulkwhoisRenderer timeout)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68741f4a18348325945ef089408043df