### PR TITLE
Add empty domain test

### DIFF
--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -61,6 +61,14 @@ describe('cli utility', () => {
     expect(mockLookup).not.toHaveBeenCalled();
   });
 
+  test('lookupDomains skips lookups for empty domain list', async () => {
+    mockLookup.mockClear();
+    const opts: CliOptions = { domains: [], tlds: ['com'], format: 'txt' };
+    const results = await lookupDomains(opts);
+    expect(results).toEqual([]);
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
   test('lookupDomains runs lookups concurrently', async () => {
     let active = 0;
     let maxActive = 0;


### PR DESCRIPTION
## Summary
- extend CLI tests with empty domain array check

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm test` *(fails: better_sqlite3 binary mismatch)*
- `npm run test:e2e` *(fails: session not created for Chromedriver)*

------
https://chatgpt.com/codex/tasks/task_e_687431a51208832591207f3a5d82e902