### PR TITLE
test: verify scheduler counter behavior

### DIFF
--- a/test/counter.test.ts
+++ b/test/counter.test.ts
@@ -1,3 +1,9 @@
+// Mock processDomain so counter can be tested in isolation
+jest.mock('../app/ts/main/bulkwhois/scheduler', () => {
+  const actual = jest.requireActual('../app/ts/main/bulkwhois/scheduler');
+  return { ...actual, processDomain: jest.fn() };
+});
+
 import { counter } from '../app/ts/main/bulkwhois/scheduler';
 import defaultBulkWhois from '../app/ts/main/bulkwhois/process.defaults';
 import { IpcChannel } from '../app/ts/common/ipcChannels';


### PR DESCRIPTION
## Summary
- mock `processDomain` to isolate scheduler counter
- use fake timers to check interval increments

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_687431a1354083258cffa6be911cd547