### PR TITLE
Add fontawesome vendor file to prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -23,3 +23,4 @@ app/vendor/jquery.js
 app/vendor/html-entities/*.js
 app/vendor/html-entities/index.d.ts
 package.json
+app/vendor/fontawesome.js


### PR DESCRIPTION
## Summary
- ignore `app/vendor/fontawesome.js` in Prettier config

## Testing
- `npm run format:check`
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Module did not self-register)*
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68743899550c83258d5e70f238e6d779