### PR TITLE
Add concurrency option to CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -180,6 +180,10 @@ node dist/app/ts/cli.js --wordlist words.txt --tlds com net --format csv --out r
 # using a proxy
 node dist/app/ts/cli.js --domain example.com --proxy 127.0.0.1:9050
 
+# adjust concurrency
+node dist/app/ts/cli.js --wordlist words.txt --concurrency 10
+# defaults to 5 simultaneous lookups
+
 # purge expired cache
 node dist/app/ts/cli.js --purge-cache
 


### PR DESCRIPTION
## Summary
- allow setting concurrency via `--concurrency`
- forward concurrency value to lookup logic
- document CLI concurrency usage
- extend CLI unit tests

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_687438aa4c248325a4181e0be0062309