### PR TITLE
feat: enforce json body limit

### DIFF
--- a/app/ts/server/index.ts
+++ b/app/ts/server/index.ts
@@ -7,7 +7,7 @@ const debug = debugFactory('server');
 
 export function createServer() {
   const app = express();
-  app.use(express.json());
+  app.use(express.json({ limit: '1mb' }));
 
   app.post('/lookup', async (req: Request, res: Response) => {
     const domain = req.body?.domain;

--- a/readme.md
+++ b/readme.md
@@ -197,6 +197,13 @@ node dist/app/ts/cli.js --download-model
 node dist/app/ts/cli.js --suggest "short tech names" --suggest-count 5
 ```
 
+### HTTP server
+
+Running `node dist/app/ts/server/index.js` starts a small API exposing `/lookup`
+and `/bulk-lookup` routes. Request bodies are parsed with `express.json` and are
+limited to **1&nbsp;MB**. Payloads larger than this size are rejected with a
+`413` response.
+
 If a lookup fails, the result for that domain is still included with
 `status` set to `error` and an empty `whoisreply` field.
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -53,4 +53,16 @@ describe('server endpoints', () => {
     expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: 'fail' });
   });
+
+  test('rejects bodies over 1mb', async () => {
+    const large = 'a'.repeat(1024 * 1024 + 1);
+    const res = await request(app).post('/lookup').send({ big: large });
+    expect(res.status).toBe(413);
+  });
+
+  test('bulk-lookup rejects bodies over 1mb', async () => {
+    const large = 'a'.repeat(1024 * 1024 + 1);
+    const res = await request(app).post('/bulk-lookup').send({ big: large });
+    expect(res.status).toBe(413);
+  });
 });


### PR DESCRIPTION
## Summary
- limit JSON payloads in `createServer`
- test payloads larger than 1MB
- document the size limit in the README

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: better-sqlite3 module version mismatch)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6874f96c81508325a9ca216794b3b343