### PR TITLE
feat(cli): secure filename randomization

### DIFF
--- a/app/ts/cli/export.ts
+++ b/app/ts/cli/export.ts
@@ -1,4 +1,4 @@
-import { randomInt } from '../utils/random.js';
+import { randomBytes } from 'crypto';
 
 export function generateFilename(ext: string): string {
   function pad(n: number): string {
@@ -12,6 +12,6 @@ export function generateFilename(ext: string): string {
     pad(d.getHours()) +
     pad(d.getMinutes()) +
     pad(d.getSeconds());
-  const hex = randomInt(0, 0xffffff).toString(16).padStart(6, '0');
+  const hex = randomBytes(3).toString('hex');
   return `bulkwhois-export-${datetime}-${hex}${ext}`;
 }

--- a/test/generateFilename.test.ts
+++ b/test/generateFilename.test.ts
@@ -2,7 +2,7 @@ import { generateFilename } from '../app/ts/cli/export';
 
 describe('generateFilename', () => {
   const RealDate = Date;
-  const RealRandom = Math.random;
+  let randomBytesSpy: jest.SpyInstance;
 
   beforeAll(() => {
     class MockDate extends RealDate {
@@ -15,17 +15,19 @@ describe('generateFilename', () => {
     }
     // @ts-ignore
     global.Date = MockDate as DateConstructor;
-    Math.random = () => 0.1;
+    randomBytesSpy = jest
+      .spyOn(require('crypto'), 'randomBytes')
+      .mockReturnValue(Buffer.from('012345', 'hex'));
   });
 
   afterAll(() => {
     // @ts-ignore
     global.Date = RealDate;
-    Math.random = RealRandom;
+    randomBytesSpy.mockRestore();
   });
 
   test('returns deterministic filename with given extension', () => {
     const result = generateFilename('.csv');
-    expect(result).toBe('bulkwhois-export-20210102030405-199999.csv');
+    expect(result).toBe('bulkwhois-export-20210102030405-012345.csv');
   });
 });


### PR DESCRIPTION
## Summary
- replace `randomInt` with `crypto.randomBytes` for filename generation
- update unit test to stub `crypto.randomBytes`

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: SyntaxError in jest.setup.ts)*
- `npm run test:e2e` *(fails: WebDriverError: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68750b88cf988325b7059e5f305b35f8