### PR TITLE
fix: close fs watchers on app exit

### DIFF
--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -76,7 +76,7 @@ interface MainSettings extends BaseSettings {
   [key: string]: any;
 }
 
-import './main/fsIpc.js';
+import { cleanupWatchers } from './main/fsIpc.js';
 import './main/pathIpc.js';
 import './main/utils.js';
 import './main/index.js';
@@ -84,6 +84,8 @@ import './main/index.js';
 let settings: MainSettings;
 let mainWindow: BrowserWindow;
 let exitConfirmed = false;
+
+app.on('will-quit', cleanupWatchers);
 
 /*
   app.on('ready', function() {...}

--- a/app/ts/main/fsIpc.ts
+++ b/app/ts/main/fsIpc.ts
@@ -7,6 +7,13 @@ type ReaddirOpts = fs.ReaddirOptions | BufferEncoding | undefined;
 const watchers = new Map<number, fs.FSWatcher>();
 let watcherId = 0;
 
+export function cleanupWatchers() {
+  for (const watcher of watchers.values()) {
+    watcher.close();
+  }
+  watchers.clear();
+}
+
 ipcMain.handle('fs:readFile', async (_e, p: string, opts?: ReadFileOpts) => {
   return fs.promises.readFile(p, opts);
 });

--- a/test/fsIpc.test.ts
+++ b/test/fsIpc.test.ts
@@ -37,7 +37,7 @@ jest.mock('fs', () => {
   };
 });
 
-import '../app/ts/main/fsIpc';
+import { cleanupWatchers } from '../app/ts/main/fsIpc';
 
 const getHandler = (c: string) => ipcMainHandlers[c];
 
@@ -78,5 +78,18 @@ describe('fsIpc handlers', () => {
 
     await unwatchHandler({}, id);
     expect(watchCloseMocks[0]).toHaveBeenCalled();
+  });
+
+  test('cleanupWatchers closes active watchers', async () => {
+    const watchHandler = getHandler('fs:watch');
+    const sender = { send: jest.fn() };
+
+    await watchHandler({ sender } as any, 'a', '/tmp/a', {});
+    await watchHandler({ sender } as any, 'b', '/tmp/b', {});
+
+    cleanupWatchers();
+
+    expect(watchCloseMocks[0]).toHaveBeenCalled();
+    expect(watchCloseMocks[1]).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- ensure file system watchers are closed on app quit
- expose `cleanupWatchers` from fsIpc
- hook the cleanup to Electron `will-quit` event
- test watcher cleanup logic

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Jest encountered unexpected token)*
- `npm run test:e2e` *(fails: session not created: user data directory is already in use)*

------
https://chatgpt.com/codex/tasks/task_e_68750b8bc9708325a4bb27b2a658afa3