### PR TITLE
Add server route tests

### DIFF
--- a/test/serverRoutes.test.ts
+++ b/test/serverRoutes.test.ts
@@ -1,0 +1,59 @@
+import request from 'supertest';
+
+jest.mock('../app/ts/common/lookup', () => ({
+  lookup: jest.fn(async () => 'lookup-data')
+}));
+
+jest.mock('../app/ts/cli', () => ({
+  lookupDomains: jest.fn(async () => ['bulk-data'])
+}));
+
+import { createServer } from '../app/ts/server/index';
+import { lookup } from '../app/ts/common/lookup';
+import { lookupDomains } from '../app/ts/cli';
+
+let server: ReturnType<ReturnType<typeof createServer>['listen']>;
+
+beforeEach(() => {
+  const app = createServer();
+  server = app.listen();
+});
+
+afterEach(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+describe('server routes', () => {
+  test('missing domain returns 400', async () => {
+    const res = await request(server).post('/lookup').send({});
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'domain required' });
+  });
+
+  test('valid single lookup', async () => {
+    const res = await request(server).post('/lookup').send({ domain: 'example.com' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ result: 'lookup-data' });
+    expect(lookup).toHaveBeenCalledWith('example.com');
+  });
+
+  test('bulk lookup with valid payload', async () => {
+    const payload = { domains: ['a.com'], tlds: ['com', 'net'], proxy: 'p' };
+    const res = await request(server).post('/bulk-lookup').send(payload);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ result: ['bulk-data'] });
+    expect(lookupDomains).toHaveBeenCalledWith({ ...payload, format: 'txt' });
+  });
+
+  test('bulk lookup with invalid payload', async () => {
+    const res = await request(server).post('/bulk-lookup').send({ domains: 'a.com' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ result: ['bulk-data'] });
+    expect(lookupDomains).toHaveBeenCalledWith({
+      domains: [],
+      tlds: ['com'],
+      proxy: undefined,
+      format: 'txt'
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add `serverRoutes.test.ts` integration tests for express routes

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: SyntaxError in jest.setup.ts)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68753b80b9d88325aca714da0fd552f7