### PR TITLE
fix: type union for scheduler data

### DIFF
--- a/app/ts/main/bulkwhois/scheduler.ts
+++ b/app/ts/main/bulkwhois/scheduler.ts
@@ -33,7 +33,7 @@ export function processDomain(
   const { sender } = event;
 
   processingIDs[domainSetup.index!] = setTimeout(async () => {
-    let data: any;
+    let data: string | Result<boolean, DnsLookupError> | null = null;
     const settings = getSettings();
     stats.domains.sent++;
     sender.send(IpcChannel.BulkwhoisStatusUpdate, 'domains.sent', stats.domains.sent);


### PR DESCRIPTION
## Summary
- properly type `data` in the bulk WHOIS scheduler

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Jest encountered unexpected tokens)*
- `npm run test:e2e` *(fails: WebDriver could not start Electron)*

------
https://chatgpt.com/codex/tasks/task_e_68753b75c82c83259981980178d16f90