### PR TITLE
Fix equality check in scheduler

### DIFF
--- a/app/ts/main/bulkwhois/scheduler.ts
+++ b/app/ts/main/bulkwhois/scheduler.ts
@@ -46,7 +46,7 @@ export function processDomain(
 
     try {
       data =
-        settings.lookupGeneral.type == 'whois'
+        settings.lookupGeneral.type === 'whois'
           ? await whoisLookup(domainSetup.domain!, {
               follow: domainSetup.follow,
               timeout: domainSetup.timeout


### PR DESCRIPTION
## Summary
- use strict equality for lookup type in BulkWhois scheduler

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: SyntaxError in jest.setup.ts)*
- `npm run test:e2e` *(fails: WebDriverError: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68753b70e10883258725f346266c41d1