### PR TITLE
Fix watcher cleanup on sender destroy

### DIFF
--- a/app/ts/main/fsIpc.ts
+++ b/app/ts/main/fsIpc.ts
@@ -44,6 +44,10 @@ ipcMain.handle('fs:watch', (e, prefix: string, p: string, opts?: fs.WatchOptions
   const watcher = fs.watch(p, opts || {}, (event) => {
     sender.send(`fs:watch:${prefix}:${id}`, event);
   });
+  sender.once('destroyed', () => {
+    watcher.close();
+    watchers.delete(id);
+  });
   watchers.set(id, watcher);
   return id;
 });

--- a/test/fsIpc.test.ts
+++ b/test/fsIpc.test.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { EventEmitter } from 'events';
 
 const ipcMainHandlers: Record<string, (...args: any[]) => any> = {};
 
@@ -78,6 +79,21 @@ describe('fsIpc handlers', () => {
 
     await unwatchHandler({}, id);
     expect(watchCloseMocks[0]).toHaveBeenCalled();
+  });
+
+  test('watcher is removed when sender is destroyed', async () => {
+    const watchHandler = getHandler('fs:watch');
+    const unwatchHandler = getHandler('fs:unwatch');
+    const sender = new EventEmitter() as any;
+    sender.send = jest.fn();
+
+    const id = await watchHandler({ sender } as any, 'pref', '/tmp/file', {});
+    sender.emit('destroyed');
+    expect(watchCloseMocks[0]).toHaveBeenCalled();
+
+    watchCloseMocks[0].mockClear();
+    await unwatchHandler({}, id);
+    expect(watchCloseMocks[0]).not.toHaveBeenCalled();
   });
 
   test('cleanupWatchers closes active watchers', async () => {


### PR DESCRIPTION
## Summary
- close fs watchers if the sender is destroyed
- ensure watcher removal is tested

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Jest encountered unexpected token errors)*

------
https://chatgpt.com/codex/tasks/task_e_68753b6d031c8325967903b9a386c3a6