### PR TITLE
Handle empty counts in OpenAI suggestions

### DIFF
--- a/app/ts/ai/openaiSuggest.ts
+++ b/app/ts/ai/openaiSuggest.ts
@@ -5,6 +5,9 @@ import { ensureFetch } from '../utils/fetchCompat.js';
 const debug = debugFactory('ai.openaiSuggest');
 
 export async function suggestWords(prompt: string, count: number): Promise<string[]> {
+  if (count <= 0) {
+    return [];
+  }
   await ensureFetch();
   const { url, apiKey } = settings.ai.openai ?? {};
   if (!url || !apiKey) {

--- a/test/openaiSuggest.test.ts
+++ b/test/openaiSuggest.test.ts
@@ -41,4 +41,12 @@ describe('openai suggestions', () => {
     expect(nodeFetchMock).toHaveBeenCalled();
     expect(res).toEqual(['alpha']);
   });
+
+  test('returns empty array when count non-positive', async () => {
+    settings.ai.openai.url = 'https://api';
+    settings.ai.openai.apiKey = 'key';
+    const res = await suggestWords('hello', 0);
+    expect((fetch as jest.Mock).mock.calls.length).toBe(0);
+    expect(res).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary
- exit early in `openaiSuggest` when `count` is non-positive
- test no call is made when requesting 0 suggestions

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Jest encountered unexpected token)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68753b6a13148325b4f1b850b3b9b977