### PR TITLE
Fix path aliases for Node runtime

### DIFF
--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { dirnameCompat } from '@utils/dirnameCompat.js';
+import { dirnameCompat } from '#utils/dirnameCompat.js';
 import { debugFactory } from './logger.js';
 import {
   settings,

--- a/app/ts/main/bulkwhois/queue.ts
+++ b/app/ts/main/bulkwhois/queue.ts
@@ -1,6 +1,6 @@
-import { debugFactory } from '@common/logger.js';
-import { formatString } from '@common/stringformat.js';
-import { randomInt } from '@utils/random.js';
+import { debugFactory } from '#common/logger.js';
+import { formatString } from '#common/stringformat.js';
+import { randomInt } from '#utils/random.js';
 import type { Settings } from '../settings-main.js';
 import type { DomainSetup } from './types.js';
 

--- a/app/ts/main/bulkwhois/resultHandler.ts
+++ b/app/ts/main/bulkwhois/resultHandler.ts
@@ -1,16 +1,16 @@
-import { debugFactory } from '@common/logger.js';
-import { isDomainAvailable, getDomainParameters } from '@common/availability.js';
-import DomainStatus from '@common/status.js';
-import { toJSON } from '@common/parser.js';
+import { debugFactory } from '#common/logger.js';
+import { isDomainAvailable, getDomainParameters } from '#common/availability.js';
+import DomainStatus from '#common/status.js';
+import { toJSON } from '#common/parser.js';
 import { performance } from 'perf_hooks';
 import { getSettings } from '../settings-main.js';
-import { formatString } from '@common/stringformat.js';
+import { formatString } from '#common/stringformat.js';
 import type { BulkWhois, ProcessedResult } from './types.js';
-import * as dns from '@common/dnsLookup.js';
-import { Result, DnsLookupError } from '@common/errors.js';
+import * as dns from '#common/dnsLookup.js';
+import { Result, DnsLookupError } from '#common/errors.js';
 import type { IpcMainEvent } from 'electron';
-import { addEntry as addHistoryEntry } from '@common/history.js';
-import { IpcChannel } from '@common/ipcChannels.js';
+import { addEntry as addHistoryEntry } from '#common/history.js';
+import { IpcChannel } from '#common/ipcChannels.js';
 
 const debug = debugFactory('bulkwhois.resultHandler');
 

--- a/app/ts/main/utils.ts
+++ b/app/ts/main/utils.ts
@@ -1,10 +1,10 @@
 import { ipcMain, shell } from 'electron';
 import Papa from 'papaparse';
-import { isDomainAvailable, getDomainParameters } from '@common/availability.js';
-import DomainStatus from '@common/status.js';
-import { IpcChannel } from '@common/ipcChannels.js';
-import { toJSON } from '@common/parser.js';
-import { getUserDataPath } from '@common/settings.js';
+import { isDomainAvailable, getDomainParameters } from '#common/availability.js';
+import DomainStatus from '#common/status.js';
+import { IpcChannel } from '#common/ipcChannels.js';
+import { toJSON } from '#common/parser.js';
+import { getUserDataPath } from '#common/settings.js';
 
 ipcMain.handle(IpcChannel.ParseCsv, async (_e, text: string) => {
   return Papa.parse(text, { header: true });

--- a/app/ts/renderer/bulkwhois/state.ts
+++ b/app/ts/renderer/bulkwhois/state.ts
@@ -1,5 +1,5 @@
-import { IpcChannel } from '@common/ipcChannels.js';
-import type { BulkWhoisResults } from '@main/bulkwhois/types.js';
+import { IpcChannel } from '#common/ipcChannels.js';
+import type { BulkWhoisResults } from '#main/bulkwhois/types.js';
 
 let bulkResults: BulkWhoisResults | null = null;
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,13 +11,13 @@ export default {
   transformIgnorePatterns: ['node_modules/(?!(change-case|html-entities)/)'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
-    '^@common/(.*)\\.js$': '<rootDir>/app/ts/common/$1.ts',
-    '^@main/(.*)\\.js$': '<rootDir>/app/ts/main/$1.ts',
-    '^@renderer/(.*)\\.js$': '<rootDir>/app/ts/renderer/$1.ts',
-    '^@utils/(.*)\\.js$': '<rootDir>/app/ts/utils/$1.ts',
-    '^@ai/(.*)\\.js$': '<rootDir>/app/ts/ai/$1.ts',
-    '^@cli/(.*)\\.js$': '<rootDir>/app/ts/cli/$1.ts',
-    '^@server/(.*)\\.js$': '<rootDir>/app/ts/server/$1.ts'
+    '^#common/(.*)\\.js$': '<rootDir>/app/ts/common/$1.ts',
+    '^#main/(.*)\\.js$': '<rootDir>/app/ts/main/$1.ts',
+    '^#renderer/(.*)\\.js$': '<rootDir>/app/ts/renderer/$1.ts',
+    '^#utils/(.*)\\.js$': '<rootDir>/app/ts/utils/$1.ts',
+    '^#ai/(.*)\\.js$': '<rootDir>/app/ts/ai/$1.ts',
+    '^#cli/(.*)\\.js$': '<rootDir>/app/ts/cli/$1.ts',
+    '^#server/(.*)\\.js$': '<rootDir>/app/ts/server/$1.ts'
   },
   setupFiles: ['<rootDir>/test/jest.setup.ts'],
   collectCoverage: true,

--- a/package.json
+++ b/package.json
@@ -4,6 +4,15 @@
   "type": "module",
   "description": "Bulk whois lookup tool",
   "main": "./dist/app/ts/main.js",
+  "imports": {
+    "#common/*": "./dist/app/ts/common/*.js",
+    "#main/*": "./dist/app/ts/main/*.js",
+    "#renderer/*": "./dist/app/ts/renderer/*.js",
+    "#utils/*": "./dist/app/ts/utils/*.js",
+    "#ai/*": "./dist/app/ts/ai/*.js",
+    "#cli/*": "./dist/app/ts/cli/*.js",
+    "#server/*": "./dist/app/ts/server/*.js"
+  },
   "scripts": {
     "start": "npm run build && npm run postbuild && cross-env NODE_OPTIONS=--experimental-specifier-resolution=node electron .",
     "debug-powershell": "@powershell -Command $env:DEBUG='*';npm start;",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -19,13 +19,13 @@
     ],
     "baseUrl": "./",
     "paths": {
-      "@common/*": ["app/ts/common/*"],
-      "@main/*": ["app/ts/main/*"],
-      "@renderer/*": ["app/ts/renderer/*"],
-      "@utils/*": ["app/ts/utils/*"],
-      "@ai/*": ["app/ts/ai/*"],
-      "@cli/*": ["app/ts/cli/*"],
-      "@server/*": ["app/ts/server/*"]
+      "#common/*": ["app/ts/common/*"],
+      "#main/*": ["app/ts/main/*"],
+      "#renderer/*": ["app/ts/renderer/*"],
+      "#utils/*": ["app/ts/utils/*"],
+      "#ai/*": ["app/ts/ai/*"],
+      "#cli/*": ["app/ts/cli/*"],
+      "#server/*": ["app/ts/server/*"]
     },
     "noImplicitAny": true,
     "strictNullChecks": true,


### PR DESCRIPTION
## Summary
- configure Node import maps with new `#` prefixed aliases
- update TypeScript paths and Jest module mapping
- switch code imports to new aliases

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: SyntaxError: Unexpected token 'export')*
- `npm run test:e2e` *(fails: session not created)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687b60cfaf008325a55c4f63b6bf9e2d