### PR TITLE
Fix module alias imports

### DIFF
--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { dirnameCompat } from '#utils/dirnameCompat.js';
+import { dirnameCompat } from '#utils/dirnameCompat';
 import { debugFactory } from './logger.js';
 import {
   settings,

--- a/app/ts/main/bulkwhois/queue.ts
+++ b/app/ts/main/bulkwhois/queue.ts
@@ -1,6 +1,6 @@
-import { debugFactory } from '#common/logger.js';
-import { formatString } from '#common/stringformat.js';
-import { randomInt } from '#utils/random.js';
+import { debugFactory } from '#common/logger';
+import { formatString } from '#common/stringformat';
+import { randomInt } from '#utils/random';
 import type { Settings } from '../settings-main.js';
 import type { DomainSetup } from './types.js';
 

--- a/app/ts/main/bulkwhois/resultHandler.ts
+++ b/app/ts/main/bulkwhois/resultHandler.ts
@@ -1,16 +1,16 @@
-import { debugFactory } from '#common/logger.js';
-import { isDomainAvailable, getDomainParameters } from '#common/availability.js';
-import DomainStatus from '#common/status.js';
-import { toJSON } from '#common/parser.js';
+import { debugFactory } from '#common/logger';
+import { isDomainAvailable, getDomainParameters } from '#common/availability';
+import DomainStatus from '#common/status';
+import { toJSON } from '#common/parser';
 import { performance } from 'perf_hooks';
 import { getSettings } from '../settings-main.js';
-import { formatString } from '#common/stringformat.js';
+import { formatString } from '#common/stringformat';
 import type { BulkWhois, ProcessedResult } from './types.js';
-import * as dns from '#common/dnsLookup.js';
-import { Result, DnsLookupError } from '#common/errors.js';
+import * as dns from '#common/dnsLookup';
+import { Result, DnsLookupError } from '#common/errors';
 import type { IpcMainEvent } from 'electron';
-import { addEntry as addHistoryEntry } from '#common/history.js';
-import { IpcChannel } from '#common/ipcChannels.js';
+import { addEntry as addHistoryEntry } from '#common/history';
+import { IpcChannel } from '#common/ipcChannels';
 
 const debug = debugFactory('bulkwhois.resultHandler');
 

--- a/app/ts/main/utils.ts
+++ b/app/ts/main/utils.ts
@@ -1,10 +1,10 @@
 import { ipcMain, shell } from 'electron';
 import Papa from 'papaparse';
-import { isDomainAvailable, getDomainParameters } from '#common/availability.js';
-import DomainStatus from '#common/status.js';
-import { IpcChannel } from '#common/ipcChannels.js';
-import { toJSON } from '#common/parser.js';
-import { getUserDataPath } from '#common/settings.js';
+import { isDomainAvailable, getDomainParameters } from '#common/availability';
+import DomainStatus from '#common/status';
+import { IpcChannel } from '#common/ipcChannels';
+import { toJSON } from '#common/parser';
+import { getUserDataPath } from '#common/settings';
 
 ipcMain.handle(IpcChannel.ParseCsv, async (_e, text: string) => {
   return Papa.parse(text, { header: true });

--- a/app/ts/renderer/bulkwhois/state.ts
+++ b/app/ts/renderer/bulkwhois/state.ts
@@ -1,5 +1,5 @@
-import { IpcChannel } from '#common/ipcChannels.js';
-import type { BulkWhoisResults } from '#main/bulkwhois/types.js';
+import { IpcChannel } from '#common/ipcChannels';
+import type { BulkWhoisResults } from '#main/bulkwhois/types';
 
 let bulkResults: BulkWhoisResults | null = null;
 


### PR DESCRIPTION
## Summary
- correct internal `#` alias imports that included `.js` extensions

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Jest encountered unexpected token)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_687b63ae7c7483259dac87cf17aa7459