### PR TITLE
fix: handle punycode import

### DIFF
--- a/app/ts/common/lookup.ts
+++ b/app/ts/common/lookup.ts
@@ -1,5 +1,5 @@
 import psl from 'psl';
-import { toASCII } from 'punycode/punycode.js';
+import punycode from 'punycode';
 import uts46 from 'idna-uts46';
 import whois from 'whois';
 import { debugFactory } from './logger.js';
@@ -70,7 +70,7 @@ export function convertDomain(domain: string, mode?: string): string {
 
   switch (mode) {
     case 'punycode':
-      return toASCII(domain);
+      return punycode.toASCII(domain);
     case 'uts46':
       return uts46.toAscii(domain);
     case 'uts46-transitional':


### PR DESCRIPTION
## Summary
- fix punycode import in lookup module

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Jest couldn't parse ESM setup)*
- `npm run test:e2e` *(fails: webdriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_687c0d4f2ab48325820522311ef97ee2