### PR TITLE
fix: resolve debug import for renderer

### DIFF
--- a/app/vendor/debug.js
+++ b/app/vendor/debug.js
@@ -1,2 +1,2 @@
-import debug from 'debug/src/browser.js';
+import debug from '../node_modules/debug/src/browser.js';
 export default debug;

--- a/scripts/regenerateVendor.mjs
+++ b/scripts/regenerateVendor.mjs
@@ -73,7 +73,10 @@ export function regenerateVendor() {
   );
 
   const dbgDest = path.join(vendorDir, 'debug.js');
-  writeFile(dbgDest, "import debug from 'debug/src/browser.js';\nexport default debug;\n");
+  writeFile(
+    dbgDest,
+    "import debug from '../node_modules/debug/src/browser.js';\nexport default debug;\n"
+  );
   writeFile(
     path.join(vendorDir, 'debug.d.ts'),
     "import debug from 'debug';\nexport default debug;\n"


### PR DESCRIPTION
## Summary
- use a file path in `app/vendor/debug.js` so the renderer can load it
- update vendor regeneration script to write the new path

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm test` *(fails: Jest encountered unexpected token)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_687c1de68ab48325a1fd2f8b92d38390