### PR TITLE
Enable Node integration

### DIFF
--- a/app/ts/appsettings.ts
+++ b/app/ts/appsettings.ts
@@ -24,7 +24,7 @@ const appSettings = {
     },
     appWindowWebPreferences: {
       // Web preferences
-      nodeIntegration: false, // Enable Node.js integration
+      nodeIntegration: true, // Enable Node.js integration
       contextIsolation: true, // Enable context isolation
       zoomFactor: 1.0, // Page zoom factor
       images: true, // Image support

--- a/readme.md
+++ b/readme.md
@@ -258,7 +258,7 @@ falling back to `process.cwd()`.
 
 Whoisdigger uses a settings file that rules how the application behaves overall, this can be achieved by either using the preload settings file or change the `appsettings.ts` inside `js`.
 
-Context isolation is always enabled for security purposes and cannot be disabled in configuration. Node integration is disabled by default, so renderer scripts can access Electron only through the preload API.
+Context isolation is always enabled for security purposes and cannot be disabled in configuration. Node integration is enabled by default, allowing renderer scripts to access Node.js directly. You can disable it through the configuration if required.
 
 ### Theme
 


### PR DESCRIPTION
## Summary
- allow renderer processes to access Node APIs by default
- document new default in README

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: SyntaxError in test setup)*
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_687c214576e48325b57c6b1678a16cc5