### PR TITLE
fix: correct debug module path

### DIFF
--- a/app/vendor/debug.js
+++ b/app/vendor/debug.js
@@ -1,2 +1,2 @@
-import debug from '../node_modules/debug/src/browser.js';
+import debug from 'debug/src/browser.js';
 export default debug;


### PR DESCRIPTION
## Summary
- fix debug path by importing from `debug/src/browser.js`

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: SyntaxError in jest setup)*
- `npm run test:e2e` *(fails: WebDriverError session not created)*

------
https://chatgpt.com/codex/tasks/task_e_687c24e3b6708325906a63db2473b801