### PR TITLE
fix: correct debug module path

### DIFF
--- a/scripts/regenerateVendor.mjs
+++ b/scripts/regenerateVendor.mjs
@@ -73,10 +73,7 @@ export function regenerateVendor() {
   );
 
   const dbgDest = path.join(vendorDir, 'debug.js');
-  writeFile(
-    dbgDest,
-    "import debug from '../node_modules/debug/src/browser.js';\nexport default debug;\n"
-  );
+  writeFile(dbgDest, "import debug from 'debug/src/browser.js';\nexport default debug;\n");
   writeFile(
     path.join(vendorDir, 'debug.d.ts'),
     "import debug from 'debug';\nexport default debug;\n"


### PR DESCRIPTION
## Summary
- fix vendor generation script to import debug browser variant directly

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Jest unexpected token)*
- `npm run test:e2e` *(fails: WebDriverError user-data-dir in use)*

------
https://chatgpt.com/codex/tasks/task_e_687cb1db36348325b57c32136949c575