### PR TITLE
Fix: enforce node integration

### DIFF
--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -53,6 +53,7 @@ export async function load(): Promise<Settings> {
           setSettings(mergeDefaults(parsed));
           if (settings.appWindowWebPreferences) {
             settings.appWindowWebPreferences.contextIsolation = true;
+            settings.appWindowWebPreferences.nodeIntegration = true;
           }
           setCustomSettingsLoaded(true);
           debug(`Loaded custom configuration at ${filePath}`);
@@ -60,6 +61,7 @@ export async function load(): Promise<Settings> {
           setSettings(JSON.parse(JSON.stringify(defaultSettings)));
           if (settings.appWindowWebPreferences) {
             settings.appWindowWebPreferences.contextIsolation = true;
+            settings.appWindowWebPreferences.nodeIntegration = true;
           }
           setCustomSettingsLoaded(false);
           debug(`Failed to merge custom configuration with error: ${mergeError}`);
@@ -73,6 +75,7 @@ export async function load(): Promise<Settings> {
       setCustomSettingsLoaded(false);
       if (settings.appWindowWebPreferences) {
         settings.appWindowWebPreferences.contextIsolation = true;
+        settings.appWindowWebPreferences.nodeIntegration = true;
       }
       // Silently ignore loading errors
     }
@@ -82,6 +85,7 @@ export async function load(): Promise<Settings> {
   if (settings.appWindowWebPreferences) {
     // Enforce context isolation regardless of loaded configuration
     settings.appWindowWebPreferences.contextIsolation = true;
+    settings.appWindowWebPreferences.nodeIntegration = true;
   }
   return settings;
 }

--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -124,7 +124,7 @@ app.on('ready', async function () {
     darkTheme: appWindow.darkTheme, // GTK dark theme mode
     thickFrame: appWindow.thickFrame, // Use WS_THICKFRAME style for frameless windows on Windows, which adds standard window frame. Setting it to false will remove window shadow and window animations.
     webPreferences: {
-      nodeIntegration: webPreferences.nodeIntegration, // Enable node integration
+      nodeIntegration: true, // Enable node integration always
       contextIsolation: true, // Enforce context isolation for security
       zoomFactor: webPreferences.zoomFactor, // Page zoom factor
       images: webPreferences.images, // Image support

--- a/app/ts/main/settings-main.ts
+++ b/app/ts/main/settings-main.ts
@@ -45,6 +45,7 @@ function watchConfig(): void {
         const merged = mergeDefaults(parsed);
         if (merged.appWindowWebPreferences) {
           merged.appWindowWebPreferences.contextIsolation = true;
+          merged.appWindowWebPreferences.nodeIntegration = true;
         }
         setSettings(merged);
         debug(`Reloaded custom configuration at ${cfg}`);
@@ -52,6 +53,7 @@ function watchConfig(): void {
         const defaults = JSON.parse(JSON.stringify(defaultSettings));
         if (defaults.appWindowWebPreferences) {
           defaults.appWindowWebPreferences.contextIsolation = true;
+          defaults.appWindowWebPreferences.nodeIntegration = true;
         }
         setSettings(defaults);
         debug(`Failed to merge configuration with error: ${mergeError}`);

--- a/test/nodeIntegrationForced.test.ts
+++ b/test/nodeIntegrationForced.test.ts
@@ -1,0 +1,24 @@
+import fs from 'fs';
+import path from 'path';
+import '../test/electronMock';
+
+import { loadSettings, settings, getUserDataPath } from '../app/ts/renderer/settings-renderer';
+
+describe('nodeIntegration enforcement', () => {
+  test('nodeIntegration remains true even when config disables it', async () => {
+    const dir = getUserDataPath();
+    fs.mkdirSync(dir, { recursive: true });
+    const configName = 'node-integration.json';
+    settings.customConfiguration.filepath = configName;
+    fs.writeFileSync(
+      path.join(dir, configName),
+      JSON.stringify({ appWindowWebPreferences: { nodeIntegration: false } })
+    );
+
+    const loaded = await loadSettings();
+
+    expect(loaded.appWindowWebPreferences.nodeIntegration).toBe(true);
+
+    fs.unlinkSync(path.join(dir, configName));
+  });
+});


### PR DESCRIPTION
## Summary
- enforce `nodeIntegration` to true when loading settings
- always set `nodeIntegration` when creating the main window
- keep `nodeIntegration` true when custom settings reload
- test that config can't disable nodeIntegration

## Testing
- `npx prettier --write test/nodeIntegrationForced.test.ts app/ts/common/settings.ts app/ts/main/settings-main.ts app/ts/main.ts`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run test:e2e` *(fails: session not created error)*

------
https://chatgpt.com/codex/tasks/task_e_687cb683aaf48325bc98aa542ffe5985