### PR TITLE
fix: disable context isolation

### DIFF
--- a/app/ts/appsettings.ts
+++ b/app/ts/appsettings.ts
@@ -25,7 +25,7 @@ const appSettings = {
     appWindowWebPreferences: {
       // Web preferences
       nodeIntegration: true, // Enable Node.js integration
-      contextIsolation: true, // Enable context isolation
+      contextIsolation: false, // Disable context isolation
       zoomFactor: 1.0, // Page zoom factor
       images: true, // Image support
       experimentalFeatures: false, // Enable Chromium experimental features
@@ -209,7 +209,7 @@ export const appSettingsDescriptions: Record<string, string> = {
   'appWindow.darkTheme': 'Use GTK dark theme',
   'appWindow.thickFrame': 'Use thick frame on Windows',
   'appWindowWebPreferences.nodeIntegration': 'Enable Node integration (renderer access to Node.js)',
-  'appWindowWebPreferences.contextIsolation': 'Enable context isolation',
+  'appWindowWebPreferences.contextIsolation': 'Use context isolation',
   'appWindowWebPreferences.zoomFactor': 'Page zoom factor',
   'appWindowWebPreferences.images': 'Allow images',
   'appWindowWebPreferences.experimentalFeatures': 'Enable Chromium experimental features',

--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -52,7 +52,7 @@ export async function load(): Promise<Settings> {
         try {
           setSettings(mergeDefaults(parsed));
           if (settings.appWindowWebPreferences) {
-            settings.appWindowWebPreferences.contextIsolation = true;
+            settings.appWindowWebPreferences.contextIsolation = false;
             settings.appWindowWebPreferences.nodeIntegration = true;
           }
           setCustomSettingsLoaded(true);
@@ -60,7 +60,7 @@ export async function load(): Promise<Settings> {
         } catch (mergeError) {
           setSettings(JSON.parse(JSON.stringify(defaultSettings)));
           if (settings.appWindowWebPreferences) {
-            settings.appWindowWebPreferences.contextIsolation = true;
+            settings.appWindowWebPreferences.contextIsolation = false;
             settings.appWindowWebPreferences.nodeIntegration = true;
           }
           setCustomSettingsLoaded(false);
@@ -74,7 +74,7 @@ export async function load(): Promise<Settings> {
       debug(`Failed to load custom configuration with error: ${e}`);
       setCustomSettingsLoaded(false);
       if (settings.appWindowWebPreferences) {
-        settings.appWindowWebPreferences.contextIsolation = true;
+        settings.appWindowWebPreferences.contextIsolation = false;
         settings.appWindowWebPreferences.nodeIntegration = true;
       }
       // Silently ignore loading errors
@@ -83,8 +83,8 @@ export async function load(): Promise<Settings> {
 
   if (!customSettingsLoaded) setCustomSettingsLoaded(false);
   if (settings.appWindowWebPreferences) {
-    // Enforce context isolation regardless of loaded configuration
-    settings.appWindowWebPreferences.contextIsolation = true;
+    // Force context isolation to remain disabled
+    settings.appWindowWebPreferences.contextIsolation = false;
     settings.appWindowWebPreferences.nodeIntegration = true;
   }
   return settings;

--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -125,7 +125,7 @@ app.on('ready', async function () {
     thickFrame: appWindow.thickFrame, // Use WS_THICKFRAME style for frameless windows on Windows, which adds standard window frame. Setting it to false will remove window shadow and window animations.
     webPreferences: {
       nodeIntegration: true, // Enable node integration always
-      contextIsolation: true, // Enforce context isolation for security
+      contextIsolation: false, // Disable context isolation
       zoomFactor: webPreferences.zoomFactor, // Page zoom factor
       images: webPreferences.images, // Image support
       experimentalFeatures: webPreferences.experimentalFeatures, // Enable Chromium experimental features

--- a/app/ts/main/settings-main.ts
+++ b/app/ts/main/settings-main.ts
@@ -44,7 +44,7 @@ function watchConfig(): void {
       try {
         const merged = mergeDefaults(parsed);
         if (merged.appWindowWebPreferences) {
-          merged.appWindowWebPreferences.contextIsolation = true;
+          merged.appWindowWebPreferences.contextIsolation = false;
           merged.appWindowWebPreferences.nodeIntegration = true;
         }
         setSettings(merged);
@@ -52,7 +52,7 @@ function watchConfig(): void {
       } catch (mergeError) {
         const defaults = JSON.parse(JSON.stringify(defaultSettings));
         if (defaults.appWindowWebPreferences) {
-          defaults.appWindowWebPreferences.contextIsolation = true;
+          defaults.appWindowWebPreferences.contextIsolation = false;
           defaults.appWindowWebPreferences.nodeIntegration = true;
         }
         setSettings(defaults);


### PR DESCRIPTION
## Summary
- turn off context isolation by default
- make sure settings enforcement keeps isolation disabled

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: SyntaxError in jest.setup.ts)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_687cbb02f1b8832584b2f3d42c7b7adb