### PR TITLE
fix: resolve debug vendor import path

### DIFF
--- a/app/vendor/debug.js
+++ b/app/vendor/debug.js
@@ -1,2 +1,2 @@
-import debug from 'debug/src/browser.js';
+import debug from '../../node_modules/debug/src/browser.js';
 export default debug;

--- a/scripts/regenerateVendor.mjs
+++ b/scripts/regenerateVendor.mjs
@@ -73,7 +73,11 @@ export function regenerateVendor() {
   );
 
   const dbgDest = path.join(vendorDir, 'debug.js');
-  writeFile(dbgDest, "import debug from 'debug/src/browser.js';\nexport default debug;\n");
+  const dbgPath = path
+    .relative(vendorDir, path.join(modulesDir, 'debug', 'src', 'browser.js'))
+    .split(path.sep)
+    .join('/');
+  writeFile(dbgDest, `import debug from '${dbgPath}';\nexport default debug;\n`);
   writeFile(
     path.join(vendorDir, 'debug.d.ts'),
     "import debug from 'debug';\nexport default debug;\n"

--- a/test/regenerateVendor.test.ts
+++ b/test/regenerateVendor.test.ts
@@ -50,5 +50,10 @@ describe('regenerateVendor', () => {
       path.join(rootDir, 'app', 'vendor', 'handlebars.runtime.d.ts'),
       expect.any(String)
     );
+
+    expect(writeFileMock).toHaveBeenCalledWith(
+      path.join(rootDir, 'app', 'vendor', 'debug.js'),
+      expect.stringContaining("import debug from '../../node_modules/debug/src/browser.js'")
+    );
   });
 });


### PR DESCRIPTION
## Summary
- reference `debug` package using a relative path
- generate vendor file with the correct relative import
- update vendor regeneration test

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Jest encountered unexpected token)*
- `npm run test:e2e` *(fails: WebDriverError session not created)*

------
https://chatgpt.com/codex/tasks/task_e_687cc5c9430083258af24f3a30b08218