### PR TITLE
Fix debug vendor loading

### DIFF
--- a/app/vendor/debug.js
+++ b/app/vendor/debug.js
@@ -1,2 +1,4 @@
-import debug from './debug/browser.js';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const debug = require('./debug/browser.js');
 export default debug;

--- a/scripts/regenerateVendor.mjs
+++ b/scripts/regenerateVendor.mjs
@@ -77,7 +77,13 @@ export function regenerateVendor() {
   const dbgBrowserDest = path.join(dbgDir, 'browser.js');
   copyFile(dbgSrc, dbgBrowserDest);
   const dbgDest = path.join(vendorDir, 'debug.js');
-  writeFile(dbgDest, "import debug from './debug/browser.js';\nexport default debug;\n");
+  writeFile(
+    dbgDest,
+    "import { createRequire } from 'module';\n" +
+      'const require = createRequire(import.meta.url);\n' +
+      "const debug = require('./debug/browser.js');\n" +
+      'export default debug;\n'
+  );
   writeFile(
     path.join(vendorDir, 'debug.d.ts'),
     "import debug from 'debug';\nexport default debug;\n"


### PR DESCRIPTION
## Summary
- load vendor debug via CommonJS require to avoid ESM export error
- update vendor regeneration script

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Jest unable to parse modules)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_687cc9a838f8832588b2b427e4a8f856