### PR TITLE
Fix debug import error

### DIFF
--- a/app/vendor/debug.js
+++ b/app/vendor/debug.js
@@ -1,4 +1,2 @@
-import { createRequire } from 'module';
-const require = createRequire(import.meta.url);
-const debug = require('./debug/browser.cjs');
+import debug from './debug/browser.cjs';
 export default debug;

--- a/scripts/regenerateVendor.mjs
+++ b/scripts/regenerateVendor.mjs
@@ -80,13 +80,7 @@ export function regenerateVendor() {
   copyFile(dbgBrowserSrc, dbgBrowserDest);
   copyFile(dbgCommonSrc, dbgCommonDest);
   const dbgDest = path.join(vendorDir, 'debug.js');
-  writeFile(
-    dbgDest,
-    "import { createRequire } from 'module';\n" +
-      'const require = createRequire(import.meta.url);\n' +
-      "const debug = require('./debug/browser.cjs');\n" +
-      'export default debug;\n'
-  );
+  writeFile(dbgDest, "import debug from './debug/browser.cjs';\n" + 'export default debug;\n');
   writeFile(
     path.join(vendorDir, 'debug.d.ts'),
     "import debug from 'debug';\nexport default debug;\n"


### PR DESCRIPTION
## Summary
- update vendor debug module to use an ES import
- adjust regenerateVendor script to output ES import

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Jest unexpected token)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_687cdac949508325bf87deb9c78f0a24