### PR TITLE
fix: export debug module correctly

### DIFF
--- a/app/vendor/debug.js
+++ b/app/vendor/debug.js
@@ -1,2 +1,2 @@
-import debug from './debug/browser.js';
+import debug from 'debug';
 export default debug;

--- a/scripts/regenerateVendor.mjs
+++ b/scripts/regenerateVendor.mjs
@@ -80,7 +80,7 @@ export function regenerateVendor() {
   copyFile(dbgBrowserSrc, dbgBrowserDest);
   copyFile(dbgCommonSrc, dbgCommonDest);
   const dbgDest = path.join(vendorDir, 'debug.js');
-  writeFile(dbgDest, "import debug from './debug/browser.js';\n" + 'export default debug;\n');
+  writeFile(dbgDest, "import debug from 'debug';\n" + 'export default debug;\n');
   writeFile(
     path.join(vendorDir, 'debug.d.ts'),
     "import debug from 'debug';\nexport default debug;\n"


### PR DESCRIPTION
## Summary
- re-export debug from the installed package to avoid ESM errors
- update vendor regeneration script to match new debug export

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_687ce16972fc83258b92cff20aa3beb6