### PR TITLE
Fix debug import loop

### DIFF
--- a/app/vendor/debug.js
+++ b/app/vendor/debug.js
@@ -1,2 +1,2 @@
-import debug from 'debug';
+import debug from './debug/browser.js';
 export default debug;


### PR DESCRIPTION
## Summary
- point vendor `debug.js` at browser build to avoid self-import cycle

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Unexpected token 'export')*
- `npm run test:e2e` *(fails: WebDriverError: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_687ce44259a48325bac1b64b235212ec