### PR TITLE
fix: resolve debug self-import

### DIFF
--- a/app/vendor/debug.js
+++ b/app/vendor/debug.js
@@ -1,2 +1,2 @@
-import debug from 'debug';
+import debug from './debug/browser.js';
 export default debug;

--- a/scripts/regenerateVendor.mjs
+++ b/scripts/regenerateVendor.mjs
@@ -80,7 +80,7 @@ export function regenerateVendor() {
   copyFile(dbgBrowserSrc, dbgBrowserDest);
   copyFile(dbgCommonSrc, dbgCommonDest);
   const dbgDest = path.join(vendorDir, 'debug.js');
-  writeFile(dbgDest, "import debug from 'debug';\n" + 'export default debug;\n');
+  writeFile(dbgDest, "import debug from './debug/browser.js';\n" + 'export default debug;\n');
   writeFile(
     path.join(vendorDir, 'debug.d.ts'),
     "import debug from 'debug';\nexport default debug;\n"


### PR DESCRIPTION
## Summary
- fix debug.js self-import causing reference error
- update vendor regeneration script

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format:check`
- `npm test` *(fails: SyntaxError in jest.setup.ts)*
- `npm run test:e2e` *(fails: session not created for ChromeDriver)*

------
https://chatgpt.com/codex/tasks/task_e_687ce84bccd88325b4ead01f9903b4a2