### PR TITLE
refactor: replace jquery with dom apis

### DIFF
--- a/app/ts/mainPanel.ts
+++ b/app/ts/mainPanel.ts
@@ -1,6 +1,4 @@
 import './common/fontawesome.js';
-import $ from '../vendor/jquery.js';
-(window as any).$ = (window as any).jQuery = $;
 
 // The main HTML file is precompiled and loaded directly, so loading
 // additional content at runtime is unnecessary.

--- a/app/ts/renderer.ts
+++ b/app/ts/renderer.ts
@@ -1,6 +1,4 @@
 // Base path --> assets/html
-import $ from '../vendor/jquery.js';
-
 import './renderer/index.js';
 import { loadSettings, settings, customSettingsLoaded } from './renderer/settings-renderer.js';
 import { loadTranslations, registerTranslationHelpers } from './renderer/i18n.js';
@@ -14,14 +12,19 @@ const electron = (window as any).electron as RendererElectronAPI;
 const debug = debugFactory('renderer.entry');
 debug('loaded');
 
-(window as any).$ = $;
-(window as any).jQuery = $;
+function qs<T extends Element = HTMLElement>(sel: string): T | null {
+  return document.querySelector(sel) as T | null;
+}
+
+function qsa<T extends Element = HTMLElement>(sel: string): T[] {
+  return Array.from(document.querySelectorAll(sel)) as T[];
+}
 
 /*
   $(document).ready(function() {...});
     When document is ready
  */
-$(document).ready(async function () {
+document.addEventListener('DOMContentLoaded', async () => {
   await loadSettings();
   await loadTranslations(settings.ui.language);
   registerTranslationHelpers();
@@ -32,8 +35,6 @@ $(document).ready(async function () {
 
   startup();
   void import('./renderer/navigation.js');
-
-  return;
 });
 
 /*
@@ -44,22 +45,20 @@ function startup() {
   const { appWindowNavigation: navigation } = settings;
 
   sendDebug(formatString("'navigation.developerTools': {0}", String(navigation.developerTools)));
-  if (navigation.developerTools) $('#navTabDevtools').removeClass('is-force-hidden');
+  if (navigation.developerTools) qs('#navTabDevtools')?.classList.remove('is-force-hidden');
 
   sendDebug(
     formatString("'navigation.extendedcollapsed': {0}", String(navigation.extendedCollapsed))
   );
   if (navigation.extendedCollapsed) {
-    $('#navButtonExpandedmenu').toggleClass('is-active');
-    $('.is-specialmenu').toggleClass('is-hidden');
+    qs('#navButtonExpandedmenu')?.classList.toggle('is-active');
+    qsa('.is-specialmenu').forEach((el) => el.classList.toggle('is-hidden'));
   }
 
   sendDebug(formatString("'navigation.extendedmenu': {0}", String(navigation.enableExtendedMenu)));
   if (!navigation.enableExtendedMenu) {
-    $('#navButtonExpandedmenu').addClass('is-force-hidden');
+    qs('#navButtonExpandedmenu')?.classList.add('is-force-hidden');
   } else {
-    $('#navButtonExpandedmenu').removeClass('is-force-hidden');
+    qs('#navButtonExpandedmenu')?.classList.remove('is-force-hidden');
   }
-
-  return;
 }

--- a/app/ts/renderer/singlewhois.ts
+++ b/app/ts/renderer/singlewhois.ts
@@ -1,14 +1,18 @@
 import type { WhoisResult } from '../common/availability.js';
 import { preStringStrip, toJSON } from '../common/parser.js';
 
-import { getDate } from '../common/conversions.js';
 import type { RendererElectronAPI } from '../../../types/renderer-electron-api.js';
 const electron = (window as any).electron as RendererElectronAPI;
 import { IpcChannel } from '../common/ipcChannels.js';
 import { formatString } from '../common/stringformat.js';
 
-import $ from '../../vendor/jquery.js';
-(window as any).$ = (window as any).jQuery = $;
+function qs<T extends Element = HTMLElement>(sel: string): T | null {
+  return document.querySelector(sel) as T | null;
+}
+
+function qsa<T extends Element = HTMLElement>(sel: string): T[] {
+  return Array.from(document.querySelectorAll(sel)) as T[];
+}
 import { debugFactory, errorFactory } from '../common/logger.js';
 import DomainStatus from '../common/status.js';
 
@@ -63,101 +67,109 @@ async function handleResults(domainResults: string) {
   );
 
   const { domain, updateDate, registrar, creationDate, company, expiryDate } = resultFilter;
+  const resultsEl = qs('#singlewhoisMessageWhoisResults');
+  const domainEl = qs('#singlewhoisTdDomain');
+  const updateEl = qs('#singlewhoisTdUpdate');
+  const registrarEl = qs('#singlewhoisTdRegistrar');
+  const creationEl = qs('#singlewhoisTdCreation');
+  const companyEl = qs('#singlewhoisTdCompany');
+  const expiryEl = qs('#singlewhoisTdExpiry');
 
   switch (domainStatus) {
     case DomainStatus.Unavailable:
-      $('#singlewhoisMessageUnavailable').removeClass('is-hidden');
-      $('#singlewhoisMessageWhoisResults').text(domainResults);
+      qs('#singlewhoisMessageUnavailable')?.classList.remove('is-hidden');
+      if (resultsEl) resultsEl.textContent = domainResults;
 
-      $('#singlewhoisTdDomain').attr('url', 'http://' + (domain ?? ''));
-      $('#singlewhoisTdDomain').text(domain ?? '');
+      domainEl?.setAttribute('url', 'http://' + (domain ?? ''));
+      if (domainEl) domainEl.textContent = domain ?? '';
 
-      $('#singlewhoisTdUpdate').text(updateDate ?? '');
-      $('#singlewhoisTdRegistrar').text(registrar ?? '');
-      $('#singlewhoisTdCreation').text(creationDate ?? '');
-      $('#singlewhoisTdCompany').text(company ?? '');
-      $('#singlewhoisTdExpiry').text(expiryDate ?? '');
-      $('#singlewhoisTableWhoisinfo.is-hidden').removeClass('is-hidden');
+      if (updateEl) updateEl.textContent = updateDate ?? '';
+      if (registrarEl) registrarEl.textContent = registrar ?? '';
+      if (creationEl) creationEl.textContent = creationDate ?? '';
+      if (companyEl) companyEl.textContent = company ?? '';
+      if (expiryEl) expiryEl.textContent = expiryDate ?? '';
+      qs('#singlewhoisTableWhoisinfo')?.classList.remove('is-hidden');
       break;
 
     case DomainStatus.Available:
-      $('#singlewhoisMessageWhoisResults').text(domainResults);
-      $('#singlewhoisMessageAvailable').removeClass('is-hidden');
+      if (resultsEl) resultsEl.textContent = domainResults;
+      qs('#singlewhoisMessageAvailable')?.classList.remove('is-hidden');
       break;
 
     default:
       if (domainStatus.includes('error')) {
         errorReason = domainStatus.split(':')[1]; // Get Error reason
-        $('#singlewhoisMessageWhoisResults').text(
-          formatString('Whois error due to {0}:\n{1}', errorReason, domainResults)
-        );
-        $('#singlewhoisMessageError').removeClass('is-hidden');
+        if (resultsEl)
+          resultsEl.textContent = formatString(
+            'Whois error due to {0}:\n{1}',
+            errorReason,
+            domainResults
+          );
+        qs('#singlewhoisMessageError')?.classList.remove('is-hidden');
       } else {
-        $('#singlewhoisMessageWhoisResults').text(
-          formatString('Whois default error\n{0}', domainResults)
-        );
-        $('#singlewhoisMessageError').removeClass('is-hidden');
+        if (resultsEl)
+          resultsEl.textContent = formatString(
+            'Whois default error\n{0}',
+            domainResults
+          );
+        qs('#singlewhoisMessageError')?.classList.remove('is-hidden');
       }
       break;
   }
 
-  $('#singlewhoisSearchButtonSearch').removeClass('is-loading');
-  $('#singlewhoisSearchInputDomain').removeAttr('readonly');
+  qs('#singlewhoisSearchButtonSearch')?.classList.remove('is-loading');
+  qs('#singlewhoisSearchInputDomain')?.removeAttribute('readonly');
 }
 
 /*
   electron.on('singlewhois:copied', function() {...});
     On event: Domain copied
  */
-  electron.on('singlewhois:copied', function () {
-  $('#singlewhoisDomainCopied').addClass('is-active');
-
-  return;
+electron.on('singlewhois:copied', function () {
+  qs('#singlewhoisDomainCopied')?.classList.add('is-active');
 });
 
 /*
   $('#singlewhoisSearchInputDomain').keyup(function(...) {...});
     On keyup: Trigger search event with [ENTER] key
  */
-$('#singlewhoisSearchInputDomain').keyup(function (event) {
-  // Cancel the default action, if needed
+qs('#singlewhoisSearchInputDomain')?.addEventListener('keyup', (event) => {
   event.preventDefault();
-  // Number 13 is the "Enter" key on the keyboard
-  if (event.keyCode === 13) $('#singlewhoisSearchButtonSearch').click();
-
-  return;
+  if ((event as KeyboardEvent).key === 'Enter') {
+    qs('#singlewhoisSearchButtonSearch')?.dispatchEvent(new Event('click'));
+  }
 });
 
 /*
   $('#singlewhoisTdDomain').click(function() {...});
     On click: Open website for domain lookup URL in a new window
  */
-$(document).on('click', '#singlewhoisTdDomain', function () {
-  const domain = $('#singlewhoisTdDomain').attr('url') as string;
+qs('#singlewhoisTdDomain')?.addEventListener('click', () => {
+  const domain = qs('#singlewhoisTdDomain')?.getAttribute('url') ?? '';
   electron.send('singlewhois:openlink', domain);
-
-  return;
 });
 
 /*
   $('#singlewhoisSearchButtonSearch').click(function() {...});
     On click: Single whois lookup/search button
  */
-$(document).on('click', '#singlewhoisSearchButtonSearch', function () {
+qs('#singlewhoisSearchButtonSearch')?.addEventListener('click', function () {
   const { input } = singleWhois;
   let { domain } = input;
 
-  if ($(this).hasClass('is-loading')) return true;
+  const btn = this as HTMLElement;
+  if (btn.classList.contains('is-loading')) return;
   debug('#singlewhoisSearchButtonSearch was clicked');
 
-  domain = $('#singlewhoisSearchInputDomain').val() as string;
+  const val = (qs('#singlewhoisSearchInputDomain') as HTMLInputElement | null)?.value;
+  domain = val ?? '';
 
   debug(formatString('Looking up for {0}', domain));
 
-  $('#singlewhoisSearchButtonSearch').addClass('is-loading');
-  $('#singlewhoisSearchInputDomain').attr('readonly', '');
-  $('.notification:not(.is-hidden)').addClass('is-hidden');
-  $('#singlewhoisTableWhoisinfo:not(.is-hidden)').addClass('is-hidden');
+  btn.classList.add('is-loading');
+  qs('#singlewhoisSearchInputDomain')?.setAttribute('readonly', '');
+  qsa('.notification:not(.is-hidden)').forEach((el) => el.classList.add('is-hidden'));
+  qs('#singlewhoisTableWhoisinfo')?.classList.add('is-hidden');
   tableReset();
   void (async () => {
     try {
@@ -165,8 +177,8 @@ $(document).on('click', '#singlewhoisSearchButtonSearch', function () {
       await handleResults(result);
     } catch (e) {
       error(`Lookup failed: ${e}`);
-      $('#singlewhoisSearchButtonSearch').removeClass('is-loading');
-      $('#singlewhoisSearchInputDomain').removeAttr('readonly');
+      btn.classList.remove('is-loading');
+      qs('#singlewhoisSearchInputDomain')?.removeAttribute('readonly');
     }
   })();
   return undefined;
@@ -176,33 +188,29 @@ $(document).on('click', '#singlewhoisSearchButtonSearch', function () {
   $('.singlewhoisMessageWhoisOpen').click(function() {...});
     On click: Single whois lookup modal open click
  */
-$(document).on('click', '.singlewhoisMessageWhoisOpen', function () {
-  debug('Opening whois reply');
-  $('#singlewhoisMessageWhois').addClass('is-active');
-
-  return;
+qsa('.singlewhoisMessageWhoisOpen').forEach((el) => {
+  el.addEventListener('click', () => {
+    debug('Opening whois reply');
+    qs('#singlewhoisMessageWhois')?.classList.add('is-active');
+  });
 });
 
 /*
   $('#singlewhoisMessageWhoisClose').click(function() {...});
     On click: Single whois lookup modal close click
  */
-$(document).on('click', '#singlewhoisMessageWhoisClose', function () {
+qs('#singlewhoisMessageWhoisClose')?.addEventListener('click', () => {
   debug('Closing whois reply');
-  $('#singlewhoisMessageWhois').removeClass('is-active');
-
-  return;
+  qs('#singlewhoisMessageWhois')?.classList.remove('is-active');
 });
 
 /*
   $('#singlewhoisDomainCopiedClose').click(function() {...});
     On click: Domain copied close click
  */
-$(document).on('click', '#singlewhoisDomainCopiedClose', function () {
+qs('#singlewhoisDomainCopiedClose')?.addEventListener('click', () => {
   debug('Closing domain copied');
-  $('#singlewhoisDomainCopied').removeClass('is-active');
-
-  return;
+  qs('#singlewhoisDomainCopied')?.classList.remove('is-active');
 });
 
 /*
@@ -211,13 +219,17 @@ $(document).on('click', '#singlewhoisDomainCopiedClose', function () {
  */
 function tableReset() {
   debug('Resetting whois result table');
-  $('#singlewhoisTdDomain').attr('href', '#');
-  $('#singlewhoisTdDomain').text('n/a');
-  $('#singlewhoisTdUpdate').text('n/a');
-  $('#singlewhoisTdRegistrar').text('n/a');
-  $('#singlewhoisTdCreation').text('n/a');
-  $('#singlewhoisTdCompany').text('n/a');
-  $('#singlewhoisTdExpiry').text('n/a');
-
-  return;
+  const domain = qs('#singlewhoisTdDomain');
+  domain?.setAttribute('href', '#');
+  if (domain) domain.textContent = 'n/a';
+  const update = qs('#singlewhoisTdUpdate');
+  if (update) update.textContent = 'n/a';
+  const reg = qs('#singlewhoisTdRegistrar');
+  if (reg) reg.textContent = 'n/a';
+  const creation = qs('#singlewhoisTdCreation');
+  if (creation) creation.textContent = 'n/a';
+  const company = qs('#singlewhoisTdCompany');
+  if (company) company.textContent = 'n/a';
+  const expiry = qs('#singlewhoisTdExpiry');
+  if (expiry) expiry.textContent = 'n/a';
 }


### PR DESCRIPTION
## Summary
- remove jquery usage in singlewhois renderer
- swap jquery-based helpers for DOM utilities
- clean up main renderer bootstrap
- drop jquery from mainPanel loader

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run test:e2e` *(fails: WebDriverError: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_687d61627fe08325b66d647a5b70c092