### PR TITLE
refactor: drop jquery in wordlistinput

### DIFF
--- a/app/ts/renderer/bulkwhois/wordlistinput.ts
+++ b/app/ts/renderer/bulkwhois/wordlistinput.ts
@@ -1,11 +1,9 @@
-import * as conversions from '../../common/conversions.js';
 import { settings } from '../settings-renderer.js';
 import { debugFactory, errorFactory } from '../../common/logger.js';
 import type { RendererElectronAPI } from '../../../../types/renderer-electron-api.js';
 
 const electron = (window as any).electron as RendererElectronAPI;
 import { tableReset } from './auxiliary.js';
-import $ from '../../../vendor/jquery.js';
 import { getTimeEstimates } from './estimate.js';
 
 const debug = debugFactory('bulkwhois.wordlistinput');
@@ -17,16 +15,23 @@ import { IpcChannel } from '../../common/ipcChannels.js';
 
 let bwWordlistContents = ''; // Global wordlist input contents
 
-$(document).on('click', '#bwSuggestButton', async () => {
-  const prompt = String($('#bwSuggestPrompt').val() ?? '');
+document.getElementById('bwSuggestButton')?.addEventListener('click', async () => {
+  const promptInput = document.getElementById('bwSuggestPrompt') as
+    | HTMLInputElement
+    | HTMLTextAreaElement
+    | null;
+  const prompt = String(promptInput?.value ?? '');
   if (!prompt) return;
   try {
     const words: string[] = await electron.invoke('ai:suggest', prompt, 5);
     if (words.length > 0) {
-      const textarea = $('#bwWordlistTextareaDomains');
-      const current = String(textarea.val() ?? '').trim();
+      const textarea = document.getElementById(
+        'bwWordlistTextareaDomains'
+      ) as HTMLTextAreaElement | null;
+      if (!textarea) return;
+      const current = String(textarea.value ?? '').trim();
       const prefix = current ? '\n' : '';
-      textarea.val(current + prefix + words.join('\n'));
+      textarea.value = current + prefix + words.join('\n');
     }
   } catch (e) {
     error(`Suggestion failed: ${e}`);
@@ -40,13 +45,20 @@ $(document).on('click', '#bwSuggestButton', async () => {
 function handleWordlistConfirmation(): void {
   const bwFileStats: Record<string, any> = {};
 
-  bwWordlistContents = String($('#bwWordlistTextareaDomains').val() ?? '');
-  if (bwWordlistContents === '' || bwWordlistContents === null) {
-    $('#bwWordlistconfirm').addClass('is-hidden');
-    $('#bwEntry').removeClass('is-hidden');
+  const textarea = document.getElementById(
+    'bwWordlistTextareaDomains'
+  ) as HTMLTextAreaElement | null;
+  bwWordlistContents = String(textarea?.value ?? '');
+  const confirmEl = document.getElementById('bwWordlistconfirm');
+  const entryEl = document.getElementById('bwEntry');
+
+  if (!bwWordlistContents) {
+    confirmEl?.classList.add('is-hidden');
+    entryEl?.classList.remove('is-hidden');
   } else {
-    $('#bwWordlistSpanInfo').text('Loading wordlist stats...');
-    $('#bwWordlistSpanInfo').text('Getting line count...');
+    const infoSpan = document.getElementById('bwWordlistSpanInfo');
+    infoSpan && (infoSpan.textContent = 'Loading wordlist stats...');
+    infoSpan && (infoSpan.textContent = 'Getting line count...');
     bwFileStats['linecount'] = bwWordlistContents.toString().split('\n').length;
 
     const estimate = getTimeEstimates(bwFileStats['linecount'], settings);
@@ -54,28 +66,39 @@ function handleWordlistConfirmation(): void {
     bwFileStats['maxestimate'] = estimate.max;
 
     if (estimate.max) {
-      $('#bwWordlistSpanTimebetweenmin').text(
-        formatString('{0}ms ', settings.lookupRandomizeTimeBetween.minimum)
-      );
-      $('#bwWordlistSpanTimebetweenmax').text(
-        formatString('/ {0}ms', settings.lookupRandomizeTimeBetween.maximum)
-      );
-      $('#bwWordlistTdEstimate').text(
-        formatString('{0} to {1}', bwFileStats['minestimate'], bwFileStats['maxestimate'])
-      );
+      const minSpan = document.getElementById('bwWordlistSpanTimebetweenmin');
+      const maxSpan = document.getElementById('bwWordlistSpanTimebetweenmax');
+      minSpan &&
+        (minSpan.textContent = formatString('{0}ms ', settings.lookupRandomizeTimeBetween.minimum));
+      maxSpan &&
+        (maxSpan.textContent = formatString(
+          '/ {0}ms',
+          settings.lookupRandomizeTimeBetween.maximum
+        ));
+      const estTd = document.getElementById('bwWordlistTdEstimate');
+      estTd &&
+        (estTd.textContent = formatString(
+          '{0} to {1}',
+          bwFileStats['minestimate'],
+          bwFileStats['maxestimate']
+        ));
     } else {
-      $('#bwWordlistSpanTimebetweenminmax').addClass('is-hidden');
-      $('#bwWordlistSpanTimebetweenmin').text(settings.lookupGeneral.timeBetween + 'ms');
-      $('#bwWordlistTdEstimate').text(formatString('> {0}', bwFileStats['minestimate']));
+      document.getElementById('bwWordlistSpanTimebetweenminmax')?.classList.add('is-hidden');
+      const minSpan = document.getElementById('bwWordlistSpanTimebetweenmin');
+      minSpan && (minSpan.textContent = `${settings.lookupGeneral.timeBetween}ms`);
+      const estTd = document.getElementById('bwWordlistTdEstimate');
+      estTd && (estTd.textContent = formatString('> {0}', bwFileStats['minestimate']));
     }
 
     bwFileStats['filepreview'] = bwWordlistContents.toString().substring(0, 50);
-    $('#bwWordlistloading').addClass('is-hidden');
-    $('#bwWordlistconfirm').removeClass('is-hidden');
+    document.getElementById('bwWordlistloading')?.classList.add('is-hidden');
+    confirmEl?.classList.remove('is-hidden');
 
     // stats
-    $('#bwWordlistTdDomains').text(formatString('{0} line(s)', bwFileStats['linecount']));
-    $('#bwWordlistTdFilepreview').text(bwFileStats['filepreview'] + '...');
+    const domainsTd = document.getElementById('bwWordlistTdDomains');
+    domainsTd && (domainsTd.textContent = formatString('{0} line(s)', bwFileStats['linecount']));
+    const previewTd = document.getElementById('bwWordlistTdFilepreview');
+    previewTd && (previewTd.textContent = bwFileStats['filepreview'] + '...');
   }
 
   return;
@@ -89,85 +112,71 @@ electron.on(IpcChannel.BulkwhoisWordlistInputConfirmation, () => {
   $('#bwEntryButtonWordlist').click(function() {...});
     Wordlist Input, Entry container button
  */
-$(document).on('click', '#bwEntryButtonWordlist', function () {
-  $('#bwEntry').addClass('is-hidden');
-  $('#bwWordlistinput').removeClass('is-hidden');
-
-  return;
+document.getElementById('bwEntryButtonWordlist')?.addEventListener('click', () => {
+  document.getElementById('bwEntry')?.classList.add('is-hidden');
+  document.getElementById('bwWordlistinput')?.classList.remove('is-hidden');
 });
 
 /*
   $('#bwWordlistinputButtonCancel').click(function() {...});
     Wordlist Input, cancel input
  */
-$(document).on('click', '#bwWordlistinputButtonCancel', function () {
-  $('#bwWordlistinput').addClass('is-hidden');
-  $('#bwEntry').removeClass('is-hidden');
-
-  return;
+document.getElementById('bwWordlistinputButtonCancel')?.addEventListener('click', () => {
+  document.getElementById('bwWordlistinput')?.classList.add('is-hidden');
+  document.getElementById('bwEntry')?.classList.remove('is-hidden');
 });
 
 /*
   $('#bwWordlistinputButtonConfirm').click(function() {...});
     Wordlist Input, go to confirm
  */
-$(document).on('click', '#bwWordlistinputButtonConfirm', function () {
-  $('#bwWordlistinput').addClass('is-hidden');
+document.getElementById('bwWordlistinputButtonConfirm')?.addEventListener('click', () => {
+  document.getElementById('bwWordlistinput')?.classList.add('is-hidden');
   void (async () => {
     await electron.invoke(IpcChannel.BulkwhoisInputWordlist);
     handleWordlistConfirmation();
   })();
-
-  return;
 });
 
 /*
   $('#bwWordlistconfirmButtonCancel').click(function() {...});
      Wordlist input, cancel confirmation
  */
-$(document).on('click', '#bwWordlistconfirmButtonCancel', function () {
-  $('#bwWordlistconfirm').addClass('is-hidden');
-  $('#bwEntry').removeClass('is-hidden');
-
-  return;
+document.getElementById('bwWordlistconfirmButtonCancel')?.addEventListener('click', () => {
+  document.getElementById('bwWordlistconfirm')?.classList.add('is-hidden');
+  document.getElementById('bwEntry')?.classList.remove('is-hidden');
 });
 
 /*
   $('#bwWordlistconfirmButtonStart').click(function() {...});
     Wordlist input, proceed to bulk whois
  */
-$(document).on('click', '#bwWordlistconfirmButtonStart', function () {
+document.getElementById('bwWordlistconfirmButtonStart')?.addEventListener('click', () => {
   const bwDomainArray = bwWordlistContents
     .toString()
     .split('\n')
     .map(Function.prototype.call, String.prototype.trim);
-  const bwTldsArray = (
-    ($('#bwWordlistInputTlds').val() as string | number | string[] | undefined) || ''
-  )
-    .toString()
-    .split(',');
+  const tldsInput = document.getElementById('bwWordlistInputTlds') as HTMLInputElement | null;
+  const bwTldsArray = (tldsInput?.value ?? '').toString().split(',');
 
   tableReset(bwDomainArray.length, bwTldsArray.length);
-  $('#bwWordlistconfirm').addClass('is-hidden');
-  $('#bwProcessing').removeClass('is-hidden');
+  document.getElementById('bwWordlistconfirm')?.classList.add('is-hidden');
+  document.getElementById('bwProcessing')?.classList.remove('is-hidden');
 
   void electron.invoke(IpcChannel.BulkwhoisLookup, bwDomainArray, bwTldsArray);
-
-  return;
 });
 
 /*
   $('#bwWordlistInputTlds').keyup(function(...) {...});
     ipsum
  */
-$('#bwWordlistInputTlds').keyup(function (event) {
-  // Cancel the default action, if needed
-  event.preventDefault();
-  // Number 13 is the "Enter" key on the keyboard
-  if (event.keyCode === 13) {
-    // Trigger the button element with a click
-    $('#bwWordlistconfirmButtonStart').click();
-  }
-
-  return;
-});
+document
+  .getElementById('bwWordlistInputTlds')
+  ?.addEventListener('keyup', (event: KeyboardEvent) => {
+    event.preventDefault();
+    if (event.key === 'Enter') {
+      (
+        document.getElementById('bwWordlistconfirmButtonStart') as HTMLButtonElement | null
+      )?.click();
+    }
+  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@types/better-sqlite3": "^7.6.13",
         "@types/express": "^5.0.3",
         "@types/jest": "^30.0.0",
+        "@types/jquery": "^3.5.32",
         "@types/node": "^24.0.15",
         "@typescript-eslint/eslint-plugin": "^8.35.0",
         "@typescript-eslint/parser": "^8.36.0",
@@ -3644,6 +3645,16 @@
         "pretty-format": "^30.0.0"
       }
     },
+    "node_modules/@types/jquery": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.32.tgz",
+      "integrity": "sha512-b9Xbf4CkMqS02YH8zACqN1xzdxc3cO735Qe5AbSUFmyOiaWAbcpqh9Wna+Uk0vgACvoQHpWDg2rGdHkYPLmCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sizzle": "*"
+      }
+    },
     "node_modules/@types/jsdom": {
       "version": "21.1.7",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
@@ -3738,6 +3749,13 @@
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
       "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/sizzle": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.9.tgz",
+      "integrity": "sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/express": "^5.0.3",
     "@types/jest": "^30.0.0",
+    "@types/jquery": "^3.5.32",
     "@types/node": "^24.0.15",
     "@typescript-eslint/eslint-plugin": "^8.35.0",
     "@typescript-eslint/parser": "^8.36.0",


### PR DESCRIPTION
## Summary
- remove jquery from wordlist wordlistinput and use DOM APIs
- add @types/jquery for existing code

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Jest encountered unexpected token)*
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_688274b768a88325806d4c1288b4ab6b