### PR TITLE
refactor: remove jquery usage

### DIFF
--- a/app/ts/renderer/bulkwhois/event-bindings.ts
+++ b/app/ts/renderer/bulkwhois/event-bindings.ts
@@ -1,4 +1,4 @@
-import $ from '../../../vendor/jquery.js';
+import { qs, on } from '../../utils/dom.js';
 import { IpcChannel } from '../../common/ipcChannels.js';
 import { debugFactory } from '../../common/logger.js';
 
@@ -7,17 +7,20 @@ const debug = debugFactory('bulkwhois.events');
 export function bindProcessingEvents(electron: {
   send: (channel: string, ...args: any[]) => void;
 }): void {
-  $(document).on('click', '#bwProcessingButtonPause', function () {
-    const searchStatus = $('#bwProcessingButtonPauseSpanText').text();
+  on('click', '#bwProcessingButtonPause', () => {
+    const searchStatus = qs('#bwProcessingButtonPauseSpanText')?.textContent ?? '';
     switch (searchStatus) {
       case 'Continue':
         setPauseButton();
         electron.send(IpcChannel.BulkwhoisLookupContinue);
         break;
       case 'Pause':
-        $('#bwProcessingButtonPause').removeClass('is-warning').addClass('is-success');
-        $('#bwProcessingButtonPauseicon').removeClass('fa-pause').addClass('fa-play');
-        $('#bwProcessingButtonPauseSpanText').text('Continue');
+        qs('#bwProcessingButtonPause')!.classList.remove('is-warning');
+        qs('#bwProcessingButtonPause')!.classList.add('is-success');
+        qs('#bwProcessingButtonPauseicon')!.classList.remove('fa-pause');
+        qs('#bwProcessingButtonPauseicon')!.classList.add('fa-play');
+        if (qs('#bwProcessingButtonPauseSpanText'))
+          qs('#bwProcessingButtonPauseSpanText')!.textContent = 'Continue';
         electron.send(IpcChannel.BulkwhoisLookupPause);
         break;
       default:
@@ -25,44 +28,49 @@ export function bindProcessingEvents(electron: {
     }
   });
 
-  $(document).on('click', '#bwProcessingButtonStop', function () {
+  on('click', '#bwProcessingButtonStop', () => {
     debug('Pausing whois & opening stop modal');
-    $('#bwProcessingButtonPause').text().includes('Pause')
-      ? $('#bwProcessingButtonPause').trigger('click')
-      : false;
-    $('#bwProcessingModalStop').addClass('is-active');
+    const btn = qs('#bwProcessingButtonPause');
+    if (btn?.textContent?.includes('Pause')) {
+      btn.dispatchEvent(new Event('click', { bubbles: true }));
+    }
+    qs('#bwProcessingModalStop')!.classList.add('is-active');
   });
 
-  $(document).on('click', '#bwProcessingModalStopButtonContinue', function () {
+  on('click', '#bwProcessingModalStopButtonContinue', () => {
     debug('Closing Stop modal & continue');
-    $('#bwProcessingModalStop').removeClass('is-active');
+    qs('#bwProcessingModalStop')!.classList.remove('is-active');
   });
 
-  $(document).on('click', '#bwProcessingModalStopButtonStop', function () {
+  on('click', '#bwProcessingModalStopButtonStop', () => {
     debug('Closing Stop modal & going back to start');
-    $('#bwProcessingModalStop').removeClass('is-active');
-    $('#bwProcessing').addClass('is-hidden');
+    qs('#bwProcessingModalStop')!.classList.remove('is-active');
+    qs('#bwProcessing')!.classList.add('is-hidden');
     setPauseButton();
-    $('#bwEntry').removeClass('is-hidden');
+    qs('#bwEntry')!.classList.remove('is-hidden');
   });
 
-  $(document).on('click', '#bwProcessingModalStopButtonStopsave', function () {
+  on('click', '#bwProcessingModalStopButtonStopsave', () => {
     debug('Closing Stop modal & exporting');
     electron.send(IpcChannel.BulkwhoisLookupStop);
-    $('#bwProcessingModalStop').removeClass('is-active');
-    $('#bwProcessing').addClass('is-hidden');
+    qs('#bwProcessingModalStop')!.classList.remove('is-active');
+    qs('#bwProcessing')!.classList.add('is-hidden');
     setPauseButton();
-    $('#bwExport').removeClass('is-hidden');
+    qs('#bwExport')!.classList.remove('is-hidden');
   });
 
-  $(document).on('click', '#bwProcessingButtonNext', function () {
-    $('#bwProcessing').addClass('is-hidden');
-    $('#bwExport').removeClass('is-hidden');
+  on('click', '#bwProcessingButtonNext', () => {
+    qs('#bwProcessing')!.classList.add('is-hidden');
+    qs('#bwExport')!.classList.remove('is-hidden');
   });
 }
 
 function setPauseButton() {
-  $('#bwProcessingButtonPause').removeClass('is-success').addClass('is-warning');
-  $('#bwProcessingButtonPauseicon').removeClass('fa-play').addClass('fa-pause');
-  $('#bwProcessingButtonPauseSpanText').text('Pause');
+  const btn = qs('#bwProcessingButtonPause')!;
+  btn.classList.remove('is-success');
+  btn.classList.add('is-warning');
+  qs('#bwProcessingButtonPauseicon')!.classList.remove('fa-play');
+  qs('#bwProcessingButtonPauseicon')!.classList.add('fa-pause');
+  if (qs('#bwProcessingButtonPauseSpanText'))
+    qs('#bwProcessingButtonPauseSpanText')!.textContent = 'Pause';
 }

--- a/app/ts/renderer/bulkwhois/fileinput.ts
+++ b/app/ts/renderer/bulkwhois/fileinput.ts
@@ -19,7 +19,7 @@ const electron = (window as any).electron as RendererElectronAPI & {
   path: { basename: (p: string) => Promise<string> };
 };
 import { tableReset } from './auxiliary.js';
-import $ from '../../../vendor/jquery.js';
+import { qs, on } from '../../utils/dom.js';
 
 import { formatString } from '../../common/stringformat.js';
 import { settings } from '../settings-renderer.js';
@@ -49,30 +49,33 @@ async function refreshBwFile(pathToFile: string): Promise<void> {
     bwFileStats.maxestimate = estimate.max;
 
     if (estimate.max) {
-      $('#bwFileSpanTimebetweenmin').text(
-        formatString('{0}ms ', lookup.randomize.timeBetween.minimum)
+      qs('#bwFileSpanTimebetweenmin')!.textContent = formatString(
+        '{0}ms ',
+        lookup.randomize.timeBetween.minimum
       );
-      $('#bwFileSpanTimebetweenmax').text(
-        formatString('/ {0}ms', lookup.randomize.timeBetween.maximum)
+      qs('#bwFileSpanTimebetweenmax')!.textContent = formatString(
+        '/ {0}ms',
+        lookup.randomize.timeBetween.maximum
       );
-      $('#bwFileTdEstimate').text(
-        formatString('{0} to {1}', bwFileStats.minestimate, bwFileStats.maxestimate)
+      qs('#bwFileTdEstimate')!.textContent = formatString(
+        '{0} to {1}',
+        bwFileStats.minestimate,
+        bwFileStats.maxestimate
       );
     } else {
-      $('#bwFileSpanTimebetweenminmax').addClass('is-hidden');
-      $('#bwFileSpanTimebetweenmin').text(settings.lookupGeneral.timeBetween + 'ms');
-      $('#bwFileTdEstimate').text(formatString('> {0}', bwFileStats.minestimate));
+      qs('#bwFileSpanTimebetweenminmax')!.classList.add('is-hidden');
+      qs('#bwFileSpanTimebetweenmin')!.textContent = settings.lookupGeneral.timeBetween + 'ms';
+      qs('#bwFileTdEstimate')!.textContent = formatString('> {0}', bwFileStats.minestimate);
     }
 
     bwFileStats.filepreview = bwFileContents.toString().substring(0, 50);
 
-    $('#bwFileTdName').text(String(bwFileStats.filename));
-    $('#bwFileTdLastmodified').text(conversions.getDate(bwFileStats.mtime) ?? '');
-    $('#bwFileTdLastaccess').text(conversions.getDate(bwFileStats.atime) ?? '');
-    $('#bwFileTdFilesize').text(
-      String(bwFileStats.humansize) + formatString(' ({0} line(s))', String(bwFileStats.linecount))
-    );
-    $('#bwFileTdFilepreview').text(String(bwFileStats.filepreview) + '...');
+    qs('#bwFileTdName')!.textContent = String(bwFileStats.filename);
+    qs('#bwFileTdLastmodified')!.textContent = conversions.getDate(bwFileStats.mtime) ?? '';
+    qs('#bwFileTdLastaccess')!.textContent = conversions.getDate(bwFileStats.atime) ?? '';
+    qs('#bwFileTdFilesize')!.textContent =
+      String(bwFileStats.humansize) + formatString(' ({0} line(s))', String(bwFileStats.linecount));
+    qs('#bwFileTdFilepreview')!.textContent = String(bwFileStats.filepreview) + '...';
   } catch (e) {
     error(`Failed to reload file: ${e}`);
   }
@@ -101,13 +104,13 @@ async function handleFileConfirmation(
   debug(filePath);
   if (filePath === undefined || filePath == '' || filePath === null) {
     debug(filePath);
-    $('#bwFileinputloading').addClass('is-hidden');
-    $('#bwEntry').removeClass('is-hidden');
+    qs('#bwFileinputloading')!.classList.add('is-hidden');
+    qs('#bwEntry')!.classList.remove('is-hidden');
   } else {
-    $('#bwLoadingInfo').text('Loading file stats...');
+    qs('#bwLoadingInfo')!.textContent = 'Loading file stats...';
     if (isDragDrop === true) {
-      $('#bwEntry').addClass('is-hidden');
-      $('#bwFileinputloading').removeClass('is-hidden');
+      qs('#bwEntry')!.classList.add('is-hidden');
+      qs('#bwFileinputloading')!.classList.remove('is-hidden');
       try {
         bwFileStats = (await electron.stat(filePath as string)) as FileStats;
         bwFileStats.filename = await electron.path.basename(filePath as string);
@@ -115,11 +118,11 @@ async function handleFileConfirmation(
           bwFileStats.size,
           misc.useStandardSize
         );
-        $('#bwFileSpanInfo').text('Loading file contents...');
+        qs('#bwFileSpanInfo')!.textContent = 'Loading file contents...';
         bwFileContents = await electron.bwFileRead(filePath as string);
       } catch (e) {
         error(`Failed to read file: ${e}`);
-        $('#bwFileSpanInfo').text('Failed to load file');
+        qs('#bwFileSpanInfo')!.textContent = 'Failed to load file';
         return;
       }
     } else {
@@ -130,15 +133,15 @@ async function handleFileConfirmation(
           bwFileStats.size,
           misc.useStandardSize
         );
-        $('#bwFileSpanInfo').text('Loading file contents...');
+        qs('#bwFileSpanInfo')!.textContent = 'Loading file contents...';
         bwFileContents = await electron.bwFileRead((filePath as string[])[0]);
       } catch (e) {
         error(`Failed to read file: ${e}`);
-        $('#bwFileSpanInfo').text('Failed to load file');
+        qs('#bwFileSpanInfo')!.textContent = 'Failed to load file';
         return;
       }
     }
-    $('#bwFileSpanInfo').text('Getting line count...');
+    qs('#bwFileSpanInfo')!.textContent = 'Getting line count...';
     bwFileStats.linecount = bwFileContents.toString().split('\n').length;
 
     const estimate = getTimeEstimates(bwFileStats.linecount!, settings);
@@ -146,34 +149,37 @@ async function handleFileConfirmation(
     bwFileStats.maxestimate = estimate.max;
 
     if (estimate.max) {
-      $('#bwFileSpanTimebetweenmin').text(
-        formatString('{0}ms ', lookup.randomize.timeBetween.minimum)
+      qs('#bwFileSpanTimebetweenmin')!.textContent = formatString(
+        '{0}ms ',
+        lookup.randomize.timeBetween.minimum
       );
-      $('#bwFileSpanTimebetweenmax').text(
-        formatString('/ {0}ms', lookup.randomize.timeBetween.maximum)
+      qs('#bwFileSpanTimebetweenmax')!.textContent = formatString(
+        '/ {0}ms',
+        lookup.randomize.timeBetween.maximum
       );
-      $('#bwFileTdEstimate').text(
-        formatString('{0} to {1}', bwFileStats.minestimate, bwFileStats.maxestimate)
+      qs('#bwFileTdEstimate')!.textContent = formatString(
+        '{0} to {1}',
+        bwFileStats.minestimate,
+        bwFileStats.maxestimate
       );
     } else {
-      $('#bwFileSpanTimebetweenminmax').addClass('is-hidden');
-      $('#bwFileSpanTimebetweenmin').text(settings.lookupGeneral.timeBetween + 'ms');
-      $('#bwFileTdEstimate').text(formatString('> {0}', bwFileStats.minestimate));
+      qs('#bwFileSpanTimebetweenminmax')!.classList.add('is-hidden');
+      qs('#bwFileSpanTimebetweenmin')!.textContent = settings.lookupGeneral.timeBetween + 'ms';
+      qs('#bwFileTdEstimate')!.textContent = formatString('> {0}', bwFileStats.minestimate);
     }
 
     bwFileStats.filepreview = bwFileContents.toString().substring(0, 50);
     debug(bwFileStats.filepreview);
-    $('#bwFileinputloading').addClass('is-hidden');
-    $('#bwFileinputconfirm').removeClass('is-hidden');
+    qs('#bwFileinputloading')!.classList.add('is-hidden');
+    qs('#bwFileinputconfirm')!.classList.remove('is-hidden');
 
     // stats
-    $('#bwFileTdName').text(String(bwFileStats.filename));
-    $('#bwFileTdLastmodified').text(conversions.getDate(bwFileStats.mtime) ?? '');
-    $('#bwFileTdLastaccess').text(conversions.getDate(bwFileStats.atime) ?? '');
-    $('#bwFileTdFilesize').text(
-      String(bwFileStats.humansize) + formatString(' ({0} line(s))', String(bwFileStats.linecount))
-    );
-    $('#bwFileTdFilepreview').text(String(bwFileStats.filepreview) + '...');
+    qs('#bwFileTdName')!.textContent = String(bwFileStats.filename);
+    qs('#bwFileTdLastmodified')!.textContent = conversions.getDate(bwFileStats.mtime) ?? '';
+    qs('#bwFileTdLastaccess')!.textContent = conversions.getDate(bwFileStats.atime) ?? '';
+    qs('#bwFileTdFilesize')!.textContent =
+      String(bwFileStats.humansize) + formatString(' ({0} line(s))', String(bwFileStats.linecount));
+    qs('#bwFileTdFilepreview')!.textContent = String(bwFileStats.filepreview) + '...';
     //$('#bwTableMaxEstimate').text(bwFileStats['maxestimate']); // show estimated bulk lookup time
     debug('cont:' + bwFileContents);
 
@@ -208,46 +214,45 @@ electron.on(
   $('#bwEntryButtonFile').click(function() {...});
     File Input, Entry container button
  */
-$(document).on('click', '#bwEntryButtonFile', function () {
-  $('#bwEntry').addClass('is-hidden');
-  $.when($('#bwFileinputloading').removeClass('is-hidden').delay(10)).done(async function () {
+on('click', '#bwEntryButtonFile', () => {
+  qs('#bwEntry')!.classList.add('is-hidden');
+  const loader = qs('#bwFileinputloading')!;
+  loader.classList.remove('is-hidden');
+  setTimeout(async () => {
     const filePath = await electron.invoke(IpcChannel.BulkwhoisInputFile);
     await handleFileConfirmation(filePath);
-  });
-
-  return;
+  }, 10);
 });
 
 /*
   $('#bwFileButtonCancel').click(function() {...});
     File Input, cancel file confirmation
  */
-$(document).on('click', '#bwFileButtonCancel', function () {
+on('click', '#bwFileButtonCancel', () => {
   watcher.close();
-  $('#bwFileinputconfirm').addClass('is-hidden');
-  $('#bwEntry').removeClass('is-hidden');
-
-  return;
+  qs('#bwFileinputconfirm')!.classList.add('is-hidden');
+  qs('#bwEntry')!.classList.remove('is-hidden');
 });
 
 /*
   $('#bwFileButtonConfirm').click(function() {...});
     File Input, proceed to bulk whois
  */
-$(document).on('click', '#bwFileButtonConfirm', function () {
+on('click', '#bwFileButtonConfirm', () => {
   watcher.close();
   const bwDomainArray = bwFileContents
     .toString()
     .split('\n')
     .map(Function.prototype.call, String.prototype.trim);
-  const bwTldsArray = (($('#bwFileInputTlds').val() as string) || '')
+  const input = qs<HTMLInputElement>('#bwFileInputTlds');
+  const bwTldsArray = (input?.value || '')
     .split(',')
     .map((t) => t.trim())
     .filter(Boolean);
 
   tableReset(bwDomainArray.length, bwTldsArray.length);
-  $('#bwFileinputconfirm').addClass('is-hidden');
-  $('#bwProcessing').removeClass('is-hidden');
+  qs('#bwFileinputconfirm')!.classList.add('is-hidden');
+  qs('#bwProcessing')!.classList.remove('is-hidden');
 
   debug(bwDomainArray);
   debug(bwTldsArray);
@@ -259,47 +264,35 @@ $(document).on('click', '#bwFileButtonConfirm', function () {
   dragDropInitialization (self-executing)
     Bulk whois file input by drag and drop
  */
-(function dragDropInitialization() {
-  $(document).ready(() => {
-    const holder = document.getElementById('bulkwhoisMainContainer') as HTMLElement | null;
-    if (!holder) return;
+document.addEventListener('DOMContentLoaded', () => {
+  const holder = document.getElementById('bulkwhoisMainContainer') as HTMLElement | null;
+  if (!holder) return;
 
-    holder.ondragover = function () {
-      return false;
-    };
-
-    holder.ondragleave = function () {
-      return false;
-    };
-
-    holder.ondragend = function () {
-      return false;
-    };
-
-    holder.ondrop = function (event) {
-      event.preventDefault();
-      for (const f of Array.from(event.dataTransfer!.files)) {
-        const file = f as any;
-        debug(`File(s) you dragged here: ${file.path}`);
-        electron.send('ondragstart', file.path);
-      }
-      return false;
-    };
-  });
-})();
+  holder.ondragover = () => false;
+  holder.ondragleave = () => false;
+  holder.ondragend = () => false;
+  holder.ondrop = (event) => {
+    event.preventDefault();
+    for (const f of Array.from(event.dataTransfer!.files)) {
+      const file = f as any;
+      debug(`File(s) you dragged here: ${file.path}`);
+      electron.send('ondragstart', file.path);
+    }
+    return false;
+  };
+});
 
 /*
   $('#bulkwhoisMainContainer').on('drop', function(...) {...});
     On Drop ipsum
  */
-$('#bulkwhoisMainContainer').on('drop', function (event) {
+on('drop', '#bulkwhoisMainContainer', (event: DragEvent) => {
   event.preventDefault();
-  for (const f of Array.from((event as any).originalEvent.dataTransfer.files)) {
+  for (const f of Array.from(event.dataTransfer!.files)) {
     const file = f as any;
     debug(`File(s) you dragged here: ${file.path}`);
     electron.send('ondragstart', file.path);
   }
-
   return false;
 });
 
@@ -307,14 +300,9 @@ $('#bulkwhoisMainContainer').on('drop', function (event) {
   $('#bwFileInputTlds').keyup(function(...) {...});
     ipsum
  */
-$('#bwFileInputTlds').keyup(function (event) {
-  // Cancel the default action, if needed
+qs('#bwFileInputTlds')?.addEventListener('keyup', (event: KeyboardEvent) => {
   event.preventDefault();
-  // Number 13 is the "Enter" key on the keyboard
-  if (event.keyCode === 13) {
-    // Trigger the button element with a click
-    $('#bwFileButtonConfirm').click();
+  if (event.key === 'Enter' || event.keyCode === 13) {
+    qs('#bwFileButtonConfirm')?.dispatchEvent(new Event('click', { bubbles: true }));
   }
-
-  return;
 });

--- a/app/ts/renderer/bulkwhois/status-handler.ts
+++ b/app/ts/renderer/bulkwhois/status-handler.ts
@@ -1,4 +1,4 @@
-import $ from '../../../vendor/jquery.js';
+import { qs } from '../../utils/dom.js';
 import { debugFactory } from '../../common/logger.js';
 import { formatString } from '../../common/stringformat.js';
 import { IpcChannel } from '../../common/ipcChannels.js';
@@ -14,96 +14,130 @@ export function registerStatusUpdates(electron: {
     let percent;
     switch (stat) {
       case 'start':
-        if ($('#bwProcessingButtonNext').hasClass('is-hidden') === false) {
-          $('#bwProcessingButtonNext').addClass('is-hidden');
-          $('#bwProcessingButtonPause').removeClass('is-hidden');
-          $('#bwProcessingButtonStop').removeClass('is-hidden');
+        if (!qs('#bwProcessingButtonNext')!.classList.contains('is-hidden')) {
+          qs('#bwProcessingButtonNext')!.classList.add('is-hidden');
+          qs('#bwProcessingButtonPause')!.classList.remove('is-hidden');
+          qs('#bwProcessingButtonStop')!.classList.remove('is-hidden');
         }
         break;
       case 'domains.processed':
         percent =
           parseFloat(
-            ((value / parseInt($('#bwProcessingSpanTotal').text(), base)) * 100).toFixed(1)
+            (
+              (value / parseInt(qs('#bwProcessingSpanTotal')!.textContent || '0', base)) *
+              100
+            ).toFixed(1)
           ) || 0;
-        $('#bwProcessingSpanProcessed').text(formatString('{0} ({1}%)', value, percent));
+        qs('#bwProcessingSpanProcessed')!.textContent = formatString('{0} ({1}%)', value, percent);
         break;
       case 'domains.waiting':
         percent =
           parseFloat(
-            ((value / parseInt($('#bwProcessingSpanSent').text(), base)) * 100).toFixed(1)
+            (
+              (value / parseInt(qs('#bwProcessingSpanSent')!.textContent || '0', base)) *
+              100
+            ).toFixed(1)
           ) || 0;
-        $('#bwProcessingSpanWaiting').text(formatString('{0} ({1}%)', value, percent));
+        qs('#bwProcessingSpanWaiting')!.textContent = formatString('{0} ({1}%)', value, percent);
         break;
       case 'domains.sent':
         percent =
           parseFloat(
-            ((value / parseInt($('#bwProcessingSpanTotal').text(), base)) * 100).toFixed(1)
+            (
+              (value / parseInt(qs('#bwProcessingSpanTotal')!.textContent || '0', base)) *
+              100
+            ).toFixed(1)
           ) || 0;
-        $('#bwProcessingSpanSent').text(formatString('{0} ({1}%)', value, percent));
+        qs('#bwProcessingSpanSent')!.textContent = formatString('{0} ({1}%)', value, percent);
         break;
       case 'domains.total':
-        $('#bwProcessingSpanTotal').text(value);
+        qs('#bwProcessingSpanTotal')!.textContent = String(value);
         break;
       case 'time.current':
-        $('#bwProcessingSpanTimecurrent').text(formatString('{0}', value));
+        qs('#bwProcessingSpanTimecurrent')!.textContent = formatString('{0}', value);
         break;
       case 'time.remaining':
-        $('#bwProcessingSpanTimeremaining').text(formatString('{0}', value));
+        qs('#bwProcessingSpanTimeremaining')!.textContent = formatString('{0}', value);
         break;
       case 'reqtimes.maximum':
-        $('#bwProcessingSpanReqtimemax').text(
-          formatString('{0}ms', typeof value === 'number' ? value.toFixed(2) : value)
+        qs('#bwProcessingSpanReqtimemax')!.textContent = formatString(
+          '{0}ms',
+          typeof value === 'number' ? value.toFixed(2) : value
         );
         break;
       case 'reqtimes.minimum':
-        $('#bwProcessingSpanReqtimemin').text(
-          formatString('{0}ms', typeof value === 'number' ? value.toFixed(2) : value)
+        qs('#bwProcessingSpanReqtimemin')!.textContent = formatString(
+          '{0}ms',
+          typeof value === 'number' ? value.toFixed(2) : value
         );
         break;
       case 'reqtimes.last':
-        $('#bwProcessingSpanReqtimelast').text(
-          formatString('{0}ms', typeof value === 'number' ? value.toFixed(2) : value)
+        qs('#bwProcessingSpanReqtimelast')!.textContent = formatString(
+          '{0}ms',
+          typeof value === 'number' ? value.toFixed(2) : value
         );
         break;
       case 'reqtimes.average':
-        $('#bwProcessingSpanReqtimeavg').text(
-          formatString('{0}ms', typeof value === 'number' ? value.toFixed(2) : value)
+        qs('#bwProcessingSpanReqtimeavg')!.textContent = formatString(
+          '{0}ms',
+          typeof value === 'number' ? value.toFixed(2) : value
         );
         break;
       case 'status.available':
         percent =
           parseFloat(
-            ((value / parseInt($('#bwProcessingSpanTotal').text(), base)) * 100).toFixed(1)
+            (
+              (value / parseInt(qs('#bwProcessingSpanTotal')!.textContent || '0', base)) *
+              100
+            ).toFixed(1)
           ) || 0;
-        $('#bwProcessingSpanStatusavailable').text(formatString('{0} ({1}%)', value, percent));
+        qs('#bwProcessingSpanStatusavailable')!.textContent = formatString(
+          '{0} ({1}%)',
+          value,
+          percent
+        );
         break;
       case 'status.unavailable':
         percent =
           parseFloat(
-            ((value / parseInt($('#bwProcessingSpanTotal').text(), base)) * 100).toFixed(1)
+            (
+              (value / parseInt(qs('#bwProcessingSpanTotal')!.textContent || '0', base)) *
+              100
+            ).toFixed(1)
           ) || 0;
-        $('#bwProcessingSpanStatusunavailable').text(formatString('{0} ({1}%)', value, percent));
+        qs('#bwProcessingSpanStatusunavailable')!.textContent = formatString(
+          '{0} ({1}%)',
+          value,
+          percent
+        );
         break;
       case 'status.error':
         percent =
           parseFloat(
-            ((value / parseInt($('#bwProcessingSpanTotal').text(), base)) * 100).toFixed(1)
+            (
+              (value / parseInt(qs('#bwProcessingSpanTotal')!.textContent || '0', base)) *
+              100
+            ).toFixed(1)
           ) || 0;
-        $('#bwProcessingSpanStatuserror').text(formatString('{0} ({1}%)', value, percent));
+        qs('#bwProcessingSpanStatuserror')!.textContent = formatString(
+          '{0} ({1}%)',
+          value,
+          percent
+        );
         break;
       case 'laststatus.available':
-        $('#bwProcessingSpanLaststatusavailable').text(formatString('{0}', value));
+        qs('#bwProcessingSpanLaststatusavailable')!.textContent = formatString('{0}', value);
         break;
       case 'laststatus.unavailable':
-        $('#bwProcessingSpanLaststatusunavailable').text(formatString('{0}', value));
+        qs('#bwProcessingSpanLaststatusunavailable')!.textContent = formatString('{0}', value);
         break;
       case 'laststatus.error':
-        $('#bwProcessingSpanLaststatuserror').text(formatString('{0}', value));
+        qs('#bwProcessingSpanLaststatuserror')!.textContent = formatString('{0}', value);
         break;
       case 'finished':
-        $('#bwProcessingButtonPause').addClass('is-hidden');
-        $('#bwProcessingButtonStop').addClass('is-hidden');
-        $('#bwProcessingButtonNext').removeClass('is-hidden');
+        qs('#bwProcessingButtonPause')!.classList.add('is-hidden');
+        qs('#bwProcessingButtonStop')!.classList.add('is-hidden');
+        qs('#bwProcessingButtonNext')!.classList.remove('is-hidden');
         break;
       default:
         break;

--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -1,5 +1,5 @@
 import * as conversions from '../../common/conversions.js';
-import $ from '../../../vendor/jquery.js';
+import { qs, on } from '../../utils/dom.js';
 import '../../../vendor/datatables.js';
 import { debugFactory } from '../../common/logger.js';
 import type { RendererElectronAPI } from '../../../../types/renderer-electron-api.js';
@@ -29,33 +29,27 @@ export function renderAnalyser(contents: any): void {
   $('#bwaAnalyserButtonClose').click(function() {...});
     Bulk whois analyser close button
  */
-$('#bwaAnalyserButtonClose').click(function () {
+on('click', '#bwaAnalyserButtonClose', () => {
   debug('#bwaAnalyserButtonClose clicked');
-  $('#bwaAnalyserModalClose').addClass('is-active');
-
-  return;
+  qs('#bwaAnalyserModalClose')!.classList.add('is-active');
 });
 
 /*
   $('#bwaAnalyserModalCloseButtonYes').click(function() {...});
     bwa, close dialog confirm/yes
  */
-$('#bwaAnalyserModalCloseButtonYes').click(function () {
-  $('#bwaAnalyser').addClass('is-hidden');
-  $('#bwaAnalyserModalClose').removeClass('is-active');
-  $('#bwaEntry').removeClass('is-hidden');
-
-  return;
+on('click', '#bwaAnalyserModalCloseButtonYes', () => {
+  qs('#bwaAnalyser')!.classList.add('is-hidden');
+  qs('#bwaAnalyserModalClose')!.classList.remove('is-active');
+  qs('#bwaEntry')!.classList.remove('is-hidden');
 });
 
 /*
   $('#bwaAnalyserModalCloseButtonNo').click(function() {...});
     Bulk whois analyser close dialog cancel/no button
  */
-$('#bwaAnalyserModalCloseButtonNo').click(function () {
-  $('#bwaAnalyserModalClose').removeClass('is-active');
-
-  return;
+on('click', '#bwaAnalyserModalCloseButtonNo', () => {
+  qs('#bwaAnalyserModalClose')!.classList.remove('is-active');
 });
 
 /*
@@ -79,7 +73,7 @@ function showTable() {
   }
   header.content += '</tr>';
 
-  $('#bwaAnalyserTableThead').html(header.content);
+  qs('#bwaAnalyserTableThead')!.innerHTML = header.content;
 
   // Generate record fields
   body.content = '';
@@ -91,14 +85,14 @@ function showTable() {
     }
     body.content += '</tr>\n';
   }
-  $('#bwaAnalyserTableTbody').html(body.content);
+  qs('#bwaAnalyserTableTbody')!.innerHTML = body.content;
 
-  body.table = ($('#bwaAnalyserTable') as any).dataTable({
+  body.table = (qs('#bwaAnalyserTable') as any).dataTable({
     destroy: true
   });
 
-  $('#bwaFileinputconfirm').addClass('is-hidden');
-  $('#bwaAnalyser').removeClass('is-hidden');
+  qs('#bwaFileinputconfirm')!.classList.add('is-hidden');
+  qs('#bwaAnalyser')!.classList.remove('is-hidden');
   //body.content.destroy();
 
   return;

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -1,6 +1,6 @@
 import * as conversions from '../../common/conversions.js';
 import type { FileStats } from '../../common/fileStats.js';
-import $ from '../../../vendor/jquery.js';
+import { qs, on } from '../../utils/dom.js';
 import '../../../vendor/datatables.js';
 import { settings } from '../settings-renderer.js';
 import { debugFactory, errorFactory } from '../../common/logger.js';
@@ -43,14 +43,13 @@ async function readFileContents(path: string): Promise<any> {
 }
 
 function updateFileInfoUI(stats: FileStats): void {
-  $('#bwaFileTdFilename').text(String(stats.filename));
-  $('#bwaFileTdLastmodified').text(conversions.getDate(stats.mtime) ?? '');
-  $('#bwaFileTdLastaccessed').text(conversions.getDate(stats.atime) ?? '');
-  $('#bwaFileTdFilesize').text(
-    String(stats.humansize) + formatString(' ({0} record(s))', String(stats.linecount))
-  );
-  $('#bwaFileTdFilepreview').text(String(stats.filepreview) + '...');
-  $('#bwaFileTextareaErrors').text(String(stats.errors || 'No errors'));
+  qs('#bwaFileTdFilename')!.textContent = String(stats.filename);
+  qs('#bwaFileTdLastmodified')!.textContent = conversions.getDate(stats.mtime) ?? '';
+  qs('#bwaFileTdLastaccessed')!.textContent = conversions.getDate(stats.atime) ?? '';
+  qs('#bwaFileTdFilesize')!.textContent =
+    String(stats.humansize) + formatString(' ({0} record(s))', String(stats.linecount));
+  qs('#bwaFileTdFilepreview')!.textContent = String(stats.filepreview) + '...';
+  qs('#bwaFileTextareaErrors')!.textContent = String(stats.errors || 'No errors');
 }
 
 async function refreshBwaFile(pathToFile: string): Promise<void> {
@@ -75,15 +74,16 @@ async function refreshBwaFile(pathToFile: string): Promise<void> {
       bwaFileStats.filepreview = '';
     }
     bwaFileStats.errors = JSON.stringify(bwaFileContents.errors).slice(1, -1);
-    $('#bwaFileTdFilename').text(String(bwaFileStats.filename));
-    $('#bwaFileTdLastmodified').text(conversions.getDate(bwaFileStats.mtime) ?? '');
-    $('#bwaFileTdLastaccessed').text(conversions.getDate(bwaFileStats.atime) ?? '');
-    $('#bwaFileTdFilesize').text(
+    qs('#bwaFileTdFilename')!.textContent = String(bwaFileStats.filename);
+    qs('#bwaFileTdLastmodified')!.textContent =
+      conversions.getDate(bwaFileStats.mtime) ?? '';
+    qs('#bwaFileTdLastaccessed')!.textContent =
+      conversions.getDate(bwaFileStats.atime) ?? '';
+    qs('#bwaFileTdFilesize')!.textContent =
       String(bwaFileStats.humansize) +
-        formatString(' ({0} record(s))', String(bwaFileStats.linecount))
-    );
-    $('#bwaFileTdFilepreview').text(String(bwaFileStats.filepreview) + '...');
-    $('#bwaFileTextareaErrors').text(String(bwaFileStats.errors || 'No errors'));
+      formatString(' ({0} record(s))', String(bwaFileStats.linecount));
+    qs('#bwaFileTdFilepreview')!.textContent = String(bwaFileStats.filepreview) + '...';
+    qs('#bwaFileTextareaErrors')!.textContent = String(bwaFileStats.errors || 'No errors');
   } catch (e) {
     error(`Failed to reload file: ${e}`);
   }
@@ -107,32 +107,32 @@ async function handleFileConfirmation(
       : null
     : (filePath as string | null);
 
-  $('#bwaFileSpanInfo').text('Waiting for file...');
+  qs('#bwaFileSpanInfo')!.textContent = 'Waiting for file...';
 
   if (filePath === undefined || filePath == '' || filePath === null) {
-    $('#bwaFileinputloading').addClass('is-hidden');
-    $('#bwaEntry').removeClass('is-hidden');
+    qs('#bwaFileinputloading')!.classList.add('is-hidden');
+    qs('#bwaEntry')!.classList.remove('is-hidden');
     return;
   }
 
-  $('#bwaFileSpanInfo').text('Loading file stats...');
+  qs('#bwaFileSpanInfo')!.textContent = 'Loading file stats...';
   if (isDragDrop === true) {
-    $('#bwaEntry').addClass('is-hidden');
-    $('#bwaFileinputloading').removeClass('is-hidden');
+    qs('#bwaEntry')!.classList.add('is-hidden');
+    qs('#bwaFileinputloading')!.classList.remove('is-hidden');
   }
 
   try {
     const targetPath = Array.isArray(filePath) ? (filePath as string[])[0] : (filePath as string);
     bwaFileStats = await loadFileStats(targetPath, isDragDrop);
-    $('#bwaFileSpanInfo').text('Loading file contents...');
+    qs('#bwaFileSpanInfo')!.textContent = 'Loading file contents...';
     bwaFileContents = await readFileContents(targetPath);
   } catch (e) {
     error(`Failed to read file: ${e}`);
-    $('#bwaFileSpanInfo').text('Failed to load file');
+    qs('#bwaFileSpanInfo')!.textContent = 'Failed to load file';
     return;
   }
 
-  $('#bwaFileSpanInfo').text('Getting line count...');
+  qs('#bwaFileSpanInfo')!.textContent = 'Getting line count...';
   bwaFileStats.linecount = bwaFileContents.data.length;
   try {
     bwaFileStats.filepreview = JSON.stringify(bwaFileContents.data[0], null, '\t').substring(0, 50);
@@ -140,8 +140,8 @@ async function handleFileConfirmation(
     bwaFileStats.filepreview = '';
   }
   bwaFileStats.errors = JSON.stringify(bwaFileContents.errors).slice(1, -1);
-  $('#bwaFileinputloading').addClass('is-hidden');
-  $('#bwaFileinputconfirm').removeClass('is-hidden');
+  qs('#bwaFileinputloading')!.classList.add('is-hidden');
+  qs('#bwaFileinputconfirm')!.classList.remove('is-hidden');
 
   updateFileInfoUI(bwaFileStats);
 
@@ -162,35 +162,31 @@ electron.on('bwa:fileinput.confirmation', (_e: unknown, filePath: string | strin
   $('#bwaEntryButtonOpen').click(function() {...});
     Bulk whois, file input, entry container button
  */
-$(document).on('click', '#bwaEntryButtonOpen', function () {
-  $('#bwaEntry').addClass('is-hidden');
-  $.when($('#bwaFileinputloading').removeClass('is-hidden').delay(10)).done(function () {
-    void (async () => {
-      const path = await electron.invoke(IpcChannel.BwaInputFile);
-      void handleFileConfirmation(path);
-    })();
-  });
-
-  return;
+on('click', '#bwaEntryButtonOpen', () => {
+  qs('#bwaEntry')!.classList.add('is-hidden');
+  const loader = qs('#bwaFileinputloading')!;
+  loader.classList.remove('is-hidden');
+  setTimeout(async () => {
+    const path = await electron.invoke(IpcChannel.BwaInputFile);
+    void handleFileConfirmation(path);
+  }, 10);
 });
 
 /*
   $('#bwaFileinputconfirmButtonCancel').click(function() {...});
     Bulk whois, file input, cancel button, file confirmation
  */
-$('#bwaFileinputconfirmButtonCancel').click(function () {
+on('click', '#bwaFileinputconfirmButtonCancel', () => {
   watcher.close();
-  $('#bwaFileinputconfirm').addClass('is-hidden');
-  $('#bwaEntry').removeClass('is-hidden');
-
-  return;
+  qs('#bwaFileinputconfirm')!.classList.add('is-hidden');
+  qs('#bwaEntry')!.classList.remove('is-hidden');
 });
 
 /*
   $('#bwaFileinputconfirmButtonStart').click(function() {...});
     Bulk whois, file input, start button, file confirmation
  */
-$('#bwaFileinputconfirmButtonStart').click(function () {
+on('click', '#bwaFileinputconfirmButtonStart', () => {
   watcher.close();
   void (async () => {
     const data = await electron.invoke(IpcChannel.BwaAnalyserStart, bwaFileContents);
@@ -202,41 +198,32 @@ $('#bwaFileinputconfirmButtonStart').click(function () {
     showTable();
   });*/
 
-  return;
 });
 
 /*
 // File Input, proceed to bulk whois
-$('#bwafButtonConfirm').click(function() {
-  const bwDomainArray = bwFileContents.toString().split('\n').map(Function.prototype.call, String.prototype.trim);
-  const bwTldsArray = $('#bwfSearchTlds').val().toString().split(',');
+on('click', '#bwafButtonConfirm', () => {
+  const bwDomainArray = bwaFileContents.toString().split('\n').map(Function.prototype.call, String.prototype.trim);
+  const bwTldsArray = (qs<HTMLInputElement>('#bwfSearchTlds')?.value || '').split(',');
 
-  $('#bwFileInputConfirm').addClass('is-hidden');
-  $('#bwProcessing').removeClass('is-hidden');
+  qs('#bwFileInputConfirm')!.classList.add('is-hidden');
+  qs('#bwProcessing')!.classList.remove('is-hidden');
 
   electron.send(IpcChannel.BulkwhoisLookup, bwDomainArray, bwTldsArray);
 });
 
 // Bulk whois file input by drag and drop
-(function() {
+(() => {
   const holder = document.getElementById('bwaMainContainer');
-  holder.ondragover = function() {
-    return false;
-  };
-
-  holder.ondragleave = function() {
-    return false;
-  };
-
-  holder.ondragend = function() {
-    return false;
-  };
-
-  holder.ondrop = function(event) {
+  if (!holder) return;
+  holder.ondragover = () => false;
+  holder.ondragleave = () => false;
+  holder.ondragend = () => false;
+  holder.ondrop = (event) => {
     event.preventDefault();
-    for (const file of event.dataTransfer.files) {
+    for (const file of Array.from(event.dataTransfer!.files)) {
       debug(`File(s) you dragged here: ${file.path}`);
-      electron.send('ondragstart', file.path);
+      electron.send('ondragstart', (file as any).path);
     }
     return false;
   };

--- a/app/ts/utils/dom.ts
+++ b/app/ts/utils/dom.ts
@@ -1,0 +1,26 @@
+export function qs<T extends Element = HTMLElement>(
+  selector: string,
+  parent: ParentNode = document
+): T | null {
+  return parent.querySelector(selector) as T | null;
+}
+
+export function qsa<T extends Element = HTMLElement>(
+  selector: string,
+  parent: ParentNode = document
+): T[] {
+  return Array.from(parent.querySelectorAll(selector)) as T[];
+}
+
+export function on<K extends keyof HTMLElementEventMap>(
+  event: K,
+  selector: string,
+  handler: (event: HTMLElementEventMap[K]) => void
+): void {
+  document.addEventListener(event, (e) => {
+    const target = e.target as Element | null;
+    if (target && target.closest(selector)) {
+      handler(e as any);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add simple DOM helper utilities
- replace jQuery-based DOM code in bulk whois and BWA modules

## Testing
- `npx prettier --write app/ts/utils/dom.ts app/ts/renderer/bulkwhois/fileinput.ts app/ts/renderer/bulkwhois/event-bindings.ts app/ts/renderer/bulkwhois/status-handler.ts app/ts/renderer/bwa/analyser.ts app/ts/renderer/bwa/fileinput.ts`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run test:e2e` *(fails: session not created WebDriverError)*

------
https://chatgpt.com/codex/tasks/task_e_6883bf37565c8325b5ce6601dd4ac492