### PR TITLE
fix: ensure jQuery available for datatables

### DIFF
--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -1,6 +1,8 @@
 import * as conversions from '../../common/conversions.js';
 import { qs, on } from '../../utils/dom.js';
-import '../../../vendor/jquery.js';
+import jq from '../../../vendor/jquery.js';
+(window as any).jQuery = jq;
+(window as any).$ = jq;
 import '../../../vendor/datatables.js';
 import { debugFactory } from '../../common/logger.js';
 import type { RendererElectronAPI } from '../../../../types/renderer-electron-api.js';

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -1,7 +1,9 @@
 import * as conversions from '../../common/conversions.js';
 import type { FileStats } from '../../common/fileStats.js';
 import { qs, on } from '../../utils/dom.js';
-import '../../../vendor/jquery.js';
+import jq from '../../../vendor/jquery.js';
+(window as any).jQuery = jq;
+(window as any).$ = jq;
 import '../../../vendor/datatables.js';
 import { settings } from '../settings-renderer.js';
 import { debugFactory, errorFactory } from '../../common/logger.js';


### PR DESCRIPTION
## Summary
- make jQuery available on `window` before importing datatables

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Unexpected token 'export')*
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6888daf7bc5c8325adf0166127d17cfe