### PR TITLE
fix datatables dependency

### DIFF
--- a/scripts/regenerateVendor.mjs
+++ b/scripts/regenerateVendor.mjs
@@ -69,6 +69,12 @@ export function regenerateVendor() {
     path.join(modulesDir, 'datatables', 'media', 'js', 'jquery.dataTables.js'),
     path.join(vendorDir, 'datatables.js')
   );
+  const dtPath = path.join(vendorDir, 'datatables.js');
+  let dtContent = fs.readFileSync(dtPath, 'utf8');
+  if (!dtContent.startsWith("import './jquery.js';")) {
+    dtContent = "import './jquery.js';\n" + dtContent + '\nexport default window.jQuery;\n';
+    fs.writeFileSync(dtPath, dtContent);
+  }
   writeFile(
     path.join(vendorDir, 'datatables.d.ts'),
     'const datatables: any;\nexport default datatables;\n'


### PR DESCRIPTION
## Summary
- ensure datatables vendor file loads jQuery first

## Testing
- `npm run lint`
- `npm run format`
- `npx tsc --noEmit`
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6888daf7bc5c8325adf0166127d17cfe