### PR TITLE
Fix jquery globalThis replacement

### DIFF
--- a/app/vendor/jquery.js
+++ b/app/vendor/jquery.js
@@ -34,7 +34,7 @@
 	}
 
 // Pass this if window is not defined yet
-} )( typeof window !== "undefined" ? window : this, function( window, noGlobal ) {
+} )( typeof window !== "undefined" ? window : globalThis, function( window, noGlobal ) {
 
 // Edge <= 12 - 13+, Firefox <=18 - 45+, IE 10 - 11, Safari 5.1 - 9+, iOS 6 - 9.1
 // throw exceptions when non-strict code (e.g., ASP.NET 4.5) accesses strict mode

--- a/scripts/regenerateVendor.mjs
+++ b/scripts/regenerateVendor.mjs
@@ -38,13 +38,21 @@ export function regenerateVendor() {
   const jqSrc = path.join(modulesDir, 'jquery', 'dist', 'jquery.js');
   const jqDest = path.join(vendorDir, 'jquery.js');
   copyFile(jqSrc, jqDest);
+
+  const jqReplace = 'typeof window !== "undefined" ? window : this';
+  const jqReplaceWith = 'typeof window !== "undefined" ? window : globalThis';
+
+  let jqContent = fs.readFileSync(jqDest, 'utf8');
+  if (jqContent.includes(jqReplace)) {
+    jqContent = jqContent.replace(jqReplace, jqReplaceWith);
+  }
   const jqAppend =
     '\nif (typeof window !== "undefined") { window.$ = window.jQuery; }\n' +
     'export default window.jQuery;\n';
-  const jqContent = fs.readFileSync(jqDest, 'utf8');
   if (!jqContent.includes('export default')) {
-    fs.appendFileSync(jqDest, jqAppend);
+    jqContent += jqAppend;
   }
+  fs.writeFileSync(jqDest, jqContent);
   writeFile(
     path.join(vendorDir, 'jquery.d.ts'),
     "import jQuery from 'jquery';\nexport default jQuery;\n"


### PR DESCRIPTION
## Summary
- modify vendor regen script to replace reference to `this` with `globalThis`
- regenerate vendor jquery bundle

## Testing
- `npm run regen:vendor`
- `npm run build`
- `npm test` *(fails: ReferenceError: jest is not defined)*
- `npm run lint`
- `npm run format`
- `npx tsc --noEmit`
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6888e6b0254c83258ce75458e32d0373