### PR TITLE
feat: load jQuery from module

### DIFF
--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -1,6 +1,6 @@
 import * as conversions from '../../common/conversions.js';
 import { qs, on } from '../../utils/dom.js';
-import jq from '../../../vendor/jquery.js';
+import jq from '../jqueryGlobal.js';
 (window as any).jQuery = jq;
 (window as any).$ = jq;
 import '../../../vendor/datatables.js';

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -1,7 +1,7 @@
 import * as conversions from '../../common/conversions.js';
 import type { FileStats } from '../../common/fileStats.js';
 import { qs, on } from '../../utils/dom.js';
-import jq from '../../../vendor/jquery.js';
+import jq from '../jqueryGlobal.js';
 (window as any).jQuery = jq;
 (window as any).$ = jq;
 import '../../../vendor/datatables.js';

--- a/app/ts/renderer/darkmode.ts
+++ b/app/ts/renderer/darkmode.ts
@@ -1,4 +1,4 @@
-import $ from '../../vendor/jquery.js';
+import $ from './jqueryGlobal.js';
 import { settings, saveSettings } from './settings-renderer.js';
 import { debugFactory } from '../common/logger.js';
 

--- a/app/ts/renderer/history.ts
+++ b/app/ts/renderer/history.ts
@@ -1,4 +1,4 @@
-import $ from '../../vendor/jquery.js';
+import $ from './jqueryGlobal.js';
 import type { RendererElectronAPI } from '../../../types/renderer-electron-api.js';
 const electron = (window as any).electron as RendererElectronAPI;
 import { debugFactory } from '../common/logger.js';

--- a/app/ts/renderer/jqueryGlobal.ts
+++ b/app/ts/renderer/jqueryGlobal.ts
@@ -1,0 +1,4 @@
+import jQuery from 'jquery';
+(globalThis as any).jQuery = jQuery;
+(globalThis as any).$ = jQuery;
+export default jQuery;

--- a/app/ts/renderer/settings.ts
+++ b/app/ts/renderer/settings.ts
@@ -1,4 +1,4 @@
-import $ from '../../vendor/jquery.js';
+import $ from './jqueryGlobal.js';
 import { debugFactory } from '../common/logger.js';
 import { IpcChannel } from '../common/ipcChannels.js';
 import type * as fs from 'fs';

--- a/app/ts/renderer/templateLoader.ts
+++ b/app/ts/renderer/templateLoader.ts
@@ -1,4 +1,4 @@
-import $ from '../../vendor/jquery.js';
+import $ from './jqueryGlobal.js';
 import Handlebars from '../../vendor/handlebars.runtime.js';
 import { debugFactory } from '../common/logger.js';
 

--- a/app/ts/renderer/to.ts
+++ b/app/ts/renderer/to.ts
@@ -3,7 +3,7 @@
 import type { RendererElectronAPI } from '../../../types/renderer-electron-api.js';
 const { invoke } = (window as any).electron as RendererElectronAPI;
 import { IpcChannel } from '../common/ipcChannels.js';
-import $ from '../../vendor/jquery.js';
+import $ from './jqueryGlobal.js';
 import { debugFactory, errorFactory } from '../common/logger.js';
 
 const debug = debugFactory('renderer.to');

--- a/scripts/regenerateVendor.mjs
+++ b/scripts/regenerateVendor.mjs
@@ -79,8 +79,13 @@ export function regenerateVendor() {
   );
   const dtPath = path.join(vendorDir, 'datatables.js');
   let dtContent = fs.readFileSync(dtPath, 'utf8');
-  if (!dtContent.startsWith("import './jquery.js';")) {
-    dtContent = "import './jquery.js';\n" + dtContent + '\nexport default window.jQuery;\n';
+  if (!dtContent.startsWith("import jQuery from 'jquery';")) {
+    dtContent =
+      "import jQuery from 'jquery';\n" +
+      '(globalThis as any).jQuery = jQuery;\n' +
+      '(globalThis as any).$ = jQuery;\n' +
+      dtContent +
+      '\nexport default window.jQuery;\n';
     fs.writeFileSync(dtPath, dtContent);
   }
   writeFile(

--- a/test/bulkwhoisEventBindings.test.ts
+++ b/test/bulkwhoisEventBindings.test.ts
@@ -1,5 +1,5 @@
 /** @jest-environment jsdom */
-import jQuery from '../app/vendor/jquery.js';
+import jQuery from '../app/ts/renderer/jqueryGlobal';
 import { bindProcessingEvents } from '../app/ts/renderer/bulkwhois/event-bindings';
 import { IpcChannel } from '../app/ts/common/ipcChannels';
 

--- a/test/bulkwhoisStatusHandler.test.ts
+++ b/test/bulkwhoisStatusHandler.test.ts
@@ -1,5 +1,5 @@
 /** @jest-environment jsdom */
-import jQuery from '../app/vendor/jquery.js';
+import jQuery from '../app/ts/renderer/jqueryGlobal';
 import { registerStatusUpdates } from '../app/ts/renderer/bulkwhois/status-handler';
 import { IpcChannel } from '../app/ts/common/ipcChannels';
 

--- a/test/darkmode.test.ts
+++ b/test/darkmode.test.ts
@@ -2,7 +2,7 @@
 
 import '../test/electronMock';
 
-let jQuery: typeof import('../app/vendor/jquery.js');
+let jQuery: typeof import('../app/ts/renderer/jqueryGlobal');
 
 const listeners: Array<(e: { matches: boolean }) => void> = [];
 let systemPref = true;
@@ -29,7 +29,7 @@ beforeEach(() => {
 });
 
 async function loadDarkmode(): Promise<any> {
-  jQuery = require('../app/vendor/jquery.js');
+  jQuery = require('../app/ts/renderer/jqueryGlobal');
   (window as any).$ = (window as any).jQuery = jQuery;
   const settingsModule = require('../app/ts/renderer/settings-renderer');
   settingsModule.settings.theme.followSystem = true;

--- a/test/exportRenderer.test.ts
+++ b/test/exportRenderer.test.ts
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 
-import jQuery from '../app/vendor/jquery.js';
+import jQuery from '../app/ts/renderer/jqueryGlobal';
 import { IpcChannel } from '../app/ts/common/ipcChannels';
 
 const handlers: Record<string, (...args: any[]) => void> = {};

--- a/test/jqueryAvailability.test.ts
+++ b/test/jqueryAvailability.test.ts
@@ -20,7 +20,7 @@ jest.mock('../app/ts/renderer/settings-renderer', () => ({
   }))
 }));
 
-import jQuery from '../app/vendor/jquery.js';
+import jQuery from '../app/ts/renderer/jqueryGlobal';
 
 describe('renderer jQuery availability', () => {
   test('global $ references jQuery function', () => {

--- a/test/rendererOptions.test.ts
+++ b/test/rendererOptions.test.ts
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 
-let jQuery: typeof import('../app/vendor/jquery.js');
+let jQuery: typeof import('../app/ts/renderer/jqueryGlobal');
 let settingsModule: any;
 const invokeMock = jest.fn();
 jest.setTimeout(10000);
@@ -54,7 +54,7 @@ beforeEach(() => {
 });
 
 test('changing setting updates configuration', async () => {
-  jQuery = require('../app/vendor/jquery.js');
+  jQuery = require('../app/ts/renderer/jqueryGlobal');
   (window as any).$ = (window as any).jQuery = jQuery;
   settingsModule = require('../app/ts/renderer/settings-renderer');
   require('../app/ts/renderer/settings');
@@ -71,7 +71,7 @@ test('changing setting updates configuration', async () => {
 });
 
 test('reloadApp invokes ipcRenderer', async () => {
-  jQuery = require('../app/vendor/jquery.js');
+  jQuery = require('../app/ts/renderer/jqueryGlobal');
   (window as any).$ = (window as any).jQuery = jQuery;
   require('../app/ts/renderer/settings');
   jQuery.ready();
@@ -91,7 +91,7 @@ test('reloadApp invokes ipcRenderer', async () => {
 });
 
 test('openDataFolder invokes settings:open-data-dir', async () => {
-  jQuery = require('../app/vendor/jquery.js');
+  jQuery = require('../app/ts/renderer/jqueryGlobal');
   (window as any).$ = (window as any).jQuery = jQuery;
   require('../app/ts/renderer/settings');
   jQuery.ready();

--- a/types/vendor.d.ts
+++ b/types/vendor.d.ts
@@ -1,8 +1,3 @@
-declare module '*vendor/jquery.js' {
-  const jq: typeof import('jquery');
-  export default jq;
-}
-
 declare module '*vendor/handlebars.runtime.js' {
   import Handlebars from 'handlebars';
   export default Handlebars;


### PR DESCRIPTION
## Summary
- load jQuery from `jquery` package so global `$` comes from a module
- attach global jQuery in `jqueryGlobal.ts`
- use new helper across renderer code and tests
- regenerate vendor scripts so DataTables also imports jQuery

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Jest syntax errors)*
- `npm run test:e2e` *(fails: WebDriverError)*

------
https://chatgpt.com/codex/tasks/task_e_6888ee96a6e88325814041044c66a1f6