### PR TITLE
fix: add jquery import map

### DIFF
--- a/app/html/templates/mainPanel.hbs
+++ b/app/html/templates/mainPanel.hbs
@@ -18,7 +18,8 @@
     <script type="importmap">
       {
         "imports": {
-          "debug": "../vendor/debug.js"
+          "debug": "../vendor/debug.js",
+          "jquery": "../vendor/jquery.js"
         }
       }
     </script>


### PR DESCRIPTION
## Summary
- map `jquery` in the main panel import map

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Unexpected token 'export')*
- `npm run test:e2e` *(fails to start WebDriver)*

------
https://chatgpt.com/codex/tasks/task_e_6888f8c2c0f88325a8583126ff05c39a