### PR TITLE
fix: generate datatables with valid JS

### DIFF
--- a/scripts/regenerateVendor.mjs
+++ b/scripts/regenerateVendor.mjs
@@ -82,8 +82,8 @@ export function regenerateVendor() {
   if (!dtContent.startsWith("import jQuery from 'jquery';")) {
     dtContent =
       "import jQuery from 'jquery';\n" +
-      '(globalThis as any).jQuery = jQuery;\n' +
-      '(globalThis as any).$ = jQuery;\n' +
+      'globalThis.jQuery = jQuery;\n' +
+      'globalThis.$ = jQuery;\n' +
       dtContent +
       '\nexport default window.jQuery;\n';
     fs.writeFileSync(dtPath, dtContent);


### PR DESCRIPTION
## Summary
- fix vendor regeneration of datatables.js to avoid `as any` syntax

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run test:e2e` *(fails: WebDriverError: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6888fa6fedb483259b0b7b31276fe1e1