### PR TITLE
Fix DataTables jQuery alias

### DIFF
--- a/scripts/regenerateVendor.mjs
+++ b/scripts/regenerateVendor.mjs
@@ -84,6 +84,7 @@ export function regenerateVendor() {
       "import jQuery from 'jquery';\n" +
       'globalThis.jQuery = jQuery;\n' +
       'globalThis.$ = jQuery;\n' +
+      'const $ = jQuery;\n' +
       dtContent +
       '\nexport default window.jQuery;\n';
     fs.writeFileSync(dtPath, dtContent);


### PR DESCRIPTION
## Summary
- ensure jQuery alias `$` is present when regenerating vendor files

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Jest setup parse error)*
- `npm run test:e2e` *(fails: ChromeDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6888fbd7b378832597095f7d81e1fab5