### PR TITLE
fix datatables init

### DIFF
--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -90,7 +90,8 @@ function showTable() {
   }
   qs('#bwaAnalyserTableTbody')!.innerHTML = body.content;
 
-  body.table = (qs('#bwaAnalyserTable') as any).dataTable({
+  // Use jQuery wrapper to initialise DataTables correctly
+  body.table = (jq('#bwaAnalyserTable') as any).DataTable({
     destroy: true
   });
 


### PR DESCRIPTION
## Summary
- use jQuery wrapper when initializing DataTables

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Jest encountered unexpected token)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6889017dee7483258112e0a5d49feb71