### PR TITLE
fix: ensure jQuery loads in darkmode

### DIFF
--- a/app/ts/renderer/darkmode.ts
+++ b/app/ts/renderer/darkmode.ts
@@ -1,4 +1,8 @@
-import $ from './jqueryGlobal.js';
+import jQuery from 'jquery';
+
+(globalThis as any).jQuery = jQuery;
+(globalThis as any).$ = jQuery;
+const $ = jQuery;
 import { settings, saveSettings } from './settings-renderer.js';
 import { debugFactory } from '../common/logger.js';
 


### PR DESCRIPTION
## Summary
- ensure jQuery is loaded directly in darkmode.ts

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: SyntaxError: Unexpected token 'export')*

------
https://chatgpt.com/codex/tasks/task_e_68890ee0176c8325a98dedf4a875c661