### PR TITLE
refactor: drop jquery globals

### DIFF
--- a/app/html/startup.js
+++ b/app/html/startup.js
@@ -1,3 +1,4 @@
+import 'jquery';
 import registerPartials from '../ts/renderer/registerPartials.js';
 await registerPartials();
 

--- a/app/ts/renderer/darkmode.ts
+++ b/app/ts/renderer/darkmode.ts
@@ -1,8 +1,3 @@
-import jQuery from 'jquery';
-
-(globalThis as any).jQuery = jQuery;
-(globalThis as any).$ = jQuery;
-const $ = jQuery;
 import { settings, saveSettings } from './settings-renderer.js';
 import { debugFactory } from '../common/logger.js';
 
@@ -22,17 +17,17 @@ function getSystemPref(): boolean {
   return window.matchMedia('(prefers-color-scheme: dark)').matches;
 }
 
-$(document).ready(() => {
-  const darkSelect = $('#theme\\.darkMode');
-  const systemSelect = $('#theme\\.followSystem');
+document.addEventListener('DOMContentLoaded', () => {
+  const darkSelect = document.getElementById('theme.darkMode') as HTMLSelectElement | null;
+  const systemSelect = document.getElementById('theme.followSystem') as HTMLSelectElement | null;
   const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
 
   const applyFromSettings = (): void => {
     const useSystem = settings.theme?.followSystem ?? false;
     const isDark = useSystem ? mediaQuery.matches : settings.theme?.darkMode ?? false;
     applyDarkMode(isDark);
-    if (darkSelect.length) darkSelect.val(settings.theme?.darkMode ? 'true' : 'false');
-    if (systemSelect.length) systemSelect.val(useSystem ? 'true' : 'false');
+    if (darkSelect) darkSelect.value = settings.theme?.darkMode ? 'true' : 'false';
+    if (systemSelect) systemSelect.value = useSystem ? 'true' : 'false';
   };
 
   applyFromSettings();
@@ -43,9 +38,9 @@ $(document).ready(() => {
     }
   });
 
-  if (darkSelect.length) {
-    darkSelect.on('change', () => {
-      const state = darkSelect.val() === 'true';
+  if (darkSelect) {
+    darkSelect.addEventListener('change', () => {
+      const state = darkSelect.value === 'true';
       settings.theme = settings.theme || { darkMode: false, followSystem: false };
       settings.theme.darkMode = state;
       void saveSettings(settings);
@@ -55,9 +50,9 @@ $(document).ready(() => {
     });
   }
 
-  if (systemSelect.length) {
-    systemSelect.on('change', () => {
-      const state = systemSelect.val() === 'true';
+  if (systemSelect) {
+    systemSelect.addEventListener('change', () => {
+      const state = systemSelect.value === 'true';
       settings.theme = settings.theme || { darkMode: false, followSystem: false };
       settings.theme.followSystem = state;
       void saveSettings(settings);

--- a/app/ts/renderer/jqueryGlobal.ts
+++ b/app/ts/renderer/jqueryGlobal.ts
@@ -1,4 +1,4 @@
-import jQuery from 'jquery';
-(globalThis as any).jQuery = jQuery;
-(globalThis as any).$ = jQuery;
-export default jQuery;
+const jQuery: typeof import('jquery') | undefined =
+  (globalThis as any).jQuery ?? (globalThis as any).$;
+
+export default jQuery as typeof import('jquery');

--- a/test/bulkwhoisEventBindings.test.ts
+++ b/test/bulkwhoisEventBindings.test.ts
@@ -1,5 +1,5 @@
 /** @jest-environment jsdom */
-import jQuery from '../app/ts/renderer/jqueryGlobal';
+import jQuery from 'jquery';
 import { bindProcessingEvents } from '../app/ts/renderer/bulkwhois/event-bindings';
 import { IpcChannel } from '../app/ts/common/ipcChannels';
 

--- a/test/bulkwhoisStatusHandler.test.ts
+++ b/test/bulkwhoisStatusHandler.test.ts
@@ -1,5 +1,5 @@
 /** @jest-environment jsdom */
-import jQuery from '../app/ts/renderer/jqueryGlobal';
+import jQuery from 'jquery';
 import { registerStatusUpdates } from '../app/ts/renderer/bulkwhois/status-handler';
 import { IpcChannel } from '../app/ts/common/ipcChannels';
 

--- a/test/darkmode.test.ts
+++ b/test/darkmode.test.ts
@@ -2,8 +2,6 @@
 
 import '../test/electronMock';
 
-let jQuery: typeof import('../app/ts/renderer/jqueryGlobal');
-
 const listeners: Array<(e: { matches: boolean }) => void> = [];
 let systemPref = true;
 
@@ -29,13 +27,11 @@ beforeEach(() => {
 });
 
 async function loadDarkmode(): Promise<any> {
-  jQuery = require('../app/ts/renderer/jqueryGlobal');
-  (window as any).$ = (window as any).jQuery = jQuery;
   const settingsModule = require('../app/ts/renderer/settings-renderer');
   settingsModule.settings.theme.followSystem = true;
   settingsModule.settings.theme.darkMode = false;
   require('../app/ts/renderer/darkmode');
-  jQuery.ready();
+  document.dispatchEvent(new Event('DOMContentLoaded'));
   await new Promise((r) => setTimeout(r, 0));
   return settingsModule;
 }

--- a/test/exportRenderer.test.ts
+++ b/test/exportRenderer.test.ts
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 
-import jQuery from '../app/ts/renderer/jqueryGlobal';
+import jQuery from 'jquery';
 import { IpcChannel } from '../app/ts/common/ipcChannels';
 
 const handlers: Record<string, (...args: any[]) => void> = {};

--- a/test/jqueryAvailability.test.ts
+++ b/test/jqueryAvailability.test.ts
@@ -23,11 +23,10 @@ jest.mock('../app/ts/renderer/settings-renderer', () => ({
 import jQuery from '../app/ts/renderer/jqueryGlobal';
 
 describe('renderer jQuery availability', () => {
-  test('global $ references jQuery function', () => {
+  test('no global jQuery is assigned', () => {
     expect((window as any).$).toBeUndefined();
     require('../app/ts/renderer');
-    expect((window as any).$).toBe(jQuery);
-    expect((window as any).jQuery).toBe(jQuery);
-    expect(typeof (window as any).$).toBe('function');
+    expect((window as any).$).toBeUndefined();
+    expect(jQuery).toBeUndefined();
   });
 });

--- a/test/rendererOptions.test.ts
+++ b/test/rendererOptions.test.ts
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 
-let jQuery: typeof import('../app/ts/renderer/jqueryGlobal');
+let jQuery: typeof import('jquery');
 let settingsModule: any;
 const invokeMock = jest.fn();
 jest.setTimeout(10000);
@@ -54,11 +54,11 @@ beforeEach(() => {
 });
 
 test('changing setting updates configuration', async () => {
-  jQuery = require('../app/ts/renderer/jqueryGlobal');
+  jQuery = require('jquery');
   (window as any).$ = (window as any).jQuery = jQuery;
   settingsModule = require('../app/ts/renderer/settings-renderer');
   require('../app/ts/renderer/settings');
-  jQuery.ready();
+  document.dispatchEvent(new Event('DOMContentLoaded'));
   const { settings } = settingsModule;
 
   await new Promise((r) => setTimeout(r, 0));
@@ -71,10 +71,10 @@ test('changing setting updates configuration', async () => {
 });
 
 test('reloadApp invokes ipcRenderer', async () => {
-  jQuery = require('../app/ts/renderer/jqueryGlobal');
+  jQuery = require('jquery');
   (window as any).$ = (window as any).jQuery = jQuery;
   require('../app/ts/renderer/settings');
-  jQuery.ready();
+  document.dispatchEvent(new Event('DOMContentLoaded'));
 
   await new Promise((r) => setTimeout(r, 0));
   expect(invokeMock).toHaveBeenCalledWith('stats:start', expect.any(String), expect.any(String));
@@ -91,10 +91,10 @@ test('reloadApp invokes ipcRenderer', async () => {
 });
 
 test('openDataFolder invokes settings:open-data-dir', async () => {
-  jQuery = require('../app/ts/renderer/jqueryGlobal');
+  jQuery = require('jquery');
   (window as any).$ = (window as any).jQuery = jQuery;
   require('../app/ts/renderer/settings');
-  jQuery.ready();
+  document.dispatchEvent(new Event('DOMContentLoaded'));
 
   await new Promise((r) => setTimeout(r, 0));
 


### PR DESCRIPTION
## Summary
- remove jQuery import/assignments from `jqueryGlobal.ts`
- rewrite darkmode script to use native DOM
- load jQuery once from startup module
- update tests for DOMContentLoaded

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run test:e2e` *(fails: session not created error)*

------
https://chatgpt.com/codex/tasks/task_e_68892374d8448325ac4c0f322879f517