### PR TITLE
refactor: remove jquery from tool options

### DIFF
--- a/app/ts/renderer/to.ts
+++ b/app/ts/renderer/to.ts
@@ -3,7 +3,6 @@
 import type { RendererElectronAPI } from '../../../types/renderer-electron-api.js';
 const { invoke } = (window as any).electron as RendererElectronAPI;
 import { IpcChannel } from '../common/ipcChannels.js';
-import $ from './jqueryGlobal.js';
 import { debugFactory, errorFactory } from '../common/logger.js';
 
 const debug = debugFactory('renderer.to');
@@ -16,39 +15,43 @@ let filePath: string | null = null;
   $('#toButtonSelect').click(function() {...});
     Open file selection dialog
 */
-$(document).on('click', '#toButtonSelect', function () {
-  void (async () => {
+document.addEventListener('click', async (event) => {
+  const target = event.target as HTMLElement | null;
+  if (!target) return;
+  if (target.matches('#toButtonSelect')) {
     const result = await invoke(IpcChannel.ToInputFile);
     filePath = Array.isArray(result) ? result[0] : result;
-    $('#toFileSelected').text(filePath ?? '');
-  })();
-});
-
-/*
-  $('#toButtonProcess').click(function() {...});
-    Start processing with selected options
-*/
-$(document).on('click', '#toButtonProcess', async function () {
-  if (!filePath) return;
-  const options = collectOptions();
-  try {
-    const result = await invoke(IpcChannel.ToProcess, filePath, options);
-    $('#toOutput').text(result);
-  } catch (e) {
-    error(`Processing failed: ${e}`);
+    const fileLabel = document.querySelector<HTMLElement>('#toFileSelected');
+    if (fileLabel) fileLabel.textContent = filePath ?? '';
+  } else if (target.matches('#toButtonProcess')) {
+    if (!filePath) return;
+    const options = collectOptions();
+    try {
+      const result = await invoke(IpcChannel.ToProcess, filePath, options);
+      const output = document.querySelector<HTMLElement>('#toOutput');
+      if (output) output.textContent = result;
+    } catch (e) {
+      error(`Processing failed: ${e}`);
+    }
   }
 });
 
 function collectOptions() {
   const opts: any = {};
-  const prefix = $('#toPrefix').val() as string;
-  const suffix = $('#toSuffix').val() as string;
+  const prefixInput = document.querySelector<HTMLInputElement>('#toPrefix');
+  const suffixInput = document.querySelector<HTMLInputElement>('#toSuffix');
+  const prefix = prefixInput?.value ?? '';
+  const suffix = suffixInput?.value ?? '';
   if (prefix) opts.prefix = prefix;
   if (suffix) opts.suffix = suffix;
-  if ($('#toTrimSpaces').is(':checked')) opts.trimSpaces = true;
-  if ($('#toDeleteBlank').is(':checked')) opts.deleteBlankLines = true;
-  if ($('#toDedupe').is(':checked')) opts.dedupe = true;
-  const sortVal = $('input[name=toSort]:checked').val();
+
+  if (document.querySelector<HTMLInputElement>('#toTrimSpaces')?.checked) opts.trimSpaces = true;
+  if (document.querySelector<HTMLInputElement>('#toDeleteBlank')?.checked)
+    opts.deleteBlankLines = true;
+  if (document.querySelector<HTMLInputElement>('#toDedupe')?.checked) opts.dedupe = true;
+
+  const sortRadio = document.querySelector<HTMLInputElement>('input[name=toSort]:checked');
+  const sortVal = sortRadio?.value;
   if (sortVal === 'asc' || sortVal === 'desc' || sortVal === 'random') {
     opts.sort = sortVal;
   }


### PR DESCRIPTION
## Summary
- drop jquery global import
- use DOM `addEventListener` + `event.target` checks
- replace `.text()`, `.is()` and `.val()` usage

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Jest encountered unexpected token)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_6889296c66d08325a7d6cdb3f1d8d18c