### PR TITLE
Refactor renderers to drop jQuery

### DIFF
--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -1,17 +1,6 @@
 import * as conversions from '../../common/conversions.js';
 import { qs, on } from '../../utils/dom.js';
-import jq from '../jqueryGlobal.js';
-(window as any).jQuery = jq;
-(window as any).$ = jq;
 
-let datatablesReady: Promise<unknown> | null = null;
-
-async function ensureDataTables(): Promise<void> {
-  if (!(jq as any).fn.DataTable) {
-    datatablesReady ??= import('../../../vendor/datatables.js');
-    await datatablesReady;
-  }
-}
 import { debugFactory } from '../../common/logger.js';
 import type { RendererElectronAPI } from '../../../../types/renderer-electron-api.js';
 
@@ -68,7 +57,6 @@ on('click', '#bwaAnalyserModalCloseButtonNo', () => {
     ipsum
  */
 async function showTable() {
-  await ensureDataTables();
   const header: Record<string, any> = {},
     body: Record<string, any> = {};
   header.columns = Object.keys(bwaFileContents.data[0]);
@@ -98,11 +86,6 @@ async function showTable() {
     body.content += '</tr>\n';
   }
   qs('#bwaAnalyserTableTbody')!.innerHTML = body.content;
-
-  // Use jQuery wrapper to initialise DataTables correctly
-  body.table = (jq('#bwaAnalyserTable') as any).DataTable({
-    destroy: true
-  });
 
   qs('#bwaFileinputconfirm')!.classList.add('is-hidden');
   qs('#bwaAnalyser')!.classList.remove('is-hidden');

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -1,9 +1,6 @@
 import * as conversions from '../../common/conversions.js';
 import type { FileStats } from '../../common/fileStats.js';
 import { qs, on } from '../../utils/dom.js';
-import jq from '../jqueryGlobal.js';
-(window as any).jQuery = jq;
-(window as any).$ = jq;
 import { settings } from '../settings-renderer.js';
 import { debugFactory, errorFactory } from '../../common/logger.js';
 import type * as fs from 'fs';

--- a/app/ts/renderer/history.ts
+++ b/app/ts/renderer/history.ts
@@ -1,4 +1,4 @@
-import $ from './jqueryGlobal.js';
+import { qs, qsa, on } from '../utils/dom.js';
 import type { RendererElectronAPI } from '../../../types/renderer-electron-api.js';
 const electron = (window as any).electron as RendererElectronAPI;
 import { debugFactory } from '../common/logger.js';
@@ -12,26 +12,32 @@ function formatDate(ts: number): string {
 
 function loadHistory(): void {
   electron.invoke('history:get').then((entries: any[]) => {
-    const tbody = $('#historyTable tbody');
-    tbody.empty();
+    const tbody = qs('#historyTable tbody')!;
+    tbody.innerHTML = '';
     if (!entries.length) {
-      $('#historyEmpty').removeClass('is-hidden');
+      qs('#historyEmpty')!.classList.remove('is-hidden');
       return;
     }
-    $('#historyEmpty').addClass('is-hidden');
+    qs('#historyEmpty')!.classList.add('is-hidden');
     for (const e of entries) {
-      const row = $('<tr>');
-      row.append($('<td>').text(e.domain));
-      row.append($('<td>').text(e.status));
-      row.append($('<td>').text(formatDate(e.timestamp)));
-      tbody.append(row);
+      const row = document.createElement('tr');
+      const tdDomain = document.createElement('td');
+      tdDomain.textContent = e.domain;
+      row.appendChild(tdDomain);
+      const tdStatus = document.createElement('td');
+      tdStatus.textContent = e.status;
+      row.appendChild(tdStatus);
+      const tdDate = document.createElement('td');
+      tdDate.textContent = formatDate(e.timestamp);
+      row.appendChild(tdDate);
+      tbody.appendChild(row);
     }
   });
 }
 
-$(() => {
+document.addEventListener('DOMContentLoaded', () => {
   loadHistory();
-  $('#clearHistory').on('click', async () => {
+  on('click', '#clearHistory', async () => {
     await electron.invoke('history:clear');
     loadHistory();
   });

--- a/app/ts/renderer/settings.ts
+++ b/app/ts/renderer/settings.ts
@@ -1,4 +1,4 @@
-import $ from './jqueryGlobal.js';
+import { qs, qsa, on } from '../utils/dom.js';
 import { debugFactory } from '../common/logger.js';
 import { IpcChannel } from '../common/ipcChannels.js';
 import type * as fs from 'fs';
@@ -105,15 +105,19 @@ function updateStats(data: {
   readWrite: boolean;
   dataPath: string;
 }): void {
-  $('#stat-config-path').text(data.configPath);
-  $('#stat-config-size').text(
-    byteToHumanFileSize(data.configSize, settings.lookupMisc.useStandardSize)
+  qs('#stat-config-path')!.textContent = data.configPath;
+  qs('#stat-config-size')!.textContent = byteToHumanFileSize(
+    data.configSize,
+    settings.lookupMisc.useStandardSize
   );
-  $('#stat-config-loaded').text(data.loaded ? 'Loaded' : 'Not loaded');
-  $('#stat-config-mtime').text(data.mtime ? new Date(data.mtime).toUTCString() : 'N/A');
-  $('#stat-config-perms').text(data.readWrite ? 'Read/Write' : 'Read only');
-  $('#stat-data-path').text(data.dataPath);
-  $('#stat-data-size').text(byteToHumanFileSize(data.size, settings.lookupMisc.useStandardSize));
+  qs('#stat-config-loaded')!.textContent = data.loaded ? 'Loaded' : 'Not loaded';
+  qs('#stat-config-mtime')!.textContent = data.mtime ? new Date(data.mtime).toUTCString() : 'N/A';
+  qs('#stat-config-perms')!.textContent = data.readWrite ? 'Read/Write' : 'Read only';
+  qs('#stat-data-path')!.textContent = data.dataPath;
+  qs('#stat-data-size')!.textContent = byteToHumanFileSize(
+    data.size,
+    settings.lookupMisc.useStandardSize
+  );
 }
 
 const enumOptions: Record<string, string[]> = {
@@ -125,10 +129,11 @@ const enumOptions: Record<string, string[]> = {
   'ui.language': ['en', 'es']
 };
 
-function buildEntries(obj: any, prefix: string, table: JQuery<HTMLElement>): void {
+function buildEntries(obj: any, prefix: string, table: HTMLElement): void {
   Object.entries(obj).forEach(([key, value]) => {
     if (value && typeof value === 'object' && !Array.isArray(value)) {
-      table.append(
+      table.insertAdjacentHTML(
+        'beforeend',
         `<tr class="group-row"><th colspan="2"><h4 class="title is-5">${key}</h4></th></tr>`
       );
       buildEntries(value, prefix ? `${prefix}.${key}` : key, table);
@@ -148,106 +153,113 @@ function buildEntries(obj: any, prefix: string, table: JQuery<HTMLElement>): voi
       const desc = appSettingsDescriptions[path];
       const descHtml = desc ? `<p class="help is-size-7">${desc}</p>` : '';
       const thHtml = `${key}${descHtml}`;
-      const row = $(
-        `<tr><th>${thHtml}</th><td class="is-expanded"><div class="field has-addons"><div class="control is-expanded">${inputHtml}</div><div class="control"><button class="button is-small reset-btn" data-path="${path}"><span class="icon is-small"><i class="fas fa-undo"></i></span></button></div><div class="control"><span class="icon result-icon"></span></div></div></td></tr>`
-      );
-      table.append(row);
+      const rowHtml = `<tr><th>${thHtml}</th><td class="is-expanded"><div class="field has-addons"><div class="control is-expanded">${inputHtml}</div><div class="control"><button class="button is-small reset-btn" data-path="${path}"><span class="icon is-small"><i class="fas fa-undo"></i></span></button></div><div class="control"><span class="icon result-icon"></span></div></div></td></tr>`;
+      table.insertAdjacentHTML('beforeend', rowHtml);
     }
   });
 }
 
 export function populateInputs(): void {
-  $('#opTable')
-    .find('input[id], select[id]')
-    .each((_, el) => {
-      const $el = $(el);
-      const id = $el.attr('id');
-      if (!id) return;
-      const path = id.replace(/^appSettings\./, '');
-      const allowed = enumOptions[path];
-      let val = getValue(path);
-      if (allowed && (val === undefined || !allowed.includes(String(val)))) {
-        val = getDefault(path);
-        setValue(path, val);
-        void saveSettings(settings);
-      }
-      if (val !== undefined) {
-        if ($el.is('select')) {
-          $el.val(String(val));
-        } else {
-          $el.val(String(val));
-        }
-      }
-    });
+  qsa('#opTable input[id], #opTable select[id]').forEach((el) => {
+    const id = el.id;
+    if (!id) return;
+    const path = id.replace(/^appSettings\./, '');
+    const allowed = enumOptions[path];
+    let val = getValue(path);
+    if (allowed && (val === undefined || !allowed.includes(String(val)))) {
+      val = getDefault(path);
+      setValue(path, val);
+      void saveSettings(settings);
+    }
+    if (val !== undefined) {
+      (el as HTMLInputElement | HTMLSelectElement).value = String(val);
+    }
+  });
 }
 
-function saveEntry(path: string, $input: JQuery<HTMLElement>, val: any): void {
+function saveEntry(path: string, input: HTMLElement, val: any): void {
   setValue(path, val);
   void saveSettings(settings).then((result) => {
-    const icon = $input.closest('.field').find('.result-icon');
+    const icon = input.closest('.field')?.querySelector('.result-icon');
+    if (!icon) return;
     if (result === 'SAVED' || result === undefined) {
-      icon.html('<i class="fas fa-check has-text-success"></i>');
+      icon.innerHTML = '<i class="fas fa-check has-text-success"></i>';
     } else {
-      icon.html('<i class="fas fa-times has-text-danger"></i>');
+      icon.innerHTML = '<i class="fas fa-times has-text-danger"></i>';
     }
-    setTimeout(() => icon.empty(), 1500);
+    setTimeout(() => (icon.innerHTML = ''), 1500);
   });
 }
 
 function showToast(message: string, success: boolean): void {
-  const toast = $(`<div class="toast ${success ? 'is-success' : 'is-danger'}">${message}</div>`);
-  $('body').append(toast);
+  const toast = document.createElement('div');
+  toast.className = `toast ${success ? 'is-success' : 'is-danger'}`;
+  toast.textContent = message;
+  document.body.appendChild(toast);
   setTimeout(() => {
-    toast.fadeOut(400, () => toast.remove());
+    toast.style.transition = 'opacity 0.4s';
+    toast.style.opacity = '0';
+    setTimeout(() => toast.remove(), 400);
   }, 3000);
 }
 
 function filterOptions(term: string): void {
   const needle = term.trim().toLowerCase();
-  const rows = $('#opTable tr');
+  const rows = qsa('#opTable tr');
   if (!needle) {
-    rows.show();
-    $('#opSearchNoResults').addClass('is-hidden');
+    rows.forEach((r) => ((r as HTMLElement).style.display = ''));
+    qs('#opSearchNoResults')!.classList.add('is-hidden');
     return;
   }
 
-  rows.each(function () {
-    const $row = $(this);
-    if ($row.hasClass('group-row')) {
-      $row.show();
+  rows.forEach((row) => {
+    const el = row as HTMLElement;
+    if (el.classList.contains('group-row')) {
+      el.style.display = '';
       return;
     }
-    $row.toggle($row.text().toLowerCase().includes(needle));
+    const visible = el.textContent?.toLowerCase().includes(needle) ?? false;
+    el.style.display = visible ? '' : 'none';
   });
 
-  $('#opTable .group-row').each(function () {
-    const $group = $(this);
-    const visible = $group.nextUntil('.group-row').filter(':visible').length > 0;
-    $group.toggle(visible);
+  qsa('#opTable .group-row').forEach((group) => {
+    let sibling = group.nextElementSibling;
+    let visible = false;
+    while (sibling && !sibling.classList.contains('group-row')) {
+      if ((sibling as HTMLElement).style.display !== 'none') {
+        visible = true;
+        break;
+      }
+      sibling = sibling.nextElementSibling;
+    }
+    (group as HTMLElement).style.display = visible ? '' : 'none';
   });
 
-  const anyVisible = rows.not('.group-row').filter(':visible').length > 0;
-  $('#opSearchNoResults').toggleClass('is-hidden', anyVisible);
+  const anyVisible = rows.some(
+    (r) => !r.classList.contains('group-row') && (r as HTMLElement).style.display !== 'none'
+  );
+  qs('#opSearchNoResults')!.classList.toggle('is-hidden', anyVisible);
 }
 
-$(document).ready(() => {
-  const container = $('#settingsEntry');
-  const table = $('#opTable');
+document.addEventListener('DOMContentLoaded', () => {
+  const container = qs('#settingsEntry')!;
+  const table = qs('#opTable')!;
   buildEntries(appDefaults.settings, '', table);
   filterOptions('');
-  $('#opSearch').on('input', function () {
-    filterOptions($(this).val() as string);
+  const opSearch = qs<HTMLInputElement>('#opSearch');
+  opSearch?.addEventListener('input', () => {
+    filterOptions(opSearch.value);
   });
   // Wait for the final settings to load before populating fields
 
   void startStatsWorker();
 
   if (sessionStorage.getItem('settingsLoaded') !== 'true') {
-    $('#settings-not-loaded').removeClass('is-hidden');
+    qs('#settings-not-loaded')!.classList.remove('is-hidden');
   }
 
   window.addEventListener('settings-loaded', () => {
-    $('#settings-not-loaded').addClass('is-hidden');
+    qs('#settings-not-loaded')!.classList.add('is-hidden');
     populateInputs();
     void startStatsWorker();
   });
@@ -257,34 +269,36 @@ $(document).ready(() => {
     void startStatsWorker();
   });
 
-  container.on('change', 'input[id], select[id]', function () {
-    const $el = $(this);
-    const id = $el.attr('id');
+  on('change', '#settingsEntry input[id], #settingsEntry select[id]', (ev) => {
+    const el = (ev.target as Element).closest('input[id],select[id]') as
+      | HTMLInputElement
+      | HTMLSelectElement
+      | null;
+    if (!el) return;
+    const id = el.id;
     if (!id) return;
     const path = id.replace(/^appSettings\./, '');
-    const raw = $el.is('select') ? $el.val() : $el.val();
-    const val = typeof raw === 'string' ? parseValue(raw) : raw;
-    saveEntry(path, $el, val);
+    const val = parseValue((el as HTMLInputElement | HTMLSelectElement).value);
+    saveEntry(path, el, val);
   });
 
-  container.on('click', '.reset-btn', function () {
-    const path = $(this).data('path') as string;
+  on('click', '#settingsEntry .reset-btn', (ev) => {
+    const btn = (ev.target as Element).closest('.reset-btn') as HTMLElement | null;
+    if (!btn) return;
+    const path = btn.getAttribute('data-path') as string;
     const def = getDefault(path);
-    const id = `appSettings.${path}`.replace(/\./g, '\\.');
-    const $input = $('#' + id);
-    if ($input.is('select')) {
-      $input.val(String(def));
-    } else {
-      $input.val(String(def));
+    const input = qs<HTMLInputElement | HTMLSelectElement>(`[id="appSettings.${path}"]`);
+    if (input) {
+      input.value = String(def);
+      saveEntry(path, input, def);
     }
-    saveEntry(path, $input, def);
   });
 
-  $('#restoreDefaults').on('click', () => {
-    $('#restoreDefaultsModal').addClass('is-active');
+  on('click', '#restoreDefaults', () => {
+    qs('#restoreDefaultsModal')!.classList.add('is-active');
   });
 
-  $('#restoreDefaultsYes').on('click', () => {
+  on('click', '#restoreDefaultsYes', () => {
     const defaults = validateSettings({});
     Object.assign(settings, defaults);
     populateInputs();
@@ -294,14 +308,14 @@ $(document).ready(() => {
         r === 'SAVED' || r === undefined
       );
     });
-    $('#restoreDefaultsModal').removeClass('is-active');
+    qs('#restoreDefaultsModal')!.classList.remove('is-active');
   });
 
-  $('#restoreDefaultsNo, #restoreDefaultsModal .delete').on('click', () => {
-    $('#restoreDefaultsModal').removeClass('is-active');
+  on('click', '#restoreDefaultsNo, #restoreDefaultsModal .delete', () => {
+    qs('#restoreDefaultsModal')!.classList.remove('is-active');
   });
 
-  $('#reloadSettings').on('click', async () => {
+  on('click', '#reloadSettings', async () => {
     await loadSettings();
     sessionStorage.setItem('customSettingsLoaded', customSettingsLoaded ? 'true' : 'false');
     populateInputs();
@@ -315,7 +329,7 @@ $(document).ready(() => {
     refreshStats();
   });
 
-  $('#saveConfig').on('click', async () => {
+  on('click', '#saveConfig', async () => {
     const res = await saveSettings(settings);
     showToast(
       res === 'SAVED' || res === undefined ? 'Configuration saved' : 'Failed to save configuration',
@@ -324,14 +338,14 @@ $(document).ready(() => {
     refreshStats();
   });
 
-  $('#openDataFolder').on('click', async () => {
+  on('click', '#openDataFolder', async () => {
     const result = await electron.openDataDir();
     if (result) {
       showToast('Failed to open data directory', false);
     }
   });
 
-  $('#downloadModel').on('click', async () => {
+  on('click', '#downloadModel', async () => {
     if (!settings.ai.modelURL) {
       showToast('Model URL not configured', false);
       return;
@@ -344,7 +358,7 @@ $(document).ready(() => {
     }
   });
 
-  $('#reloadApp').on('click', async () => {
+  on('click', '#reloadApp', async () => {
     try {
       await electron.invoke('app:reload');
     } catch {
@@ -352,11 +366,11 @@ $(document).ready(() => {
     }
   });
 
-  $('#deleteConfig').on('click', () => {
-    $('#deleteConfigModal').addClass('is-active');
+  on('click', '#deleteConfig', () => {
+    qs('#deleteConfigModal')!.classList.add('is-active');
   });
 
-  $('#deleteConfigYes').on('click', async () => {
+  on('click', '#deleteConfigYes', async () => {
     const filePath = await electron.path.join(
       getUserDataPath(),
       settings.customConfiguration.filepath
@@ -372,32 +386,32 @@ $(document).ready(() => {
       }
     }
     refreshStats();
-    $('#deleteConfigModal').removeClass('is-active');
+    qs('#deleteConfigModal')!.classList.remove('is-active');
   });
 
-  $('#deleteConfigNo, #deleteConfigModal .delete').on('click', () => {
-    $('#deleteConfigModal').removeClass('is-active');
+  on('click', '#deleteConfigNo, #deleteConfigModal .delete', () => {
+    qs('#deleteConfigModal')!.classList.remove('is-active');
   });
 
-  const backToTop = $('#settingsBackToTop');
-  const goToBottom = $('#settingsGoToBottom');
-  const containerEl = $('#contents-container');
-  containerEl.on('scroll', () => {
-    if ($('#settingsMainContainer').hasClass('current')) {
-      const top = containerEl.scrollTop() ?? 0;
-      const bottom = (containerEl[0]?.scrollHeight ?? 0) - (containerEl.innerHeight() ?? 0) - top;
-      backToTop.toggleClass('is-visible', top > 200);
-      goToBottom.toggleClass('is-visible', bottom > 200);
+  const backToTop = qs('#settingsBackToTop')!;
+  const goToBottom = qs('#settingsGoToBottom')!;
+  const containerEl = qs('#contents-container') as HTMLElement;
+  containerEl.addEventListener('scroll', () => {
+    if (qs('#settingsMainContainer')!.classList.contains('current')) {
+      const top = containerEl.scrollTop;
+      const bottom = containerEl.scrollHeight - containerEl.clientHeight - top;
+      backToTop.classList.toggle('is-visible', top > 200);
+      goToBottom.classList.toggle('is-visible', bottom > 200);
     } else {
-      backToTop.removeClass('is-visible');
-      goToBottom.removeClass('is-visible');
+      backToTop.classList.remove('is-visible');
+      goToBottom.classList.remove('is-visible');
     }
   });
-  backToTop.on('click', () => {
-    containerEl.animate({ scrollTop: 0 }, 300);
+  backToTop.addEventListener('click', () => {
+    containerEl.scrollTo({ top: 0, behavior: 'smooth' });
   });
-  goToBottom.on('click', () => {
-    containerEl.animate({ scrollTop: containerEl[0]?.scrollHeight ?? 0 }, 300);
+  goToBottom.addEventListener('click', () => {
+    containerEl.scrollTo({ top: containerEl.scrollHeight, behavior: 'smooth' });
   });
 });
 

--- a/app/ts/renderer/templateLoader.ts
+++ b/app/ts/renderer/templateLoader.ts
@@ -1,4 +1,4 @@
-import $ from './jqueryGlobal.js';
+import { qs } from '../utils/dom.js';
 import Handlebars from '../../vendor/handlebars.runtime.js';
 import { debugFactory } from '../common/logger.js';
 
@@ -14,5 +14,6 @@ export async function loadTemplate(
   const precompiled = module.default || module;
   const compiled = Handlebars.template(precompiled);
   const html = compiled(context);
-  $(selector).html(html);
+  const el = qs(selector);
+  if (el) el.innerHTML = html;
 }


### PR DESCRIPTION
## Summary
- replace jQuery selectors with DOM helpers
- rewrite jQuery methods to vanilla DOM
- remove jqueryGlobal usage from renderer modules

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run test:e2e` *(fails: WebDriverError session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68892ebab5308325acb33e9cc52594b2