### PR TITLE
fix: handle fs imports in renderer

### DIFF
--- a/app/ts/renderer/registerPartials.ts
+++ b/app/ts/renderer/registerPartials.ts
@@ -17,9 +17,18 @@ export async function registerPartials(): Promise<void> {
       partials[name] = Handlebars.template((mod as any).default || mod);
     }
   } else {
-    const fs = await import('fs');
-    const path = await import('path');
-    const { pathToFileURL, fileURLToPath } = await import('url');
+    // In the renderer during development, dynamic imports of Node builtin
+    // modules fail because the module loader doesn't resolve them.
+    // When running under Electron with nodeIntegration enabled, `require`
+    // is available globally. Fall back to using it if present so the
+    // renderer can access the filesystem without throwing a module
+    // resolution error.
+    const fs: typeof import('fs') =
+      typeof require === 'function' ? require('fs') : await import('fs');
+    const path: typeof import('path') =
+      typeof require === 'function' ? require('path') : await import('path');
+    const { pathToFileURL, fileURLToPath }: typeof import('url') =
+      typeof require === 'function' ? require('url') : await import('url');
     const dir = path.join(
       path.dirname(fileURLToPath(import.meta.url)),
       '..',


### PR DESCRIPTION
## Summary
- fallback to `require` when importing `fs` in renderer

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run test:e2e` *(fails: ChromeDriver start message only)*

------
https://chatgpt.com/codex/tasks/task_e_688932d694648325913cc2e6eb5690d4