### PR TITLE
refactor: remove jquery from template loader test

### DIFF
--- a/app/html/startup.js
+++ b/app/html/startup.js
@@ -1,4 +1,3 @@
-import 'jquery';
 import registerPartials from '../ts/renderer/registerPartials.js';
 await registerPartials();
 

--- a/test/templateLoader.test.ts
+++ b/test/templateLoader.test.ts
@@ -1,7 +1,5 @@
 /** @jest-environment jsdom */
 
-import jQuery from 'jquery';
-
 jest.mock('../app/vendor/handlebars.runtime.js', () => {
   const compiledFn = jest.fn((ctx: any) => `<span>${ctx.text}</span>`);
   const template = jest.fn(() => compiledFn);
@@ -20,16 +18,12 @@ jest.mock(
 import { loadTemplate } from '../app/ts/renderer/templateLoader';
 const handlebars = require('../app/vendor/handlebars.runtime.js').default;
 
-beforeAll(() => {
-  (window as any).$ = (window as any).jQuery = jQuery;
-});
-
 describe('loadTemplate', () => {
   test('dynamically loads template and inserts html', async () => {
     document.body.innerHTML = '<div id="target"></div>';
     await loadTemplate('#target', 'mock.hbs', { text: 'hello' });
 
     expect(handlebars.template).toHaveBeenCalledWith({ name: 'mock' });
-    expect(jQuery('#target').html()).toBe('<span>hello</span>');
+    expect(document.querySelector<HTMLElement>('#target')?.innerHTML).toBe('<span>hello</span>');
   });
 });


### PR DESCRIPTION
## Summary
- stop importing jQuery in `startup.js`
- rewrite `templateLoader.test` without jQuery

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: SyntaxError: Unexpected token 'export')*
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68895502f30083258b1dcfa0693b7773