### PR TITLE
feat: use DataTables vanilla API

### DIFF
--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -1,5 +1,6 @@
 import * as conversions from '../../common/conversions.js';
 import { qs, on } from '../../utils/dom.js';
+import DataTable from 'datatables.net';
 
 import { debugFactory } from '../../common/logger.js';
 import type { RendererElectronAPI } from '../../../../types/renderer-electron-api.js';
@@ -89,7 +90,7 @@ async function showTable() {
 
   qs('#bwaFileinputconfirm')!.classList.add('is-hidden');
   qs('#bwaAnalyser')!.classList.remove('is-hidden');
-  //body.content.destroy();
+  new (DataTable as any)('#bwaAnalyserTable', { destroy: true });
 
   return;
 }

--- a/app/vendor/jquery.js
+++ b/app/vendor/jquery.js
@@ -10706,7 +10706,7 @@ jQuery.noConflict = function( deep ) {
 // (trac-7102#comment:10, https://github.com/jquery/jquery/pull/557)
 // and CommonJS for browser emulators (trac-13566)
 if ( typeof noGlobal === "undefined" ) {
-	window.jQuery = window.$ = jQuery;
+        /* no global assignments */
 }
 
 
@@ -10715,5 +10715,4 @@ if ( typeof noGlobal === "undefined" ) {
 return jQuery;
 } );
 
-if (typeof window !== "undefined") { window.$ = window.jQuery; }
 export default window.jQuery;

--- a/scripts/regenerateVendor.mjs
+++ b/scripts/regenerateVendor.mjs
@@ -46,9 +46,7 @@ export function regenerateVendor() {
   if (jqContent.includes(jqReplace)) {
     jqContent = jqContent.replace(jqReplace, jqReplaceWith);
   }
-  const jqAppend =
-    '\nif (typeof window !== "undefined") { window.$ = window.jQuery; }\n' +
-    'export default window.jQuery;\n';
+  const jqAppend = '\nexport default window.jQuery;\n';
   if (!jqContent.includes('export default')) {
     jqContent += jqAppend;
   }
@@ -79,14 +77,8 @@ export function regenerateVendor() {
   );
   const dtPath = path.join(vendorDir, 'datatables.js');
   let dtContent = fs.readFileSync(dtPath, 'utf8');
-  if (!dtContent.startsWith("import jQuery from 'jquery';")) {
-    dtContent =
-      "import jQuery from 'jquery';\n" +
-      'globalThis.jQuery = jQuery;\n' +
-      'globalThis.$ = jQuery;\n' +
-      'const $ = jQuery;\n' +
-      dtContent +
-      '\nexport default window.jQuery;\n';
+  if (!dtContent.includes('export default')) {
+    dtContent += '\nexport default window.DataTable;\n';
     fs.writeFileSync(dtPath, dtContent);
   }
   writeFile(


### PR DESCRIPTION
## Summary
- use datatables.net directly in the BWA analyser
- remove jQuery global injection from vendor scripts
- tweak vendor regeneration script for vanilla DataTables

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Jest encountered unexpected token)*
- `npm run test:e2e` *(fails: WebDriverError: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_688a22cc0bd88325aae9c97694e5c6ad