### PR TITLE
fix datatables import

### DIFF
--- a/app/html/templates/mainPanel.hbs
+++ b/app/html/templates/mainPanel.hbs
@@ -19,7 +19,8 @@
       {
         "imports": {
           "debug": "../vendor/debug.js",
-          "jquery": "../vendor/jquery.js"
+          "jquery": "../vendor/jquery.js",
+          "datatables.net": "../vendor/datatables.js"
         }
       }
     </script>


### PR DESCRIPTION
## Summary
- map `datatables.net` to local `datatables.js` in main panel import map

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_688a2d0469e08325949ec6441a92664b