### PR TITLE
Fix jQuery initialization order

### DIFF
--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -1,5 +1,6 @@
 import * as conversions from '../../common/conversions.js';
 import { qs, on } from '../../utils/dom.js';
+import jQuery from 'jquery';
 import DataTable from 'datatables.net';
 
 import { debugFactory } from '../../common/logger.js';


### PR DESCRIPTION
## Summary
- ensure jQuery is imported before using DataTables

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: SyntaxError in jest.setup.ts)*
- `npm run test:e2e` *(fails: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_688a31e3d3448325943fb5b61d9312db