### PR TITLE
fix: correct ascending proxy rotation order

### DIFF
--- a/app/ts/common/proxy.ts
+++ b/app/ts/common/proxy.ts
@@ -37,8 +37,8 @@ export function getProxy(): ProxyInfo | undefined {
       entry = list[randomInt(0, list.length - 1)];
       break;
     case 'ascending':
-      index = (index + 1) % list.length;
       entry = list[index];
+      index = (index + 1) % list.length;
       break;
     case 'descending':
       index = index <= 0 ? list.length - 1 : index - 1;

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -36,6 +36,15 @@ describe('proxy helper', () => {
     expect(third).toEqual({ ipaddress: '1.1.1.1', port: 8080, type: 5 });
   });
 
+  test('returns first proxy on first call in ascending mode', () => {
+    settings.lookupProxy.enable = true;
+    settings.lookupProxy.mode = 'multi';
+    settings.lookupProxy.list = ['1.1.1.1:8080', '2.2.2.2:8080'];
+    settings.lookupProxy.multimode = 'ascending';
+    const first = getProxy();
+    expect(first).toEqual({ ipaddress: '1.1.1.1', port: 8080, type: 5 });
+  });
+
   test('cycles proxies ascending', () => {
     settings.lookupProxy.enable = true;
     settings.lookupProxy.mode = 'multi';
@@ -44,9 +53,11 @@ describe('proxy helper', () => {
     const first = getProxy();
     const second = getProxy();
     const third = getProxy();
-    expect(first).toEqual({ ipaddress: '2.2.2.2', port: 8080, type: 5 });
-    expect(second).toEqual({ ipaddress: '3.3.3.3', port: 8080, type: 5 });
-    expect(third).toEqual({ ipaddress: '1.1.1.1', port: 8080, type: 5 });
+    const fourth = getProxy();
+    expect(first).toEqual({ ipaddress: '1.1.1.1', port: 8080, type: 5 });
+    expect(second).toEqual({ ipaddress: '2.2.2.2', port: 8080, type: 5 });
+    expect(third).toEqual({ ipaddress: '3.3.3.3', port: 8080, type: 5 });
+    expect(fourth).toEqual({ ipaddress: '1.1.1.1', port: 8080, type: 5 });
   });
 
   test('cycles proxies descending', () => {


### PR DESCRIPTION
## Summary
- ensure `getProxy` selects current entry before advancing index when ascending
- test ascending rotation starts with first proxy

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: SyntaxError: Unexpected token 'export' in test/jest.setup.ts)*
- `npm run test:e2e` *(fails: WebDriverError: session not created: user data directory is already in use)*

------
https://chatgpt.com/codex/tasks/task_e_689b5401d6b08325b8e689e838291591