### PR TITLE
fix: normalize domain before cache lookup

### DIFF
--- a/app/ts/common/lookup.ts
+++ b/app/ts/common/lookup.ts
@@ -40,18 +40,18 @@ export async function lookup(
   const { lookupConversion: conversion, lookupGeneral: general } = getSettings();
   let domainResults: string;
 
+  domain = conversion.enabled ? convertDomain(domain) : domain;
+  if (general.psl) {
+    const clean = psl.get(domain);
+    domain = clean ? clean.replace(/((\*\.)*)/g, '') : domain;
+  }
+
   const cached = await requestCache.get('whois', domain, cacheOpts);
   if (cached !== undefined) {
     return cached;
   }
 
   try {
-    domain = conversion.enabled ? convertDomain(domain) : domain;
-    if (general.psl) {
-      const clean = psl.get(domain);
-      domain = clean ? clean.replace(/((\*\.)*)/g, '') : domain;
-    }
-
     debug(`Looking up for ${domain}`);
     domainResults = await lookupPromise(domain, options);
   } catch (e) {

--- a/test/cacheOverride.test.ts
+++ b/test/cacheOverride.test.ts
@@ -59,4 +59,20 @@ describe('cache override', () => {
     expect(spy).toHaveBeenCalledTimes(2);
     spy.mockRestore();
   });
+
+  test('whois lookup on converted domain hits cache', async () => {
+    const prev = { ...settings.lookupConversion };
+    settings.lookupConversion.enabled = true;
+    settings.lookupConversion.algorithm = 'punycode';
+    const spy = jest.spyOn(whois, 'lookup').mockImplementation((...args: any[]) => {
+      const cb = args[args.length - 1] as Function;
+      cb(null, 'DATA');
+    });
+    await lookup('täst.de');
+    await lookup('xn--tst-qla.de');
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+    settings.lookupConversion.enabled = prev.enabled;
+    settings.lookupConversion.algorithm = prev.algorithm;
+  });
 });


### PR DESCRIPTION
## Summary
- normalize domain before accessing cache so retrieval and storage use same key
- add test verifying converted domain lookups hit cache

## Testing
- `npm run format`
- `npx tsc --noEmit`
- `npm run lint`
- `npm test` *(fails: Unexpected token 'export')*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_689b65de80288325a4a7a1cc15d5063a