### PR TITLE
fix: handle template load failures

### DIFF
--- a/app/ts/renderer/templateLoader.ts
+++ b/app/ts/renderer/templateLoader.ts
@@ -8,12 +8,20 @@ debug('loaded');
 export async function loadTemplate(
   selector: string,
   template: string,
-  context: any = {}
+  context: any = {},
+  fallback?: string
 ): Promise<void> {
-  const module = await import(`../../compiled-templates/${template.replace(/\.hbs$/, '.cjs')}`);
-  const precompiled = module.default || module;
-  const compiled = Handlebars.template(precompiled);
-  const html = compiled(context);
   const el = qs(selector);
-  if (el) el.innerHTML = html;
+  try {
+    const module = await import(`../../compiled-templates/${template.replace(/\.hbs$/, '.cjs')}`);
+    const precompiled = module.default || module;
+    const compiled = Handlebars.template(precompiled);
+    const html = compiled(context);
+    if (el) el.innerHTML = html;
+  } catch (error) {
+    debug('failed to load template', error);
+    if (fallback && el) {
+      el.innerHTML = fallback;
+    }
+  }
 }

--- a/test/templateLoader.test.ts
+++ b/test/templateLoader.test.ts
@@ -1,10 +1,16 @@
 /** @jest-environment jsdom */
 
+const debugMock = jest.fn();
+
 jest.mock('../app/vendor/handlebars.runtime.js', () => {
   const compiledFn = jest.fn((ctx: any) => `<span>${ctx.text}</span>`);
   const template = jest.fn(() => compiledFn);
   return { __esModule: true, default: { template } };
 });
+
+jest.mock('../app/ts/common/logger.js', () => ({
+  debugFactory: jest.fn(() => debugMock)
+}));
 
 jest.mock(
   '../app/compiled-templates/mock.cjs',
@@ -18,6 +24,10 @@ jest.mock(
 import { loadTemplate } from '../app/ts/renderer/templateLoader';
 const handlebars = require('../app/vendor/handlebars.runtime.js').default;
 
+beforeEach(() => {
+  debugMock.mockClear();
+});
+
 describe('loadTemplate', () => {
   test('dynamically loads template and inserts html', async () => {
     document.body.innerHTML = '<div id="target"></div>';
@@ -25,5 +35,13 @@ describe('loadTemplate', () => {
 
     expect(handlebars.template).toHaveBeenCalledWith({ name: 'mock' });
     expect(document.querySelector<HTMLElement>('#target')?.innerHTML).toBe('<span>hello</span>');
+  });
+
+  test('handles missing template gracefully', async () => {
+    document.body.innerHTML = '<div id="target"></div>';
+    await expect(loadTemplate('#target', 'missing.hbs', {}, 'fallback')).resolves.toBeUndefined();
+
+    expect(document.querySelector<HTMLElement>('#target')?.innerHTML).toBe('fallback');
+    expect(debugMock).toHaveBeenCalledWith('failed to load template', expect.any(Error));
   });
 });


### PR DESCRIPTION
## Summary
- prevent renderer template loader from crashing on missing templates
- test missing template case with fallback and debug logging

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm test` *(fails: Jest encountered an unexpected token in jest.setup.ts)*
- `npm run test:e2e` *(fails: WebDriverError: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_689b65f041708325801335f9231b9dc8