### PR TITLE
fix: restore proxy settings after CLI lookup

### DIFF
--- a/app/ts/cli.ts
+++ b/app/ts/cli.ts
@@ -94,7 +94,12 @@ export function parseArgs(argv: string[]): CliOptions {
 }
 
 export async function lookupDomains(opts: CliOptions): Promise<WhoisResult[]> {
+  let originalProxy: typeof settings.lookupProxy | undefined;
   if (opts.proxy) {
+    originalProxy = {
+      ...settings.lookupProxy,
+      list: settings.lookupProxy.list ? [...settings.lookupProxy.list] : undefined
+    };
     settings.lookupProxy.enable = true;
     settings.lookupProxy.mode = 'single';
     settings.lookupProxy.single = opts.proxy;
@@ -139,8 +144,9 @@ export async function lookupDomains(opts: CliOptions): Promise<WhoisResult[]> {
       }
     })
   );
-
-  return Promise.all(tasks);
+  const results = await Promise.all(tasks);
+  if (originalProxy) Object.assign(settings.lookupProxy, originalProxy);
+  return results;
 }
 
 export async function exportResults(results: WhoisResult[], opts: CliOptions): Promise<string> {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -9,6 +9,7 @@ import {
 } from '../app/ts/cli';
 import DomainStatus from '../app/ts/common/status';
 import { lookup as whoisLookup } from '../app/ts/common/lookup';
+import { settings } from '../app/ts/common/settings';
 
 jest.mock('../app/ts/common/lookup', () => ({ lookup: jest.fn() }));
 
@@ -136,6 +137,22 @@ describe('cli utility', () => {
     };
     await lookupDomains(opts);
     expect(maxActive).toBeLessThanOrEqual(2);
+  });
+
+  test('lookupDomains restores proxy settings after override', async () => {
+    mockLookup.mockResolvedValueOnce('data');
+    const original = {
+      ...settings.lookupProxy,
+      list: settings.lookupProxy.list ? [...settings.lookupProxy.list] : []
+    };
+    const opts: CliOptions = {
+      domains: ['example.com'],
+      tlds: ['com'],
+      format: 'txt',
+      proxy: 'http://proxy:8080'
+    };
+    await lookupDomains(opts);
+    expect(settings.lookupProxy).toEqual(original);
   });
 
   test('exportResults writes csv output', async () => {


### PR DESCRIPTION
## Summary
- preserve original proxy settings while running CLI lookups
- add regression test to ensure proxy settings remain unchanged

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: SyntaxError: Unexpected token 'export')*

------
https://chatgpt.com/codex/tasks/task_e_689b65eb8cd88325a5b6e629678f6513