### PR TITLE
fix: include filename in watch events

### DIFF
--- a/app/ts/main/fsIpc.ts
+++ b/app/ts/main/fsIpc.ts
@@ -41,8 +41,8 @@ ipcMain.handle('fs:exists', async (_e, p: string) => {
 ipcMain.handle('fs:watch', (e, prefix: string, p: string, opts?: fs.WatchOptions) => {
   const id = ++watcherId;
   const sender = e.sender;
-  const watcher = fs.watch(p, opts || {}, (event) => {
-    sender.send(`fs:watch:${prefix}:${id}`, event);
+  const watcher = fs.watch(p, opts || {}, (event, filename) => {
+    sender.send(`fs:watch:${prefix}:${id}`, { event, filename });
   });
   sender.once('destroyed', () => {
     watcher.close();

--- a/app/ts/preload.cts
+++ b/app/ts/preload.cts
@@ -39,11 +39,12 @@ const api = {
     prefix: string,
     p: string,
     opts: import('fs').WatchOptions,
-    cb: (evt: string) => void
+    cb: (evt: { event: string; filename: string | null }) => void
   ) => {
     const id = await ipcRenderer.invoke('fs:watch', prefix, p, opts);
     const chan = `fs:watch:${prefix}:${id}`;
-    const handler = (_e: IpcRendererEvent, ev: string) => cb(ev);
+    const handler = (_e: IpcRendererEvent, ev: { event: string; filename: string | null }) =>
+      cb(ev);
     ipcRenderer.on(chan, handler);
     return {
       close: () => {

--- a/app/ts/renderer/bulkwhois/fileinput.ts
+++ b/app/ts/renderer/bulkwhois/fileinput.ts
@@ -13,7 +13,7 @@ const electron = (window as any).electron as RendererElectronAPI & {
     prefix: string,
     p: string,
     opts: fs.WatchOptions,
-    cb: (evt: string) => void
+    cb: (evt: { event: string; filename: string | null }) => void
   ) => Promise<{ close: () => void }>;
   stat: (p: string) => Promise<any>;
   path: { basename: (p: string) => Promise<string> };
@@ -186,8 +186,8 @@ async function handleFileConfirmation(
     debug(bwFileStats.linecount);
 
     if (chosenPath) {
-      await watcher.watch('bw', chosenPath, { persistent: false }, (evt: string) => {
-        if (evt === 'change') void refreshBwFile(chosenPath);
+      await watcher.watch('bw', chosenPath, { persistent: false }, (evt) => {
+        if (evt.event === 'change') void refreshBwFile(chosenPath);
       });
     }
   }

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -12,7 +12,7 @@ const electron = (window as any).electron as RendererElectronAPI & {
     prefix: string,
     p: string,
     opts: fs.WatchOptions,
-    cb: (evt: string) => void
+    cb: (evt: { event: string; filename: string | null }) => void
   ) => Promise<{ close: () => void }>;
   stat: (p: string) => Promise<any>;
   path: { basename: (p: string) => Promise<string> };
@@ -145,8 +145,8 @@ async function handleFileConfirmation(
   updateFileInfoUI(bwaFileStats);
 
   if (chosenPath) {
-    await watcher.watch('bwa', chosenPath, { persistent: false }, (evt: string) => {
-      if (evt === 'change') void refreshBwaFile(chosenPath);
+    await watcher.watch('bwa', chosenPath, { persistent: false }, (evt) => {
+      if (evt.event === 'change') void refreshBwaFile(chosenPath);
     });
   }
 

--- a/app/ts/renderer/settings.ts
+++ b/app/ts/renderer/settings.ts
@@ -15,7 +15,7 @@ const electron = (window as any).electron as RendererElectronAPI & {
   watch: (
     p: string,
     opts: fs.WatchOptions,
-    cb: (evt: string) => void
+    cb: (evt: { event: string; filename: string | null }) => void
   ) => Promise<{ close: () => void }>;
   path: { join: (...args: string[]) => Promise<string>; basename: (p: string) => Promise<string> };
   send: (channel: string, ...args: any[]) => void;

--- a/app/ts/utils/fileWatcher.ts
+++ b/app/ts/utils/fileWatcher.ts
@@ -1,10 +1,15 @@
 import type * as fs from 'fs';
 
+export interface WatchEvent {
+  event: string;
+  filename: string | null;
+}
+
 export type WatchFn = (
   prefix: string,
   path: string,
   opts: fs.WatchOptions,
-  cb: (evt: string) => void
+  cb: (evt: WatchEvent) => void
 ) => Promise<{ close: () => void }>;
 
 export class FileWatcherManager {
@@ -15,7 +20,7 @@ export class FileWatcherManager {
     prefix: string,
     path: string,
     opts: fs.WatchOptions,
-    cb: (evt: string) => void
+    cb: (evt: WatchEvent) => void
   ): Promise<void> {
     this.close();
     this.watcher = await this.watchFn(prefix, path, opts, cb);

--- a/test/electronMock.ts
+++ b/test/electronMock.ts
@@ -38,8 +38,12 @@ if (!(global as any).window) {
   unlink: (p: string) => fs.promises.unlink(p),
   access: (p: string, mode?: number) => fs.promises.access(p, mode),
   exists: async (p: string) => fs.existsSync(p),
-  watch: async (p: string, opts: fs.WatchOptions, cb: (ev: string) => void) => {
-    const watcher = fs.watch(p, opts, cb);
+  watch: async (
+    p: string,
+    opts: fs.WatchOptions,
+    cb: (ev: { event: string; filename: string | null }) => void
+  ) => {
+    const watcher = fs.watch(p, opts, (event, filename) => cb({ event, filename }));
     return { close: () => watcher.close() };
   },
   path: {

--- a/test/fileWatcherManager.test.ts
+++ b/test/fileWatcherManager.test.ts
@@ -1,9 +1,9 @@
-import { FileWatcherManager } from '../app/ts/utils/fileWatcher';
+import { FileWatcherManager, type WatchFn } from '../app/ts/utils/fileWatcher';
 
 test('replaces existing watcher', async () => {
   const closeFirst = jest.fn();
   const closeSecond = jest.fn();
-  const watchFn = jest
+  const watchFn: WatchFn = jest
     .fn()
     .mockResolvedValueOnce({ close: closeFirst })
     .mockResolvedValueOnce({ close: closeSecond });


### PR DESCRIPTION
## Summary
- include filename in `fs:watch` IPC events
- expose `{event, filename}` payload through preload API and file watchers
- adjust renderer watchers and tests for new payload

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` (fails: SyntaxError in jest.setup.ts)
- `npm run test:e2e` (fails: WebDriverError session not created)


------
https://chatgpt.com/codex/tasks/task_e_689bb477f3c883258b9869c6500f2e6a