### PR TITLE
fix: handle invalid DNS cache entries

### DIFF
--- a/app/ts/common/dnsLookup.ts
+++ b/app/ts/common/dnsLookup.ts
@@ -36,7 +36,12 @@ export async function nsLookup(host: string, cacheOpts: CacheOptions = {}): Prom
 
   const cached = await requestCache.get('dns', host, cacheOpts);
   if (cached !== undefined) {
-    return JSON.parse(cached) as string[];
+    try {
+      return JSON.parse(cached) as string[];
+    } catch (e) {
+      debug(`Failed to parse cached DNS response for ${host}: ${e}`);
+      await requestCache.delete('dns', host, cacheOpts);
+    }
   }
 
   try {

--- a/app/ts/common/requestCache.ts
+++ b/app/ts/common/requestCache.ts
@@ -88,6 +88,21 @@ export class RequestCache {
     }
   }
 
+  async delete(type: string, domain: string, cacheOpts: CacheOptions = {}): Promise<void> {
+    const { requestCache } = settings;
+    const enabled = cacheOpts.enabled ?? requestCache.enabled;
+    if (!enabled) return;
+    const database = await this.init();
+    if (!database) return;
+    const key = this.makeKey(type, domain);
+    try {
+      database.prepare('DELETE FROM cache WHERE key = ?').run(key);
+      debug(`Deleted cache entry for ${key}`);
+    } catch (e) {
+      debug(`Cache delete failed: ${e}`);
+    }
+  }
+
   async purgeExpired(): Promise<number> {
     const { requestCache } = settings;
     if (!requestCache.enabled) return 0;

--- a/test/dnsLookup.test.ts
+++ b/test/dnsLookup.test.ts
@@ -1,9 +1,13 @@
 import '../test/electronMock';
 
 import dns from 'dns/promises';
+import fs from 'fs';
+import path from 'path';
 import { nsLookup, hasNsServers, isDomainAvailable } from '../app/ts/common/dnsLookup';
 import DomainStatus from '../app/ts/common/status';
 import { DnsLookupError } from '../app/ts/common/errors';
+import { RequestCache } from '../app/ts/common/requestCache';
+import { settings, getUserDataPath } from '../app/ts/renderer/settings-renderer';
 
 describe('dnsLookup', () => {
   let resolveMock: jest.SpyInstance;
@@ -54,5 +58,24 @@ describe('dnsLookup', () => {
   test("isDomainAvailable returns 'error' on error result", () => {
     const error = new DnsLookupError('fail');
     expect(isDomainAvailable({ ok: false, error })).toBe(DomainStatus.Error);
+  });
+
+  test('nsLookup deletes invalid cache and performs fresh lookup', async () => {
+    const dbFile = 'dns-cache.sqlite';
+    settings.requestCache.enabled = true;
+    settings.requestCache.database = dbFile;
+    const cache = new RequestCache();
+    await cache.set('dns', 'bad.com', 'not-json');
+    const servers = ['ns.bad.com'];
+    const spy = jest.spyOn(dns, 'resolve').mockResolvedValueOnce(servers);
+    const result = await nsLookup('bad.com');
+    expect(result).toEqual(servers);
+    expect(spy).toHaveBeenCalledTimes(1);
+    const cached = await cache.get('dns', 'bad.com');
+    expect(cached).toBe(JSON.stringify(servers));
+    spy.mockRestore();
+    const dbPath = path.resolve(getUserDataPath(), dbFile);
+    if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+    settings.requestCache.enabled = false;
   });
 });


### PR DESCRIPTION
## Summary
- guard DNS cache reads with try/catch and drop corrupt entries
- add RequestCache.delete utility and debug logging
- test DNS cache recovery on invalid JSON

## Testing
- `npm run format`
- `npx tsc --noEmit`
- `npm run lint`
- `npm test` *(fails: Jest failed to parse test setup)*
- `npm run test:e2e` *(fails: WebDriverError session not created)*

------
https://chatgpt.com/codex/tasks/task_e_689bb47e580483258c58ada444a3f49c