### PR TITLE
fix(train-ai): read default list files from sample directory

### DIFF
--- a/scripts/train-ai.ts
+++ b/scripts/train-ai.ts
@@ -87,17 +87,19 @@ async function trainDomains(domains: string[]): Promise<Model> {
   return trainFromSamples(samples);
 }
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   const { values } = parseArgs({
     options: { lists: { type: 'string', multiple: true } }
   });
   let files: string[] = values.lists as string[];
-  if (!files || files.length === 0) {
+  const useDefaults = !files || files.length === 0;
+  if (useDefaults) {
     files = fs.readdirSync('sample_lists').filter((f) => f.endsWith('.list'));
   }
   const domains: string[] = [];
   for (const f of files) {
-    const lines = fs.readFileSync(f, 'utf8').split(/\r?\n/).filter(Boolean);
+    const listPath = useDefaults ? path.join('sample_lists', f) : f;
+    const lines = fs.readFileSync(listPath, 'utf8').split(/\r?\n/).filter(Boolean);
     domains.push(...lines);
   }
   const model = await trainDomains(domains);

--- a/test/trainAi.test.ts
+++ b/test/trainAi.test.ts
@@ -1,3 +1,6 @@
+import fs from 'fs';
+import path from 'path';
+import { jest } from '@jest/globals';
 import { trainFromSamples, predict } from '../scripts/train-ai';
 import DomainStatus from '../app/ts/common/status';
 
@@ -10,5 +13,27 @@ describe('train-ai', () => {
     const model = trainFromSamples(samples);
     expect(predict(model, 'Domain Status:ok')).toBe(DomainStatus.Unavailable);
     expect(predict(model, 'No match for domain test')).toBe(DomainStatus.Available);
+  });
+
+  test('runs with default lists when none supplied', async () => {
+    jest.resetModules();
+    const lookupMock = jest.fn(async () => 'No match for domain example.com');
+    jest.doMock('../app/ts/common/lookup.js', () => ({ __esModule: true, lookup: lookupMock }));
+    jest.doMock('../app/ts/common/parser.js', () => ({ __esModule: true, toJSON: () => ({}) }));
+    jest.doMock('../app/ts/common/availability.js', () => ({
+      __esModule: true,
+      isDomainAvailable: () => 'available'
+    }));
+    const readdirSpy = jest.spyOn(fs, 'readdirSync').mockReturnValue(['foo.list'] as any);
+    const readFileSpy = jest.spyOn(fs, 'readFileSync').mockReturnValue('example.com');
+    const mkdirSpy = jest.spyOn(fs.promises, 'mkdir').mockResolvedValue(undefined as any);
+    const writeFileSpy = jest.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined as any);
+    const { main } = await import('../scripts/train-ai');
+    await expect(main()).resolves.toBeUndefined();
+    expect(readFileSpy).toHaveBeenCalledWith(path.join('sample_lists', 'foo.list'), 'utf8');
+    readdirSpy.mockRestore();
+    readFileSpy.mockRestore();
+    mkdirSpy.mockRestore();
+    writeFileSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- ensure `train-ai` reads sample list files from `sample_lists` when `--lists` not provided
- add unit test covering default training path

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: SyntaxError: Unexpected token 'export' in test/jest.setup.ts)*
- `npm run test:e2e` *(fails: WebDriverError: session not created: user data directory is already in use)*

------
https://chatgpt.com/codex/tasks/task_e_689bb46e056083259ae8e9487b6ff19c