### PR TITLE
feat: add automatic request cache purging

### DIFF
--- a/app/ts/appsettings.ts
+++ b/app/ts/appsettings.ts
@@ -133,7 +133,8 @@ const appSettings = {
       // Request caching configuration
       enabled: false, // Enable request caching (default: false)
       database: 'request-cache.sqlite', // Cache database filename
-      ttl: 3600 // Cache entry time to live in seconds
+      ttl: 3600, // Cache entry time to live in seconds
+      purgeInterval: 60000 // Cache purge interval in milliseconds
     },
     customConfiguration: {
       // Application custom configurations
@@ -262,6 +263,7 @@ export const appSettingsDescriptions: Record<string, string> = {
   'requestCache.enabled': 'Enable request caching',
   'requestCache.database': 'Cache database filename',
   'requestCache.ttl': 'Cache entry time to live (seconds)',
+  'requestCache.purgeInterval': 'Cache purge interval (milliseconds)',
   'customConfiguration.filepath': 'Custom configuration filename',
   'customConfiguration.load': 'Load custom configuration on start',
   'customConfiguration.save': 'Save custom configuration on exit',

--- a/app/ts/cli.ts
+++ b/app/ts/cli.ts
@@ -19,6 +19,17 @@ import { suggestWords } from './ai/openaiSuggest.js';
 import { readLines } from './common/wordlist.js';
 
 const requestCache = new RequestCache();
+requestCache.startAutoPurge(settings.requestCache.purgeInterval);
+const cleanup = (): void => requestCache.close();
+process.on('exit', cleanup);
+process.on('SIGINT', () => {
+  cleanup();
+  process.exit(0);
+});
+process.on('SIGTERM', () => {
+  cleanup();
+  process.exit(0);
+});
 
 const debug = debugFactory('cli');
 const error = errorFactory('cli');

--- a/app/ts/common/settings-base.ts
+++ b/app/ts/common/settings-base.ts
@@ -95,6 +95,7 @@ export interface Settings {
     enabled: boolean;
     database: string;
     ttl: number;
+    purgeInterval: number;
   };
   customConfiguration: { filepath: string; load: boolean; save: boolean };
   theme: { darkMode: boolean; followSystem: boolean };

--- a/app/ts/main/index.ts
+++ b/app/ts/main/index.ts
@@ -7,3 +7,9 @@ import './ai.js';
 import './history.js';
 import './settings.js';
 import './i18n.js';
+import { RequestCache } from '../common/requestCache.js';
+import { settings } from '../common/settings.js';
+
+const requestCache = new RequestCache();
+requestCache.startAutoPurge(settings.requestCache.purgeInterval);
+process.on('exit', () => requestCache.close());


### PR DESCRIPTION
## Summary
- add startAutoPurge to request cache and clean up timer on close
- initialize cache purging timer in main process and CLI
- allow configuring purge interval through requestCache settings

## Testing
- `npm run format`
- `npx tsc --noEmit`
- `npm run lint`
- `npm test` (fails: SyntaxError: Unexpected token 'export')
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_68a74f3c98ec8325883c048da95a4c6c