### PR TITLE
feat: enhance proxy authentication settings

### DIFF
--- a/app/ts/appsettings.ts
+++ b/app/ts/appsettings.ts
@@ -91,6 +91,8 @@ const appSettings = {
       mode: 'single', // Proxy request mode, 'single' - fixed single proxy, 'multi' - multiple proxies (default: 'single')
       single: '', // Single proxy address host:port (may include user:pass@)
       list: [], // Proxy list for multi mode (strings or {proxy, username, password})
+      username: '', // Default proxy username
+      password: '', // Default proxy password
       retries: 3, // Number of failures allowed before skipping a proxy
       /*
       multimode
@@ -249,6 +251,8 @@ export const appSettingsDescriptions: Record<string, string> = {
   'lookupProxy.mode': 'Proxy mode',
   'lookupProxy.single': 'Single proxy address (supports user:pass@host:port or object)',
   'lookupProxy.list': 'Proxy list (supports user:pass@host:port or {proxy, username, password})',
+  'lookupProxy.username': 'Default proxy username',
+  'lookupProxy.password': 'Default proxy password',
   'lookupProxy.retries': 'Allowed failures per proxy',
   'lookupProxy.multimode': 'Proxy rotation mode',
   'lookupProxy.check': 'Check proxy health',

--- a/app/ts/common/proxy.ts
+++ b/app/ts/common/proxy.ts
@@ -22,17 +22,21 @@ interface ProxySettingsEntry {
   password?: string;
 }
 
-function parseEntry(entry: string | ProxySettingsEntry): ProxyInfo | undefined {
-  let authUser: string | undefined;
-  let authPass: string | undefined;
+function parseEntry(
+  entry: string | ProxySettingsEntry,
+  defUser?: string,
+  defPass?: string
+): ProxyInfo | undefined {
+  let authUser: string | undefined = defUser;
+  let authPass: string | undefined = defPass;
   let hostPort: string;
 
   if (typeof entry === 'string') {
     hostPort = entry;
   } else {
     hostPort = entry.proxy;
-    authUser = entry.username;
-    authPass = entry.password;
+    authUser = entry.username ?? authUser;
+    authPass = entry.password ?? authPass;
   }
 
   if (hostPort.includes('@')) {
@@ -110,7 +114,7 @@ export function getProxy(): ProxyInfo | undefined {
         break;
     }
 
-    const info = parseEntry(entry);
+    const info = parseEntry(entry, proxy.username, proxy.password);
     if (!info) {
       continue;
     }

--- a/app/ts/common/settings-base.ts
+++ b/app/ts/common/settings-base.ts
@@ -82,6 +82,8 @@ export interface Settings {
     checktype: 'ping' | 'request' | 'ping+request';
     single?: string | ProxyEntry;
     list?: (string | ProxyEntry)[];
+    username?: string;
+    password?: string;
     retries: number;
   };
   lookupAssumptions: {

--- a/readme.md
+++ b/readme.md
@@ -181,6 +181,7 @@ node dist/app/ts/cli.js --domain example.com --proxy user:pass@127.0.0.1:9050
 
 Proxies that fail repeatedly are skipped once they exceed the `lookupProxy.retries` threshold (default: 3).
 Each proxy can provide its own credentials via `user:pass@host:port` or configuration objects like `{ proxy: 'host:port', username: 'user', password: 'pass' }`.
+Default credentials may also be supplied through `lookupProxy.username` and `lookupProxy.password` settings.
 
 # adjust concurrency
 node dist/app/ts/cli.js --wordlist words.txt --limit 10

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -10,6 +10,8 @@ describe('proxy helper', () => {
     settings.lookupProxy.multimode = 'sequential';
     settings.lookupProxy.single = '';
     settings.lookupProxy.list = [];
+    settings.lookupProxy.username = '';
+    settings.lookupProxy.password = '';
     settings.lookupProxy.retries = 3;
   });
 
@@ -109,6 +111,20 @@ describe('proxy helper', () => {
     settings.lookupProxy.enable = true;
     settings.lookupProxy.mode = 'multi';
     settings.lookupProxy.list = [{ proxy: '1.2.3.4:1080', username: 'user', password: 'pass' }];
+    const proxy = getProxy();
+    expect(proxy).toEqual({
+      ipaddress: '1.2.3.4',
+      port: 1080,
+      auth: { username: 'user', password: 'pass' }
+    });
+  });
+
+  test('uses global credentials', () => {
+    settings.lookupProxy.enable = true;
+    settings.lookupProxy.mode = 'single';
+    settings.lookupProxy.username = 'user';
+    settings.lookupProxy.password = 'pass';
+    settings.lookupProxy.single = '1.2.3.4:1080';
     const proxy = getProxy();
     expect(proxy).toEqual({
       ipaddress: '1.2.3.4',


### PR DESCRIPTION
## Summary
- add optional username and password to `lookupProxy` settings
- support auth parsing and retry skipping per proxy
- document proxy authentication defaults in settings and README

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Unexpected token 'export')*
- `npm run test:e2e` *(fails: session not created: user data directory already in use)*

------
https://chatgpt.com/codex/tasks/task_e_68a75028d0d48325a5a86e1e4a8649d8