### PR TITLE
refactor: use npm modules for parser utilities

### DIFF
--- a/app/ts/common/parser.ts
+++ b/app/ts/common/parser.ts
@@ -1,5 +1,5 @@
-import * as changeCase from '../../vendor/change-case.js';
-import { decode } from '../../vendor/html-entities/index.js';
+import { camelCase } from 'change-case';
+import { decode } from 'html-entities';
 
 export function preStringStrip(str: string): string {
   return str.toString().replace(/\:\t{1,2}/g, ': ');
@@ -28,7 +28,7 @@ export function parseRawData(rawData: string): Record<string, string> {
     if (line && line.includes(DELIMITER + ' ')) {
       const lineParts = line.split(DELIMITER);
       if (lineParts.length >= 2) {
-        const key = changeCase.camelCase(lineParts[0]);
+        const key = camelCase(lineParts[0]);
         const value = lineParts.splice(1).join(DELIMITER).trim();
         if (key in result) {
           result[key] += ` ${value}`;

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,7 +19,7 @@ export default {
     '^#cli/(.*)\\.js$': '<rootDir>/app/ts/cli/$1.ts',
     '^#server/(.*)\\.js$': '<rootDir>/app/ts/server/$1.ts'
   },
-  setupFiles: ['<rootDir>/test/jest.setup.ts'],
+  setupFilesAfterEnv: ['<rootDir>/test/jest.setup.ts'],
   collectCoverage: true,
   coverageDirectory: 'coverage'
 };

--- a/scripts/regenerateVendor.js
+++ b/scripts/regenerateVendor.js
@@ -48,23 +48,4 @@ writeFile(
   'const fontawesome: any;\nexport default fontawesome;\n'
 );
 
-copyFile(
-  path.join(modulesDir, 'change-case', 'dist', 'index.js'),
-  path.join(vendorDir, 'change-case.js')
-);
-writeFile(path.join(vendorDir, 'change-case.d.ts'), "export * from 'change-case';\n");
-
-const htmlSrcDir = path.join(modulesDir, 'html-entities', 'dist', 'esm');
-const htmlDestDir = path.join(vendorDir, 'html-entities');
-fs.mkdirSync(htmlDestDir, { recursive: true });
-for (const file of [
-  'index.js',
-  'index.d.ts',
-  'named-references.js',
-  'numeric-unicode-map.js',
-  'surrogate-pairs.js'
-]) {
-  copyFile(path.join(htmlSrcDir, file), path.join(htmlDestDir, file));
-}
-
 console.log('Vendor scripts regenerated.');

--- a/scripts/regenerateVendor.mjs
+++ b/scripts/regenerateVendor.mjs
@@ -66,12 +66,6 @@ export function regenerateVendor() {
   );
 
   copyFile(
-    path.join(modulesDir, 'change-case', 'dist', 'index.js'),
-    path.join(vendorDir, 'change-case.js')
-  );
-  writeFile(path.join(vendorDir, 'change-case.d.ts'), "export * from 'change-case';\n");
-
-  copyFile(
     path.join(modulesDir, 'datatables.net', 'js', 'dataTables.js'),
     path.join(vendorDir, 'datatables.js')
   );
@@ -120,19 +114,6 @@ debug.enabled = enabled;
       'export const disable: () => void;\n' +
       'export const enabled: (ns: string) => boolean;\n'
   );
-  const htmlSrcDir = path.join(modulesDir, 'html-entities', 'dist', 'esm');
-  const htmlDestDir = path.join(vendorDir, 'html-entities');
-  fs.mkdirSync(htmlDestDir, { recursive: true });
-  for (const file of [
-    'index.js',
-    'index.d.ts',
-    'named-references.js',
-    'numeric-unicode-map.js',
-    'surrogate-pairs.js'
-  ]) {
-    copyFile(path.join(htmlSrcDir, file), path.join(htmlDestDir, file));
-  }
-
   console.log('Vendor scripts regenerated.');
 }
 

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -1,4 +1,4 @@
-jest.mock('../app/vendor/change-case.js', () => ({
+jest.mock('change-case', () => ({
   camelCase: (input: string) => {
     const parts = input.replace(/^[^a-zA-Z0-9]+/, '').split(/[^a-zA-Z0-9]+/);
     return parts
@@ -7,6 +7,6 @@ jest.mock('../app/vendor/change-case.js', () => ({
   }
 }));
 
-jest.mock('../app/vendor/html-entities/index.js', () => ({
+jest.mock('html-entities', () => ({
   decode: (input: string) => input
 }));

--- a/test/regenerateVendor.test.ts
+++ b/test/regenerateVendor.test.ts
@@ -38,14 +38,6 @@ describe('regenerateVendor', () => {
       path.join(rootDir, 'node_modules', '@fortawesome', 'fontawesome-free', 'js', 'all.js'),
       path.join(rootDir, 'app', 'vendor', 'fontawesome.js')
     );
-    expect(copyFileMock).toHaveBeenCalledWith(
-      path.join(rootDir, 'node_modules', 'change-case', 'dist', 'index.js'),
-      path.join(rootDir, 'app', 'vendor', 'change-case.js')
-    );
-    expect(copyFileMock).toHaveBeenCalledWith(
-      path.join(rootDir, 'node_modules', 'html-entities', 'dist', 'esm', 'index.js'),
-      path.join(rootDir, 'app', 'vendor', 'html-entities', 'index.js')
-    );
     expect(writeFileMock).toHaveBeenCalledWith(
       path.join(rootDir, 'app', 'vendor', 'handlebars.runtime.d.ts'),
       expect.any(String)

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -155,14 +155,6 @@ declare module 'app/ts/common/resetObject' {
   export { resetObj as resetObject };
 }
 
-declare module 'change-case' {
-  export function camelCase(input: string): string;
-}
-
-declare module 'html-entities' {
-  export function decode(input: string): string;
-}
-
 declare const $: any;
 declare const settings: any;
 

--- a/types/vendor.d.ts
+++ b/types/vendor.d.ts
@@ -2,14 +2,6 @@ declare module '*vendor/handlebars.runtime.js' {
   import Handlebars from 'handlebars';
   export default Handlebars;
 }
-declare module '*vendor/change-case.js' {
-  export * from 'change-case';
-}
-
-declare module '*vendor/html-entities/index.js' {
-  export * from 'html-entities';
-}
-
 declare module '*vendor/datatables.js' {
   const d: any;
   export default d;


### PR DESCRIPTION
## Summary
- use change-case and html-entities packages instead of vendored copies
- drop obsolete vendor copy steps and update tests

## Testing
- `npm test` *(fails: Unexpected token 'export' in jest.setup.ts)*
- `npm run test:e2e` *(fails: session not created for WebDriver)*

------
https://chatgpt.com/codex/tasks/task_e_68a74f448a748325b246ef5ec1e7e043