### PR TITLE
feat: add json export to cli

### DIFF
--- a/app/ts/cli.ts
+++ b/app/ts/cli.ts
@@ -41,7 +41,7 @@ export interface CliOptions {
   wordlist?: string;
   tlds: string[];
   proxy?: string;
-  format: 'csv' | 'txt' | 'zip';
+  format: 'csv' | 'txt' | 'zip' | 'json';
   out?: string;
   purgeCache?: boolean;
   clearCache?: boolean;
@@ -58,7 +58,11 @@ export function parseArgs(argv: string[]): CliOptions {
     .option('wordlist', { type: 'string' })
     .option('tlds', { type: 'string', array: true, default: ['com'] })
     .option('proxy', { type: 'string' })
-    .option('format', { choices: ['csv', 'txt', 'zip'] as const, default: 'txt' })
+    .option('format', {
+      choices: ['csv', 'txt', 'zip', 'json'] as const,
+      default: 'txt',
+      describe: 'Output format (csv, txt, zip, or json)'
+    })
     .option('out', { type: 'string' })
     .option('purge-cache', { type: 'boolean' })
     .option('clear-cache', { type: 'boolean' })
@@ -94,7 +98,7 @@ export function parseArgs(argv: string[]): CliOptions {
     wordlist: args.wordlist,
     tlds: args.tlds as string[],
     proxy: args.proxy,
-    format: args.format as 'csv' | 'txt' | 'zip',
+    format: args.format as 'csv' | 'txt' | 'zip' | 'json',
     out: args.out,
     purgeCache: args['purge-cache'],
     clearCache: args['clear-cache'],
@@ -198,6 +202,11 @@ export async function exportResults(results: WhoisResult[], opts: CliOptions): P
       }
       const data = await zip.generateAsync({ type: 'uint8array' });
       await fs.promises.writeFile(file, data);
+      return file;
+    }
+    case 'json': {
+      const content = JSON.stringify(results, null, 2);
+      await fs.promises.writeFile(file, content);
       return file;
     }
     default: {

--- a/readme.md
+++ b/readme.md
@@ -160,7 +160,7 @@ Whoisdigger provides sample wordlists as example for testing purposes inside `sa
 
 When choosing export options, you can decide what domain status to export, if you want errors included, only basic domain information such as creation, expiration and update dates.
 
-Exporting as text will only export raw replies for each domain in a zip file, as a csv you're able to see both both basic information and whois replies (in text, inline csv or separate csv inside a zip file).
+Exporting as text will only export raw replies for each domain in a zip file; as a csv you're able to see both basic information and whois replies (in text, inline csv or separate csv inside a zip file); and as json the structured results array is written to a single file.
 
 ### CLI usage
 
@@ -172,6 +172,9 @@ node dist/app/ts/cli.js --domain example.com
 
 # bulk search using a wordlist
 node dist/app/ts/cli.js --wordlist words.txt --tlds com net --format csv --out results.csv
+
+# output JSON results
+node dist/app/ts/cli.js --wordlist words.txt --tlds com net --format json --out results.json
 
 # using a proxy
 node dist/app/ts/cli.js --domain example.com --proxy 127.0.0.1:9050

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -22,6 +22,11 @@ describe('cli utility', () => {
     expect(opts.format).toBe('csv');
   });
 
+  test('parseArgs accepts json format', () => {
+    const opts = parseArgs(['--domain', 'example.com', '--format', 'json']);
+    expect(opts.format).toBe('json');
+  });
+
   test('parseArgs recognizes cache flags', () => {
     const opts = parseArgs(['--purge-cache', '--clear-cache']);
     expect(opts.purgeCache).toBe(true);
@@ -193,6 +198,31 @@ describe('cli utility', () => {
     );
     const content = await fs.promises.readFile(file, 'utf8');
     expect(content).toContain('example.com');
+    fs.unlinkSync(file);
+  });
+
+  test('exportResults writes json output', async () => {
+    const file = path.join(__dirname, 'out.json');
+    const opts: CliOptions = { domains: [], tlds: ['com'], format: 'json', out: file };
+    await exportResults(
+      [
+        {
+          domain: 'example.com',
+          status: 'available',
+          registrar: 'reg',
+          company: 'comp',
+          creationDate: 'c',
+          updateDate: 'u',
+          expiryDate: 'e',
+          whoisreply: 'r',
+          whoisJson: {}
+        }
+      ],
+      opts
+    );
+    const content = await fs.promises.readFile(file, 'utf8');
+    const data = JSON.parse(content);
+    expect(data[0].domain).toBe('example.com');
     fs.unlinkSync(file);
   });
 


### PR DESCRIPTION
## Summary
- support `--format json` in CLI args and options
- serialize lookup results to JSON when format is `json`
- document JSON output in README and CLI help

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: SyntaxError: Unexpected token 'export')*
- `npm run test:e2e` *(fails: WebDriverError: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68a756848e5c8325b47693e5c4472c74