### PR TITLE
fix: use DOM-based HTML entity decoding

### DIFF
--- a/app/ts/common/parser.ts
+++ b/app/ts/common/parser.ts
@@ -1,4 +1,4 @@
-import { decode } from 'html-entities';
+let decodeHtml: (input: string) => string;
 
 function camelCase(input: string): string {
   const parts = input.replace(/^[^a-zA-Z0-9]+/, '').split(/[^a-zA-Z0-9]+/);
@@ -13,7 +13,18 @@ export function preStringStrip(str: string): string {
 }
 
 function stripHTMLEntities(rawData: string): string {
-  return decode(rawData);
+  if (!decodeHtml) {
+    if (typeof window === 'undefined') {
+      decodeHtml = (eval('require')('html-entities') as { decode: (s: string) => string }).decode;
+    } else {
+      const textarea = document.createElement('textarea');
+      decodeHtml = (input: string): string => {
+        textarea.innerHTML = input;
+        return textarea.value;
+      };
+    }
+  }
+  return decodeHtml(rawData);
 }
 
 function filterColonChar(rawData: string): string {


### PR DESCRIPTION
## Summary
- avoid top-level `html-entities` import by lazily loading it in Node and using a DOM-based fallback in browsers

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit` (fails: Cannot find module 'zod')
- `npm test` (fails: Jest encountered an unexpected token)
- `npm run test:e2e` (fails: session not created: probably user data directory is already in use)


------
https://chatgpt.com/codex/tasks/task_e_68a79e0586a88325aef2de498b370b34