### PR TITLE
fix: require zod in renderer settings

### DIFF
--- a/app/ts/common/settings-base.ts
+++ b/app/ts/common/settings-base.ts
@@ -112,7 +112,9 @@ export interface Settings {
   [key: string]: any;
 }
 
-import { z } from 'zod';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { z } = require('zod') as typeof import('zod');
 import { debugFactory } from './logger.js';
 import appDefaults from '../appsettings.js';
 

--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -14,7 +14,9 @@ import {
   validateSettings,
   type Settings
 } from './settings-base.js';
-import { ZodError } from 'zod';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { ZodError } = require('zod') as typeof import('zod');
 
 const debug = debugFactory('common.settings');
 


### PR DESCRIPTION
## Summary
- use `createRequire` in settings modules so `zod` resolves in the renderer

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run test:e2e` *(fails: WebDriverError: session not created: probably user data directory is already in use)*

------
https://chatgpt.com/codex/tasks/task_e_68a843a3deb08325a2d51edaec9e9f3b