### PR TITLE
fix: reference node module with node prefix

### DIFF
--- a/app/ts/common/settings-base.ts
+++ b/app/ts/common/settings-base.ts
@@ -112,7 +112,7 @@ export interface Settings {
   [key: string]: any;
 }
 
-import { createRequire } from 'module';
+import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const { z } = require('zod') as typeof import('zod');
 import { debugFactory } from './logger.js';

--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -14,7 +14,7 @@ import {
   validateSettings,
   type Settings
 } from './settings-base.js';
-import { createRequire } from 'module';
+import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const { ZodError } = require('zod') as typeof import('zod');
 

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { spawnSync } from 'child_process';
-import { createRequire } from 'module';
+import { createRequire } from 'node:module';
 import { debugFactory } from './logger.js';
 import { precompileTemplates } from './precompileTemplates.js';
 import { dirnameCompat } from './dirnameCompat.js';


### PR DESCRIPTION
## Summary
- ensure Node builtins use `node:` prefix for renderer compat

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run test:e2e` *(fails: session not created; user data dir in use)*

------
https://chatgpt.com/codex/tasks/task_e_68a8460fe86c8325af7e812e0c6f22ae