### PR TITLE
fix: allow node scheme scripts

### DIFF
--- a/app/html/templates/mainPanel.hbs
+++ b/app/html/templates/mainPanel.hbs
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline' 'node:'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;"
     />
 
     <title>whoisdigger</title>


### PR DESCRIPTION
## Summary
- allow Node built-in modules to load by adding the `node:` scheme to CSP

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Jest encountered unexpected token due to ESM imports)*
- `npm run test:e2e` *(fails: WebDriverError: session not created, user data dir in use)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a016ac688325af9858b7fbd47c08