### PR TITLE
fix: avoid node module imports in renderer

### DIFF
--- a/app/ts/common/settings-base.ts
+++ b/app/ts/common/settings-base.ts
@@ -112,9 +112,7 @@ export interface Settings {
   [key: string]: any;
 }
 
-import { createRequire } from 'node:module';
-const require = createRequire(import.meta.url);
-const { z } = require('zod') as typeof import('zod');
+import { z } from 'zod';
 import { debugFactory } from './logger.js';
 import appDefaults from '../appsettings.js';
 

--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -14,9 +14,7 @@ import {
   validateSettings,
   type Settings
 } from './settings-base.js';
-import { createRequire } from 'node:module';
-const require = createRequire(import.meta.url);
-const { ZodError } = require('zod') as typeof import('zod');
+import { ZodError } from 'zod';
 
 const debug = debugFactory('common.settings');
 


### PR DESCRIPTION
## Summary
- replace `createRequire` with direct `zod` imports to keep renderer bundles free of `node:` protocols

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run test:e2e` *(fails: session not created: probably user data directory is already in use)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a016ac688325af9858b7fbd47c08