### PR TITLE
fix: guard exit confirmation when window destroyed

### DIFF
--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -165,7 +165,9 @@ app.on('ready', async function () {
     const { ui } = settings;
     if (ui.confirmExit && !exitConfirmed) {
       event.preventDefault();
-      mainWindow.webContents.send('app:confirm-exit');
+      if (!mainWindow.webContents.isDestroyed()) {
+        mainWindow.webContents.send('app:confirm-exit');
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- prevent sending IPC when main window is disposed during close

## Testing
- `npm run lint`
- `npm run format`
- `npx tsc --noEmit`
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run test:e2e` *(fails: user data directory already in use)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bb954f4083258b564f9a26aa6d19