### PR TITLE
fix: avoid caching failed WHOIS lookups

### DIFF
--- a/app/ts/common/lookup.ts
+++ b/app/ts/common/lookup.ts
@@ -51,14 +51,20 @@ export async function lookup(
     return cached;
   }
 
+  let hadError = false;
+
   try {
     debug(`Looking up for ${domain}`);
     domainResults = await lookupPromise(domain, options);
   } catch (e) {
+    hadError = true;
+    debug(`Whois lookup error for ${domain}: ${e}`);
     domainResults = `Whois lookup error, ${e}`;
   }
 
-  await requestCache.set('whois', domain, domainResults, cacheOpts);
+  if (!hadError) {
+    await requestCache.set('whois', domain, domainResults, cacheOpts);
+  }
 
   return domainResults;
 }

--- a/test/whoiswrapper.test.ts
+++ b/test/whoiswrapper.test.ts
@@ -3,6 +3,7 @@ import '../test/electronMock';
 import whois from 'whois';
 import { lookup, getWhoisOptions, WhoisOption } from '../app/ts/common/lookup';
 import { toJSON } from '../app/ts/common/parser';
+import { RequestCache } from '../app/ts/common/requestCache';
 
 describe('whoiswrapper', () => {
   let lookupMock: jest.SpyInstance;
@@ -20,6 +21,13 @@ describe('whoiswrapper', () => {
 
   test('lookup handles invalid domain', async () => {
     await expect(lookup('invalid_domain')).resolves.toContain('Whois lookup error');
+  });
+
+  test('failed lookups are not cached', async () => {
+    const cacheSpy = jest.spyOn(RequestCache.prototype, 'set');
+    await lookup('invalid_domain');
+    expect(cacheSpy).not.toHaveBeenCalled();
+    cacheSpy.mockRestore();
   });
 
   test('toJSON parses object arrays', () => {


### PR DESCRIPTION
## Summary
- track lookup errors to avoid caching failed responses
- log WHOIS lookup errors and skip caching on failure
- test that failed lookups aren't stored in cache

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run test:e2e` *(fails: WebDriverError: session not created; user data directory already in use)*

------
https://chatgpt.com/codex/tasks/task_e_68aa14ab4d5c8325a81c7efaabd121e2