### PR TITLE
fix: handle IPv6 proxy notation

### DIFF
--- a/app/ts/common/proxy.ts
+++ b/app/ts/common/proxy.ts
@@ -49,7 +49,24 @@ function parseEntry(
     }
   }
 
-  const [ip, port] = hostPort.split(':');
+  let ip: string | undefined;
+  let port: string | undefined;
+
+  if (hostPort.startsWith('[')) {
+    const end = hostPort.indexOf(']');
+    if (end === -1) {
+      return undefined;
+    }
+    ip = hostPort.slice(1, end);
+    const remainder = hostPort.slice(end + 1);
+    if (!remainder.startsWith(':')) {
+      return undefined;
+    }
+    port = remainder.slice(1);
+  } else {
+    [ip, port] = hostPort.split(':');
+  }
+
   const portNum = parseInt(port ?? '', 10);
 
   if (!ip || isIP(ip) === 0) {
@@ -67,7 +84,7 @@ function parseEntry(
 }
 
 function proxyKey(p: ProxyInfo): string {
-  return `${p.ipaddress}:${p.port}`;
+  return isIP(p.ipaddress) === 6 ? `[${p.ipaddress}]:${p.port}` : `${p.ipaddress}:${p.port}`;
 }
 
 export function reportProxyFailure(proxy: ProxyInfo): void {

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -144,4 +144,26 @@ describe('proxy helper', () => {
     const next = getProxy();
     expect(next).toEqual({ ipaddress: '2.2.2.2', port: 8080 });
   });
+
+  test('parses IPv6 proxy string', () => {
+    settings.lookupProxy.enable = true;
+    settings.lookupProxy.mode = 'single';
+    settings.lookupProxy.single = '[2001:db8::1]:1080';
+    const proxy = getProxy();
+    expect(proxy).toEqual({ ipaddress: '2001:db8::1', port: 1080 });
+  });
+
+  test('skips IPv6 proxies exceeding retry limit', () => {
+    settings.lookupProxy.enable = true;
+    settings.lookupProxy.mode = 'multi';
+    settings.lookupProxy.list = ['[2001:db8::1]:8080', '[2001:db8::2]:8080'];
+    settings.lookupProxy.retries = 1;
+    const first = getProxy();
+    reportProxyFailure(first!);
+    const second = getProxy();
+    const third = getProxy();
+    expect(first).toEqual({ ipaddress: '2001:db8::1', port: 8080 });
+    expect(second).toEqual({ ipaddress: '2001:db8::2', port: 8080 });
+    expect(third).toEqual({ ipaddress: '2001:db8::2', port: 8080 });
+  });
 });


### PR DESCRIPTION
## Summary
- parse IPv6 proxy entries with bracket notation
- generate proxy key that avoids IPv6 colon conflicts
- cover IPv6 proxies in proxy helper tests

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` (fails: Jest encountered an unexpected token)
- `npm run test:e2e` (fails: WebDriverError: session not created)


------
https://chatgpt.com/codex/tasks/task_e_68aa17c7c5848325b6c50fe52629a903