### PR TITLE
refactor: centralize RequestCache in singleton

### DIFF
--- a/app/ts/cli.ts
+++ b/app/ts/cli.ts
@@ -9,7 +9,7 @@ import * as dns from './common/dnsLookup.js';
 import { rdapLookup, RdapResponse } from './common/rdapLookup.js';
 import pLimit from 'p-limit';
 import { settings } from './common/settings.js';
-import { RequestCache } from './common/requestCache.js';
+import { requestCache } from './common/requestCacheSingleton.js';
 import { isDomainAvailable, getDomainParameters, WhoisResult } from './common/availability.js';
 import DomainStatus from './common/status.js';
 import { toJSON } from './common/parser.js';
@@ -18,18 +18,7 @@ import { downloadModel } from './ai/modelDownloader.js';
 import { suggestWords } from './ai/openaiSuggest.js';
 import { readLines } from './common/wordlist.js';
 
-const requestCache = new RequestCache();
 requestCache.startAutoPurge(settings.requestCache.purgeInterval);
-const cleanup = (): void => requestCache.close();
-process.on('exit', cleanup);
-process.on('SIGINT', () => {
-  cleanup();
-  process.exit(0);
-});
-process.on('SIGTERM', () => {
-  cleanup();
-  process.exit(0);
-});
 
 const debug = debugFactory('cli');
 const error = errorFactory('cli');

--- a/app/ts/common/dnsLookup.ts
+++ b/app/ts/common/dnsLookup.ts
@@ -3,13 +3,12 @@ import psl from 'psl';
 import { debugFactory } from './logger.js';
 import { convertDomain } from './lookup.js';
 import { settings, Settings } from './settings.js';
-import { RequestCache, CacheOptions } from './requestCache.js';
+import { CacheOptions } from './requestCache.js';
+import { requestCache } from './requestCacheSingleton.js';
 import { DnsLookupError, Result } from './errors.js';
 import DomainStatus from './status.js';
 
 const debug = debugFactory('common.dnsLookup');
-
-const requestCache = new RequestCache();
 
 function getSettings(): Settings {
   return settings;

--- a/app/ts/common/lookup.ts
+++ b/app/ts/common/lookup.ts
@@ -4,7 +4,8 @@ import uts46 from 'idna-uts46';
 import whois from 'whois';
 import { debugFactory } from './logger.js';
 import { settings, Settings } from './settings.js';
-import { RequestCache, CacheOptions } from './requestCache.js';
+import { CacheOptions } from './requestCache.js';
+import { requestCache } from './requestCacheSingleton.js';
 import { getProxy } from './proxy.js';
 import { randomInt } from '../utils/random.js';
 
@@ -15,8 +16,6 @@ export enum WhoisOption {
 }
 
 const debug = debugFactory('common.whoisWrapper');
-
-const requestCache = new RequestCache();
 
 function getSettings(): Settings {
   return settings;

--- a/app/ts/common/rdapLookup.ts
+++ b/app/ts/common/rdapLookup.ts
@@ -1,10 +1,10 @@
 import { ensureFetch } from '../utils/fetchCompat.js';
-import { RequestCache, CacheOptions } from './requestCache.js';
+import { CacheOptions } from './requestCache.js';
+import { requestCache } from './requestCacheSingleton.js';
 import { debugFactory } from './logger.js';
 import { settings, Settings } from './settings.js';
 
 const debug = debugFactory('common.rdapLookup');
-const requestCache = new RequestCache();
 
 function getSettings(): Settings {
   return settings;

--- a/app/ts/common/requestCacheSingleton.ts
+++ b/app/ts/common/requestCacheSingleton.ts
@@ -1,0 +1,18 @@
+import { RequestCache } from './requestCache.js';
+export const requestCache = new RequestCache();
+
+const cleanup = (): void => {
+  requestCache.close();
+};
+
+process.on('exit', cleanup);
+process.on('SIGINT', () => {
+  cleanup();
+  process.exit(0);
+});
+process.on('SIGTERM', () => {
+  cleanup();
+  process.exit(0);
+});
+
+export default requestCache;

--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -8,7 +8,7 @@ import { debugFactory } from './common/logger.js';
 import { loadSettings, settings as store } from './main/settings-main.js';
 import type { Settings as BaseSettings } from './main/settings-main.js';
 import { formatString } from './common/stringformat.js';
-import { RequestCache } from './common/requestCache.js';
+import { requestCache } from './common/requestCacheSingleton.js';
 import { IpcChannel } from './common/ipcChannels.js';
 import {
   initialize as initializeRemote,
@@ -18,8 +18,6 @@ import type { IpcMainEvent } from 'electron';
 
 const debug = debugFactory('main');
 const debugb = debugFactory('renderer');
-
-const requestCache = new RequestCache();
 
 // Disable Chromium Autofill feature to silence devtools warnings in Electron
 app.commandLine.appendSwitch('disable-features', 'Autofill');

--- a/app/ts/main/cache.ts
+++ b/app/ts/main/cache.ts
@@ -1,10 +1,8 @@
 import { ipcMain } from 'electron';
 import { debugFactory } from '../common/logger.js';
-import { RequestCache } from '../common/requestCache.js';
+import { requestCache } from '../common/requestCacheSingleton.js';
 
 const debug = debugFactory('main.cache');
-
-const requestCache = new RequestCache();
 
 ipcMain.handle('cache:purge', async (_event, opts: { clear?: boolean } = {}) => {
   if (opts.clear) {

--- a/app/ts/main/index.ts
+++ b/app/ts/main/index.ts
@@ -7,9 +7,7 @@ import './ai.js';
 import './history.js';
 import './settings.js';
 import './i18n.js';
-import { RequestCache } from '../common/requestCache.js';
+import { requestCache } from '../common/requestCacheSingleton.js';
 import { settings } from '../common/settings.js';
 
-const requestCache = new RequestCache();
 requestCache.startAutoPurge(settings.requestCache.purgeInterval);
-process.on('exit', () => requestCache.close());


### PR DESCRIPTION
## Summary
- add RequestCache singleton shared across modules
- use shared requestCache in DNS, WHOIS, RDAP, CLI, and main processes
- close cache on process exit

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm test` *(fails: SyntaxError in tests: Cannot use import statement outside a module)*
- `npm run test:e2e` *(fails: WebDriverError: session not created: user data directory is already in use)*

------
https://chatgpt.com/codex/tasks/task_e_68aa205c24dc83259d36451c2c6a7093