### PR TITLE
feat: add cleanup handle for DOM event utility

### DIFF
--- a/app/ts/renderer/bulkwhois/event-bindings.ts
+++ b/app/ts/renderer/bulkwhois/event-bindings.ts
@@ -7,7 +7,7 @@ const debug = debugFactory('bulkwhois.events');
 export function bindProcessingEvents(electron: {
   send: (channel: string, ...args: any[]) => void;
 }): void {
-  on('click', '#bwProcessingButtonPause', () => {
+  void on('click', '#bwProcessingButtonPause', () => {
     const searchStatus = qs('#bwProcessingButtonPauseSpanText')?.textContent ?? '';
     switch (searchStatus) {
       case 'Continue':
@@ -28,7 +28,7 @@ export function bindProcessingEvents(electron: {
     }
   });
 
-  on('click', '#bwProcessingButtonStop', () => {
+  void on('click', '#bwProcessingButtonStop', () => {
     debug('Pausing whois & opening stop modal');
     const btn = qs('#bwProcessingButtonPause');
     if (btn?.textContent?.includes('Pause')) {
@@ -37,12 +37,12 @@ export function bindProcessingEvents(electron: {
     qs('#bwProcessingModalStop')!.classList.add('is-active');
   });
 
-  on('click', '#bwProcessingModalStopButtonContinue', () => {
+  void on('click', '#bwProcessingModalStopButtonContinue', () => {
     debug('Closing Stop modal & continue');
     qs('#bwProcessingModalStop')!.classList.remove('is-active');
   });
 
-  on('click', '#bwProcessingModalStopButtonStop', () => {
+  void on('click', '#bwProcessingModalStopButtonStop', () => {
     debug('Closing Stop modal & going back to start');
     qs('#bwProcessingModalStop')!.classList.remove('is-active');
     qs('#bwProcessing')!.classList.add('is-hidden');
@@ -50,7 +50,7 @@ export function bindProcessingEvents(electron: {
     qs('#bwEntry')!.classList.remove('is-hidden');
   });
 
-  on('click', '#bwProcessingModalStopButtonStopsave', () => {
+  void on('click', '#bwProcessingModalStopButtonStopsave', () => {
     debug('Closing Stop modal & exporting');
     electron.send(IpcChannel.BulkwhoisLookupStop);
     qs('#bwProcessingModalStop')!.classList.remove('is-active');
@@ -59,7 +59,7 @@ export function bindProcessingEvents(electron: {
     qs('#bwExport')!.classList.remove('is-hidden');
   });
 
-  on('click', '#bwProcessingButtonNext', () => {
+  void on('click', '#bwProcessingButtonNext', () => {
     qs('#bwProcessing')!.classList.add('is-hidden');
     qs('#bwExport')!.classList.remove('is-hidden');
   });

--- a/app/ts/renderer/bulkwhois/fileinput.ts
+++ b/app/ts/renderer/bulkwhois/fileinput.ts
@@ -214,7 +214,7 @@ electron.on(
   $('#bwEntryButtonFile').click(function() {...});
     File Input, Entry container button
  */
-on('click', '#bwEntryButtonFile', () => {
+void on('click', '#bwEntryButtonFile', () => {
   qs('#bwEntry')!.classList.add('is-hidden');
   const loader = qs('#bwFileinputloading')!;
   loader.classList.remove('is-hidden');
@@ -228,7 +228,7 @@ on('click', '#bwEntryButtonFile', () => {
   $('#bwFileButtonCancel').click(function() {...});
     File Input, cancel file confirmation
  */
-on('click', '#bwFileButtonCancel', () => {
+void on('click', '#bwFileButtonCancel', () => {
   watcher.close();
   qs('#bwFileinputconfirm')!.classList.add('is-hidden');
   qs('#bwEntry')!.classList.remove('is-hidden');
@@ -238,7 +238,7 @@ on('click', '#bwFileButtonCancel', () => {
   $('#bwFileButtonConfirm').click(function() {...});
     File Input, proceed to bulk whois
  */
-on('click', '#bwFileButtonConfirm', () => {
+void on('click', '#bwFileButtonConfirm', () => {
   watcher.close();
   const bwDomainArray = bwFileContents
     .toString()
@@ -286,7 +286,7 @@ document.addEventListener('DOMContentLoaded', () => {
   $('#bulkwhoisMainContainer').on('drop', function(...) {...});
     On Drop ipsum
  */
-on('drop', '#bulkwhoisMainContainer', (event: DragEvent) => {
+void on('drop', '#bulkwhoisMainContainer', (event: DragEvent) => {
   event.preventDefault();
   for (const f of Array.from(event.dataTransfer!.files)) {
     const file = f as any;

--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -31,7 +31,7 @@ export async function renderAnalyser(contents: any): Promise<void> {
   $('#bwaAnalyserButtonClose').click(function() {...});
     Bulk whois analyser close button
  */
-on('click', '#bwaAnalyserButtonClose', () => {
+void on('click', '#bwaAnalyserButtonClose', () => {
   debug('#bwaAnalyserButtonClose clicked');
   qs('#bwaAnalyserModalClose')!.classList.add('is-active');
 });
@@ -40,7 +40,7 @@ on('click', '#bwaAnalyserButtonClose', () => {
   $('#bwaAnalyserModalCloseButtonYes').click(function() {...});
     bwa, close dialog confirm/yes
  */
-on('click', '#bwaAnalyserModalCloseButtonYes', () => {
+void on('click', '#bwaAnalyserModalCloseButtonYes', () => {
   qs('#bwaAnalyser')!.classList.add('is-hidden');
   qs('#bwaAnalyserModalClose')!.classList.remove('is-active');
   qs('#bwaEntry')!.classList.remove('is-hidden');
@@ -50,7 +50,7 @@ on('click', '#bwaAnalyserModalCloseButtonYes', () => {
   $('#bwaAnalyserModalCloseButtonNo').click(function() {...});
     Bulk whois analyser close dialog cancel/no button
  */
-on('click', '#bwaAnalyserModalCloseButtonNo', () => {
+void on('click', '#bwaAnalyserModalCloseButtonNo', () => {
   qs('#bwaAnalyserModalClose')!.classList.remove('is-active');
 });
 

--- a/app/ts/renderer/bwa/fileinput.ts
+++ b/app/ts/renderer/bwa/fileinput.ts
@@ -161,7 +161,7 @@ electron.on('bwa:fileinput.confirmation', (_e: unknown, filePath: string | strin
   $('#bwaEntryButtonOpen').click(function() {...});
     Bulk whois, file input, entry container button
  */
-on('click', '#bwaEntryButtonOpen', () => {
+void on('click', '#bwaEntryButtonOpen', () => {
   qs('#bwaEntry')!.classList.add('is-hidden');
   const loader = qs('#bwaFileinputloading')!;
   loader.classList.remove('is-hidden');
@@ -175,7 +175,7 @@ on('click', '#bwaEntryButtonOpen', () => {
   $('#bwaFileinputconfirmButtonCancel').click(function() {...});
     Bulk whois, file input, cancel button, file confirmation
  */
-on('click', '#bwaFileinputconfirmButtonCancel', () => {
+void on('click', '#bwaFileinputconfirmButtonCancel', () => {
   watcher.close();
   qs('#bwaFileinputconfirm')!.classList.add('is-hidden');
   qs('#bwaEntry')!.classList.remove('is-hidden');
@@ -185,7 +185,7 @@ on('click', '#bwaFileinputconfirmButtonCancel', () => {
   $('#bwaFileinputconfirmButtonStart').click(function() {...});
     Bulk whois, file input, start button, file confirmation
  */
-on('click', '#bwaFileinputconfirmButtonStart', () => {
+void on('click', '#bwaFileinputconfirmButtonStart', () => {
   watcher.close();
   void (async () => {
     const data = await electron.invoke(IpcChannel.BwaAnalyserStart, bwaFileContents);
@@ -201,7 +201,7 @@ on('click', '#bwaFileinputconfirmButtonStart', () => {
 
 /*
 // File Input, proceed to bulk whois
-on('click', '#bwafButtonConfirm', () => {
+void on('click', '#bwafButtonConfirm', () => {
   const bwDomainArray = bwaFileContents.toString().split('\n').map(Function.prototype.call, String.prototype.trim);
   const bwTldsArray = (qs<HTMLInputElement>('#bwfSearchTlds')?.value || '').split(',');
 

--- a/app/ts/renderer/history.ts
+++ b/app/ts/renderer/history.ts
@@ -37,7 +37,7 @@ function loadHistory(): void {
 
 document.addEventListener('DOMContentLoaded', () => {
   loadHistory();
-  on('click', '#clearHistory', async () => {
+  void on('click', '#clearHistory', async () => {
     await electron.invoke('history:clear');
     loadHistory();
   });

--- a/app/ts/renderer/settings.ts
+++ b/app/ts/renderer/settings.ts
@@ -269,7 +269,7 @@ document.addEventListener('DOMContentLoaded', () => {
     void startStatsWorker();
   });
 
-  on('change', '#settingsEntry input[id], #settingsEntry select[id]', (ev) => {
+  void on('change', '#settingsEntry input[id], #settingsEntry select[id]', (ev) => {
     const el = (ev.target as Element).closest('input[id],select[id]') as
       | HTMLInputElement
       | HTMLSelectElement
@@ -282,7 +282,7 @@ document.addEventListener('DOMContentLoaded', () => {
     saveEntry(path, el, val);
   });
 
-  on('click', '#settingsEntry .reset-btn', (ev) => {
+  void on('click', '#settingsEntry .reset-btn', (ev) => {
     const btn = (ev.target as Element).closest('.reset-btn') as HTMLElement | null;
     if (!btn) return;
     const path = btn.getAttribute('data-path') as string;
@@ -294,11 +294,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  on('click', '#restoreDefaults', () => {
+  void on('click', '#restoreDefaults', () => {
     qs('#restoreDefaultsModal')!.classList.add('is-active');
   });
 
-  on('click', '#restoreDefaultsYes', () => {
+  void on('click', '#restoreDefaultsYes', () => {
     const defaults = validateSettings({});
     Object.assign(settings, defaults);
     populateInputs();
@@ -311,11 +311,11 @@ document.addEventListener('DOMContentLoaded', () => {
     qs('#restoreDefaultsModal')!.classList.remove('is-active');
   });
 
-  on('click', '#restoreDefaultsNo, #restoreDefaultsModal .delete', () => {
+  void on('click', '#restoreDefaultsNo, #restoreDefaultsModal .delete', () => {
     qs('#restoreDefaultsModal')!.classList.remove('is-active');
   });
 
-  on('click', '#reloadSettings', async () => {
+  void on('click', '#reloadSettings', async () => {
     await loadSettings();
     sessionStorage.setItem('customSettingsLoaded', customSettingsLoaded ? 'true' : 'false');
     populateInputs();
@@ -329,7 +329,7 @@ document.addEventListener('DOMContentLoaded', () => {
     refreshStats();
   });
 
-  on('click', '#saveConfig', async () => {
+  void on('click', '#saveConfig', async () => {
     const res = await saveSettings(settings);
     showToast(
       res === 'SAVED' || res === undefined ? 'Configuration saved' : 'Failed to save configuration',
@@ -338,14 +338,14 @@ document.addEventListener('DOMContentLoaded', () => {
     refreshStats();
   });
 
-  on('click', '#openDataFolder', async () => {
+  void on('click', '#openDataFolder', async () => {
     const result = await electron.openDataDir();
     if (result) {
       showToast('Failed to open data directory', false);
     }
   });
 
-  on('click', '#downloadModel', async () => {
+  void on('click', '#downloadModel', async () => {
     if (!settings.ai.modelURL) {
       showToast('Model URL not configured', false);
       return;
@@ -358,7 +358,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  on('click', '#reloadApp', async () => {
+  void on('click', '#reloadApp', async () => {
     try {
       await electron.invoke('app:reload');
     } catch {
@@ -366,11 +366,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  on('click', '#deleteConfig', () => {
+  void on('click', '#deleteConfig', () => {
     qs('#deleteConfigModal')!.classList.add('is-active');
   });
 
-  on('click', '#deleteConfigYes', async () => {
+  void on('click', '#deleteConfigYes', async () => {
     const filePath = await electron.path.join(
       getUserDataPath(),
       settings.customConfiguration.filepath
@@ -389,7 +389,7 @@ document.addEventListener('DOMContentLoaded', () => {
     qs('#deleteConfigModal')!.classList.remove('is-active');
   });
 
-  on('click', '#deleteConfigNo, #deleteConfigModal .delete', () => {
+  void on('click', '#deleteConfigNo, #deleteConfigModal .delete', () => {
     qs('#deleteConfigModal')!.classList.remove('is-active');
   });
 

--- a/app/ts/utils/dom.ts
+++ b/app/ts/utils/dom.ts
@@ -16,11 +16,15 @@ export function on<K extends keyof HTMLElementEventMap>(
   event: K,
   selector: string,
   handler: (event: HTMLElementEventMap[K]) => void
-): void {
-  document.addEventListener(event, (e) => {
+): () => void {
+  const listener = (e: Event) => {
     const target = e.target as Element | null;
     if (target && target.closest(selector)) {
       handler(e as any);
     }
-  });
+  };
+  document.addEventListener(event, listener);
+  return () => {
+    document.removeEventListener(event, listener);
+  };
 }

--- a/test/domOnCleanup.test.ts
+++ b/test/domOnCleanup.test.ts
@@ -1,0 +1,13 @@
+/** @jest-environment jsdom */
+import { on } from '../app/ts/utils/dom';
+
+test('on returns cleanup function that removes listener', () => {
+  document.body.innerHTML = '<button id="btn"></button>';
+  const handler = jest.fn();
+  const off = on('click', '#btn', handler);
+  (document.getElementById('btn') as HTMLButtonElement).click();
+  expect(handler).toHaveBeenCalledTimes(1);
+  off();
+  (document.getElementById('btn') as HTMLButtonElement).click();
+  expect(handler).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
## Summary
- allow DOM `on` helper to return a cleanup function that unregisters listeners
- update event bindings to ignore or leverage the new cleanup handle
- add unit test demonstrating listener removal

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Jest failed to parse due to `SyntaxError: Cannot use import statement outside a module`)*
- `npm run test:e2e` *(fails: WebDriverError: session not created: user data directory already in use)*

------
https://chatgpt.com/codex/tasks/task_e_68aa23cf114883258529d077bff6cdc0