### PR TITLE
fix: clean up file watchers on shutdown

### DIFF
--- a/app/ts/main/fsIpc.ts
+++ b/app/ts/main/fsIpc.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron';
+import { app, ipcMain } from 'electron';
 import fs from 'fs';
 import { IpcChannel } from '../common/ipcChannels.js';
 import { handle } from './ipc.js';
@@ -15,6 +15,12 @@ export function cleanupWatchers() {
   }
   watchers.clear();
 }
+
+app?.on('will-quit', cleanupWatchers);
+process.on('exit', cleanupWatchers);
+
+const hot = (import.meta as any).hot as undefined | { dispose: (cb: () => void) => void };
+hot?.dispose(cleanupWatchers);
 
 ipcMain.handle('fs:readFile', async (_e, p: string, opts?: ReadFileOpts) => {
   return fs.promises.readFile(p, opts);


### PR DESCRIPTION
## Summary
- ensure fs watcher cleanup occurs when Electron quits or Node exits
- handle watcher cleanup on hot module reload

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run test:e2e` *(fails: WebDriverError: session not created due to user data dir in use)*

------
https://chatgpt.com/codex/tasks/task_e_68aa285c9440832598fa592eb34a1444