### PR TITLE
fix: load renderer as esm

### DIFF
--- a/app/html/startup.js
+++ b/app/html/startup.js
@@ -1,5 +1,4 @@
-const { default: registerPartials } = require('../ts/renderer/registerPartials.js');
+import registerPartials from '../ts/renderer/registerPartials.js';
 
-registerPartials().then(() => {
-  require('../ts/mainPanel.js');
-});
+await registerPartials();
+await import('../ts/mainPanel.js');

--- a/app/html/templates/mainPanel.hbs
+++ b/app/html/templates/mainPanel.hbs
@@ -24,7 +24,7 @@
         }
       }
     </script>
-    <script src="./startup.js"></script>
+    <script type="module" src="./startup.js"></script>
   </head>
 
   <body>


### PR DESCRIPTION
## Summary
- load renderer startup script as an ES module

## Testing
- `npm run format`
- `npx tsc --noEmit`
- `npm run lint`
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run test:e2e` *(fails: session not created)*


------
https://chatgpt.com/codex/tasks/task_e_68aa2e445d4c8325b9bcddf1148e4eb2