### PR TITLE
refactor: harden Electron security

### DIFF
--- a/app/ts/appsettings.ts
+++ b/app/ts/appsettings.ts
@@ -24,15 +24,14 @@ const appSettings = {
     },
     appWindowWebPreferences: {
       // Web preferences
-      nodeIntegration: true, // Enable Node.js integration
-      contextIsolation: false, // Disable context isolation
+      nodeIntegration: false, // Disable Node.js integration
+      contextIsolation: true, // Enable context isolation
       zoomFactor: 1.0, // Page zoom factor
       images: true, // Image support
       experimentalFeatures: false, // Enable Chromium experimental features
       backgroundThrottling: true, // Whether to throttle animations and timers when the page becomes background
       offscreen: false, // enable offscreen rendering for the browser window
-      spellcheck: false, // Enable builtin spellchecker
-      enableRemoteModule: true // Enable remote module
+      spellcheck: false // Enable builtin spellchecker
     },
     startup: {
       // Application startup
@@ -220,7 +219,6 @@ export const appSettingsDescriptions: Record<string, string> = {
   'appWindowWebPreferences.backgroundThrottling': 'Throttle in background',
   'appWindowWebPreferences.offscreen': 'Enable offscreen rendering',
   'appWindowWebPreferences.spellcheck': 'Enable spellchecker',
-  'appWindowWebPreferences.enableRemoteModule': 'Enable remote module',
   'startup.developerTools': 'Open developer tools on startup',
   'theme.followSystem': 'Follow system theme preference',
   'theme.darkMode': 'Enable dark mode theme',

--- a/app/ts/common/settings-base.ts
+++ b/app/ts/common/settings-base.ts
@@ -28,7 +28,6 @@ export interface WebPreferencesSettings {
   backgroundThrottling: boolean;
   offscreen: boolean;
   spellcheck: boolean;
-  enableRemoteModule: boolean;
 }
 
 export interface AppUrlSettings {
@@ -154,8 +153,7 @@ export const SettingsSchema = z
       experimentalFeatures: z.boolean(),
       backgroundThrottling: z.boolean(),
       offscreen: z.boolean(),
-      spellcheck: z.boolean(),
-      enableRemoteModule: z.boolean()
+      spellcheck: z.boolean()
     }),
     appWindowUrl: z.object({
       pathname: z.string(),

--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -55,8 +55,8 @@ export async function load(): Promise<Settings> {
         try {
           const validated = validateSettings(parsed);
           if (validated.appWindowWebPreferences) {
-            validated.appWindowWebPreferences.contextIsolation = false;
-            validated.appWindowWebPreferences.nodeIntegration = true;
+            validated.appWindowWebPreferences.contextIsolation = true;
+            validated.appWindowWebPreferences.nodeIntegration = false;
           }
           setSettings(validated);
           setCustomSettingsLoaded(true);
@@ -68,8 +68,8 @@ export async function load(): Promise<Settings> {
               : String(mergeError);
           setSettings(JSON.parse(JSON.stringify(defaultSettings)));
           if (settings.appWindowWebPreferences) {
-            settings.appWindowWebPreferences.contextIsolation = false;
-            settings.appWindowWebPreferences.nodeIntegration = true;
+            settings.appWindowWebPreferences.contextIsolation = true;
+            settings.appWindowWebPreferences.nodeIntegration = false;
           }
           setCustomSettingsLoaded(false);
           debug(`Failed to merge custom configuration with error: ${message}`);
@@ -82,8 +82,8 @@ export async function load(): Promise<Settings> {
       debug(`Failed to load custom configuration with error: ${e}`);
       setCustomSettingsLoaded(false);
       if (settings.appWindowWebPreferences) {
-        settings.appWindowWebPreferences.contextIsolation = false;
-        settings.appWindowWebPreferences.nodeIntegration = true;
+        settings.appWindowWebPreferences.contextIsolation = true;
+        settings.appWindowWebPreferences.nodeIntegration = false;
       }
       // Silently ignore loading errors
     }
@@ -91,9 +91,9 @@ export async function load(): Promise<Settings> {
 
   if (!customSettingsLoaded) setCustomSettingsLoaded(false);
   if (settings.appWindowWebPreferences) {
-    // Force context isolation to remain disabled
-    settings.appWindowWebPreferences.contextIsolation = false;
-    settings.appWindowWebPreferences.nodeIntegration = true;
+    // Force secure defaults
+    settings.appWindowWebPreferences.contextIsolation = true;
+    settings.appWindowWebPreferences.nodeIntegration = false;
   }
   return settings;
 }

--- a/app/ts/main.ts
+++ b/app/ts/main.ts
@@ -10,10 +10,6 @@ import type { Settings as BaseSettings } from './main/settings-main.js';
 import { formatString } from './common/stringformat.js';
 import { requestCache } from './common/requestCacheSingleton.js';
 import { IpcChannel } from './common/ipcChannels.js';
-import {
-  initialize as initializeRemote,
-  enable as enableRemote
-} from '@electron/remote/main/index.js';
 import type { IpcMainEvent } from 'electron';
 
 const debug = debugFactory('main');
@@ -52,7 +48,6 @@ interface WebPreferencesSettings {
   backgroundThrottling: boolean;
   offscreen: boolean;
   spellcheck: boolean;
-  enableRemoteModule: boolean;
 }
 
 interface AppUrlSettings {
@@ -90,7 +85,6 @@ app.on('will-quit', cleanupWatchers);
     When application is ready
  */
 app.on('ready', async function () {
-  initializeRemote();
   await loadSettings();
   settings = store as MainSettings;
   const { appWindow, appWindowWebPreferences: webPreferences, appWindowUrl: appUrl } = settings;
@@ -122,8 +116,8 @@ app.on('ready', async function () {
     darkTheme: appWindow.darkTheme, // GTK dark theme mode
     thickFrame: appWindow.thickFrame, // Use WS_THICKFRAME style for frameless windows on Windows, which adds standard window frame. Setting it to false will remove window shadow and window animations.
     webPreferences: {
-      nodeIntegration: true, // Enable node integration always
-      contextIsolation: false, // Disable context isolation
+      nodeIntegration: false, // Disable node integration
+      contextIsolation: true, // Enable context isolation
       zoomFactor: webPreferences.zoomFactor, // Page zoom factor
       images: webPreferences.images, // Image support
       experimentalFeatures: webPreferences.experimentalFeatures, // Enable Chromium experimental features
@@ -133,8 +127,6 @@ app.on('ready', async function () {
       preload: path.resolve(baseDir, 'preload.cjs')
     }
   });
-
-  enableRemote(mainWindow.webContents);
 
   // mainWindow, Main window URL load
   const loadPath = path.isAbsolute(appUrl.pathname)

--- a/app/ts/main/settings-main.ts
+++ b/app/ts/main/settings-main.ts
@@ -44,16 +44,16 @@ function watchConfig(): void {
       try {
         const merged = mergeDefaults(parsed);
         if (merged.appWindowWebPreferences) {
-          merged.appWindowWebPreferences.contextIsolation = false;
-          merged.appWindowWebPreferences.nodeIntegration = true;
+          merged.appWindowWebPreferences.contextIsolation = true;
+          merged.appWindowWebPreferences.nodeIntegration = false;
         }
         setSettings(merged);
         debug(`Reloaded custom configuration at ${cfg}`);
       } catch (mergeError) {
         const defaults = JSON.parse(JSON.stringify(defaultSettings));
         if (defaults.appWindowWebPreferences) {
-          defaults.appWindowWebPreferences.contextIsolation = false;
-          defaults.appWindowWebPreferences.nodeIntegration = true;
+          defaults.appWindowWebPreferences.contextIsolation = true;
+          defaults.appWindowWebPreferences.nodeIntegration = false;
         }
         setSettings(defaults);
         debug(`Failed to merge configuration with error: ${mergeError}`);

--- a/app/ts/renderer/settings-renderer.ts
+++ b/app/ts/renderer/settings-renderer.ts
@@ -27,7 +27,7 @@ const debug = debugFactory('renderer.settings');
 debug('loaded');
 const defaultSettings: Settings = JSON.parse(JSON.stringify(appDefaults.settings as Settings));
 const defaultCustomConfiguration = settings.customConfiguration;
-let userDataPath = (electron as any)?.remote?.app?.getPath('userData') ?? '';
+let userDataPath = '';
 
 export function getUserDataPath(): string {
   return userDataPath;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "license": "MIT",
       "dependencies": {
         "@electron/packager": "^18.3.6",
-        "@electron/remote": "^2.1.3",
         "@fortawesome/fontawesome-free": "^7.0.0",
         "better-sqlite3": "^12.2.0",
         "bulma": "^1.0.4",
@@ -2145,15 +2144,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@electron/remote": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@electron/remote/-/remote-2.1.3.tgz",
-      "integrity": "sha512-XlpxC8S4ttj/v2d+PKp9na/3Ev8bV7YWNL7Cw5b9MAWgTphEml7iYgbc7V0r9D6yDOfOkj06bchZgOZdlWJGNA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "electron": ">= 13.0.0"
       }
     },
     "node_modules/@electron/universal": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   "homepage": "https://github.com/supermarsx/whoisdigger#readme",
   "dependencies": {
     "@electron/packager": "^18.3.6",
-    "@electron/remote": "^2.1.3",
     "@fortawesome/fontawesome-free": "^7.0.0",
     "better-sqlite3": "^12.2.0",
     "bulma": "^1.0.4",

--- a/test/cacheOverride.test.ts
+++ b/test/cacheOverride.test.ts
@@ -5,12 +5,13 @@ import whois from 'whois';
 import dns from 'dns/promises';
 import { lookup } from '../app/ts/common/lookup';
 import { nsLookup } from '../app/ts/common/dnsLookup';
-import { settings, getUserDataPath } from '../app/ts/renderer/settings-renderer';
+import { loadSettings, settings, getUserDataPath } from '../app/ts/renderer/settings-renderer';
 
 describe('cache override', () => {
   const dbFile = 'override-cache.sqlite';
 
-  beforeAll(() => {
+  beforeAll(async () => {
+    await loadSettings();
     settings.requestCache.enabled = true;
     settings.requestCache.database = dbFile;
     settings.requestCache.ttl = 60;

--- a/test/dnsLookup.test.ts
+++ b/test/dnsLookup.test.ts
@@ -7,12 +7,13 @@ import { nsLookup, hasNsServers, isDomainAvailable } from '../app/ts/common/dnsL
 import DomainStatus from '../app/ts/common/status';
 import { DnsLookupError } from '../app/ts/common/errors';
 import { RequestCache } from '../app/ts/common/requestCache';
-import { settings, getUserDataPath } from '../app/ts/renderer/settings-renderer';
+import { loadSettings, settings, getUserDataPath } from '../app/ts/renderer/settings-renderer';
 
 describe('dnsLookup', () => {
   let resolveMock: jest.SpyInstance;
 
-  beforeAll(() => {
+  beforeAll(async () => {
+    await loadSettings();
     resolveMock = jest.spyOn(dns, 'resolve').mockRejectedValue(new Error('ENOTFOUND'));
   });
 

--- a/test/electronMock.ts
+++ b/test/electronMock.ts
@@ -7,8 +7,7 @@ export const mockIpcSend = jest.fn();
 jest.mock('electron', () => ({
   ipcRenderer: { send: mockIpcSend },
   dialog: {},
-  app: undefined,
-  remote: { app: { getPath: mockGetPath } }
+  app: { getPath: mockGetPath }
 }));
 
 if (!(global as any).window) {
@@ -49,6 +48,5 @@ if (!(global as any).window) {
   path: {
     join: (...args: string[]) => path.join(...args),
     basename: (p: string) => path.basename(p)
-  },
-  remote: { app: { getPath: mockGetPath } }
+  }
 };

--- a/test/history.test.ts
+++ b/test/history.test.ts
@@ -1,5 +1,5 @@
 import '../test/electronMock';
-import { getUserDataPath } from '../app/ts/renderer/settings-renderer';
+import { loadSettings, getUserDataPath } from '../app/ts/renderer/settings-renderer';
 import DomainStatus from '../app/ts/common/status';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -11,6 +11,7 @@ describe('history module', () => {
   let history: typeof import('../app/ts/common/history');
 
   beforeAll(async () => {
+    await loadSettings();
     process.env.HISTORY_DB_PATH = dbFile;
     history = await import('../app/ts/common/history');
     history.clearHistory();

--- a/test/isDomainAvailableAi.test.ts
+++ b/test/isDomainAvailableAi.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import '../test/electronMock';
-import { settings, getUserDataPath } from '../app/ts/renderer/settings-renderer';
+import { loadSettings, settings, getUserDataPath } from '../app/ts/renderer/settings-renderer';
 import { loadModel } from '../app/ts/ai/availabilityModel';
 import { trainFromSamples } from '../scripts/train-ai';
 import { isDomainAvailable } from '../app/ts/common/availability';
@@ -11,6 +11,7 @@ describe('isDomainAvailable with AI', () => {
   const dir = 'ai-int';
 
   beforeAll(async () => {
+    await loadSettings();
     settings.ai.enabled = true;
     settings.ai.dataPath = dir;
     settings.ai.modelPath = 'model.json';

--- a/test/jqueryAvailability.test.ts
+++ b/test/jqueryAvailability.test.ts
@@ -2,10 +2,6 @@
 
 import '../test/electronMock';
 
-jest.mock('@electron/remote', () => ({
-  app: { getPath: jest.fn(() => '') }
-}));
-
 jest.mock('../app/ts/renderer/index', () => ({}));
 jest.mock('../app/ts/renderer/navigation', () => ({}));
 

--- a/test/nodeIntegrationForced.test.ts
+++ b/test/nodeIntegrationForced.test.ts
@@ -5,19 +5,20 @@ import '../test/electronMock';
 import { loadSettings, settings, getUserDataPath } from '../app/ts/renderer/settings-renderer';
 
 describe('nodeIntegration enforcement', () => {
-  test('nodeIntegration remains true even when config disables it', async () => {
+  test('nodeIntegration remains false even when config enables it', async () => {
+    await loadSettings();
     const dir = getUserDataPath();
     fs.mkdirSync(dir, { recursive: true });
     const configName = 'node-integration.json';
     settings.customConfiguration.filepath = configName;
     fs.writeFileSync(
       path.join(dir, configName),
-      JSON.stringify({ appWindowWebPreferences: { nodeIntegration: false } })
+      JSON.stringify({ appWindowWebPreferences: { nodeIntegration: true } })
     );
 
     const loaded = await loadSettings();
 
-    expect(loaded.appWindowWebPreferences.nodeIntegration).toBe(true);
+    expect(loaded.appWindowWebPreferences.nodeIntegration).toBe(false);
 
     fs.unlinkSync(path.join(dir, configName));
   });

--- a/test/requestCache.test.ts
+++ b/test/requestCache.test.ts
@@ -1,5 +1,5 @@
 import '../test/electronMock';
-import { settings, getUserDataPath } from '../app/ts/renderer/settings-renderer';
+import { loadSettings, settings, getUserDataPath } from '../app/ts/renderer/settings-renderer';
 import { RequestCache } from '../app/ts/common/requestCache';
 import fs from 'fs';
 import path from 'path';
@@ -8,7 +8,8 @@ describe('requestCache', () => {
   const dbFile = 'test-cache.sqlite';
   let cache: RequestCache;
 
-  beforeAll(() => {
+  beforeAll(async () => {
+    await loadSettings();
     settings.requestCache.enabled = true;
     settings.requestCache.database = dbFile;
     settings.requestCache.ttl = 1;

--- a/test/settingsPartial.test.ts
+++ b/test/settingsPartial.test.ts
@@ -7,6 +7,7 @@ describe('settings partial load', () => {
     const { loadSettings, settings, getUserDataPath } = await import(
       '../app/ts/renderer/settings-renderer'
     );
+    await loadSettings();
     const dir = getUserDataPath();
     fs.mkdirSync(dir, { recursive: true });
 

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -174,19 +174,6 @@ declare global {
   }
 }
 
-declare module '@electron/remote' {
-  export const app: any;
-  export const dialog: any;
-  export const BrowserWindow: any;
-  export function getCurrentWindow(): any;
-  export function getCurrentWebContents(): any;
-}
-
-declare module '@electron/remote/main' {
-  export function initialize(): void;
-  export function enable(webContents: any): void;
-}
-
 declare module 'papaparse' {
   const Papa: any;
   export default Papa;


### PR DESCRIPTION
## Summary
- disable node integration and enable context isolation by default
- remove deprecated @electron/remote usage
- clean up tests to use preload IPC helpers

## Testing
- `npm run format`
- `npx tsc --noEmit`
- `npm run lint`
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run test:e2e` *(fails: WebDriverError: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68aa45e0365883259af0cb97929dc04a