### PR TITLE
fix: unref request cache purge timer

### DIFF
--- a/app/ts/common/requestCache.ts
+++ b/app/ts/common/requestCache.ts
@@ -141,6 +141,7 @@ export class RequestCache {
     this.purgeTimer = setInterval(() => {
       void this.purgeExpired();
     }, interval);
+    this.purgeTimer.unref?.();
   }
 
   close(): void {

--- a/test/requestCache.test.ts
+++ b/test/requestCache.test.ts
@@ -68,4 +68,18 @@ describe('requestCache', () => {
     expect(await cache.get('whois', 'a.com')).toBeUndefined();
     expect(await cache.get('whois', 'b.com')).toBeUndefined();
   });
+
+  test('startAutoPurge unrefs timer and close clears interval', () => {
+    settings.requestCache.enabled = true;
+    const testCache = new RequestCache();
+    const timer = { unref: jest.fn() } as unknown as NodeJS.Timeout;
+    const si = jest.spyOn(global, 'setInterval').mockReturnValue(timer);
+    const ci = jest.spyOn(global, 'clearInterval').mockImplementation(() => {});
+    testCache.startAutoPurge(100);
+    expect(timer.unref).toHaveBeenCalled();
+    testCache.close();
+    expect(ci).toHaveBeenCalledWith(timer);
+    si.mockRestore();
+    ci.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- unref request cache purge timer when starting auto purge so Node can exit
- test auto purge timer unref and cleanup on close

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm test` (fails: Jest failed to parse files)
- `npm run test:e2e` (fails: WebDriverError: session not created)


------
https://chatgpt.com/codex/tasks/task_e_68aa4e1bb3108325a08de2e12cef06bf