### PR TITLE
feat: monitor domain availability

### DIFF
--- a/app/ts/appsettings.ts
+++ b/app/ts/appsettings.ts
@@ -186,6 +186,11 @@ const appSettings = {
       dataPath: 'ai-data',
       modelURL: '',
       openai: { url: '', apiKey: '' }
+    },
+    monitor: {
+      // Domain monitoring configuration
+      list: [], // Domains to monitor
+      interval: 60000 // Monitoring interval in milliseconds
     }
   }
 };
@@ -295,5 +300,7 @@ export const appSettingsDescriptions: Record<string, string> = {
   'ai.dataPath': 'Directory for AI data',
   'ai.modelURL': 'URL to download the ONNX model',
   'ai.openai.url': 'Custom OpenAI API endpoint',
-  'ai.openai.apiKey': 'OpenAI API key'
+  'ai.openai.apiKey': 'OpenAI API key',
+  'monitor.list': 'Domains to monitor',
+  'monitor.interval': 'Monitoring interval in milliseconds'
 };

--- a/app/ts/common/ipcChannels.ts
+++ b/app/ts/common/ipcChannels.ts
@@ -32,5 +32,8 @@ export enum IpcChannel {
   GetBaseDir = 'app:get-base-dir',
   I18nLoad = 'i18n:load',
   BwFileRead = 'bw:file-read',
-  BwaFileRead = 'bwa:file-read'
+  BwaFileRead = 'bwa:file-read',
+  MonitorStart = 'monitor:start',
+  MonitorStop = 'monitor:stop',
+  MonitorUpdate = 'monitor:update'
 }

--- a/app/ts/common/ipcContracts.ts
+++ b/app/ts/common/ipcContracts.ts
@@ -78,6 +78,9 @@ export interface IpcContracts {
   [IpcChannel.I18nLoad]: { request: [string]; response: string };
   [IpcChannel.BwFileRead]: { request: [string]; response: Buffer };
   [IpcChannel.BwaFileRead]: { request: [string]; response: Buffer };
+  [IpcChannel.MonitorStart]: { request: []; response: void };
+  [IpcChannel.MonitorStop]: { request: []; response: void };
+  [IpcChannel.MonitorUpdate]: { request: [string, DomainStatus]; response: void };
 }
 
 export type IpcRequest<C extends IpcChannel> = IpcContracts[C]['request'];

--- a/app/ts/common/settings-base.ts
+++ b/app/ts/common/settings-base.ts
@@ -108,6 +108,7 @@ export interface Settings {
     modelURL: string;
     openai: { url: string; apiKey: string };
   };
+  monitor: { list: string[]; interval: number };
   [key: string]: any;
 }
 
@@ -240,6 +241,10 @@ export const SettingsSchema = z
       dataPath: z.string(),
       modelURL: z.string(),
       openai: z.object({ url: z.string(), apiKey: z.string() })
+    }),
+    monitor: z.object({
+      list: z.array(z.string()),
+      interval: z.number()
     })
   })
   .catchall(z.any());

--- a/app/ts/main/index.ts
+++ b/app/ts/main/index.ts
@@ -7,6 +7,7 @@ import './ai.js';
 import './history.js';
 import './settings.js';
 import './i18n.js';
+import './monitor.js';
 import { requestCache } from '../common/requestCacheSingleton.js';
 import { settings } from '../common/settings.js';
 

--- a/app/ts/main/monitor.ts
+++ b/app/ts/main/monitor.ts
@@ -1,0 +1,53 @@
+import { handle } from './ipc.js';
+import { lookup } from '../common/lookup.js';
+import { isDomainAvailable } from '../common/availability.js';
+import DomainStatus from '../common/status.js';
+import { getSettings } from './settings-main.js';
+import { debugFactory } from '../common/logger.js';
+import type { IpcMainInvokeEvent, WebContents } from 'electron';
+import { IpcChannel } from '../common/ipcChannels.js';
+
+const debug = debugFactory('main.monitor');
+
+let timer: NodeJS.Timeout | undefined;
+const lastStatuses = new Map<string, DomainStatus>();
+let sender: WebContents | null = null;
+
+async function checkDomains(): Promise<void> {
+  const { monitor } = getSettings();
+  if (!monitor?.list?.length) return;
+
+  for (const domain of monitor.list) {
+    try {
+      const data = await lookup(domain);
+      const status = isDomainAvailable(data);
+      if (lastStatuses.get(domain) !== status) {
+        lastStatuses.set(domain, status);
+        sender?.send(IpcChannel.MonitorUpdate, domain, status);
+        debug(`Domain ${domain} status changed to ${status}`);
+      }
+    } catch (e) {
+      debug(`Lookup failed for ${domain}: ${e}`);
+    }
+  }
+}
+
+handle(IpcChannel.MonitorStart, async (event: IpcMainInvokeEvent) => {
+  sender = event.sender;
+  const { monitor } = getSettings();
+  const interval = monitor?.interval ?? 60000;
+  if (timer) clearInterval(timer);
+  await checkDomains();
+  timer = setInterval(checkDomains, interval);
+});
+
+handle(IpcChannel.MonitorStop, async () => {
+  if (timer) clearInterval(timer);
+  timer = undefined;
+});
+
+export const _test = {
+  checkDomains,
+  lastStatuses,
+  getTimer: () => timer
+};

--- a/app/ts/renderer/history.ts
+++ b/app/ts/renderer/history.ts
@@ -2,6 +2,7 @@ import { qs, qsa, on } from '../utils/dom.js';
 import type { RendererElectronAPI } from '../../../types/renderer-electron-api.js';
 const electron = (window as any).electron as RendererElectronAPI;
 import { debugFactory } from '../common/logger.js';
+import DomainStatus from '../common/status.js';
 
 const debug = debugFactory('renderer.history');
 debug('loaded');
@@ -40,6 +41,15 @@ document.addEventListener('DOMContentLoaded', () => {
   void on('click', '#clearHistory', async () => {
     await electron.invoke('history:clear');
     loadHistory();
+  });
+  void on('click', '#monitorStart', async () => {
+    await electron.invoke('monitor:start');
+  });
+  void on('click', '#monitorStop', async () => {
+    await electron.invoke('monitor:stop');
+  });
+  electron.on('monitor:update', (domain: string, status: DomainStatus) => {
+    debug(`Monitor update for ${domain}: ${status}`);
   });
 });
 

--- a/test/domainMonitor.test.ts
+++ b/test/domainMonitor.test.ts
@@ -1,0 +1,72 @@
+import DomainStatus from '../app/ts/common/status';
+import { IpcChannel } from '../app/ts/common/ipcChannels';
+
+const ipcMainHandlers: Record<string, (...args: any[]) => any> = {};
+const sendMock = jest.fn();
+
+jest.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, listener: (...args: any[]) => any) => {
+      ipcMainHandlers[channel] = listener;
+    }
+  },
+  dialog: {},
+  app: undefined,
+  BrowserWindow: class {},
+  Menu: {}
+}));
+
+jest.mock('../app/ts/common/lookup', () => ({ lookup: jest.fn() }));
+jest.mock('../app/ts/common/availability', () => ({ isDomainAvailable: jest.fn() }));
+
+import '../app/ts/main/monitor';
+import { settings } from '../app/ts/main/settings-main';
+import { lookup } from '../app/ts/common/lookup';
+import { isDomainAvailable } from '../app/ts/common/availability';
+
+describe('domain monitor', () => {
+  jest.useFakeTimers();
+
+  beforeEach(() => {
+    jest.clearAllTimers();
+    (lookup as jest.Mock).mockReset();
+    (isDomainAvailable as jest.Mock).mockReset();
+    sendMock.mockReset();
+    settings.monitor = { list: ['a.com'], interval: 1000 } as any;
+  });
+
+  test('schedules lookups and emits on change', async () => {
+    (lookup as jest.Mock).mockResolvedValue('data');
+    (isDomainAvailable as jest.Mock)
+      .mockReturnValueOnce(DomainStatus.Available)
+      .mockReturnValueOnce(DomainStatus.Available)
+      .mockReturnValueOnce(DomainStatus.Unavailable);
+
+    await ipcMainHandlers[IpcChannel.MonitorStart]!({ sender: { send: sendMock } } as any);
+    await Promise.resolve();
+
+    expect(sendMock).toHaveBeenCalledWith(
+      IpcChannel.MonitorUpdate,
+      'a.com',
+      DomainStatus.Available
+    );
+    sendMock.mockClear();
+
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+    expect(sendMock).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+    expect(sendMock).toHaveBeenCalledWith(
+      IpcChannel.MonitorUpdate,
+      'a.com',
+      DomainStatus.Unavailable
+    );
+
+    await ipcMainHandlers[IpcChannel.MonitorStop]!({} as any);
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+    expect((lookup as jest.Mock).mock.calls.length).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- add domain monitor scheduler with start/stop IPC and notifications
- persist monitor domains and interval settings
- cover monitor scheduling and change detection with tests

## Testing
- `npm run format`
- `npx tsc --noEmit`
- `npm run lint`
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run test:e2e` *(fails: WebDriverError session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68aca91a30d0832588134e7c2f5a8a28