### PR TITLE
feat: add CLI training for availability model

### DIFF
--- a/app/ts/ai/trainModel.ts
+++ b/app/ts/ai/trainModel.ts
@@ -1,0 +1,86 @@
+import fs from 'fs';
+import path from 'path';
+import { debugFactory } from '../common/logger.js';
+import { settings, getUserDataPath } from '../common/settings.js';
+import type { Label, Model } from './availabilityModel.js';
+
+const debug = debugFactory('ai.trainModel');
+
+interface Sample {
+  text: string;
+  label: Label;
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function trainFromSamples(samples: Sample[]): Model {
+  const vocabulary = new Set<string>();
+  const classTotals: Record<Label, number> = { available: 0, unavailable: 0 };
+  const tokenTotals: Record<Label, number> = { available: 0, unavailable: 0 };
+  const tokenCounts: Record<Label, Record<string, number>> = {
+    available: {},
+    unavailable: {}
+  };
+  for (const sample of samples) {
+    const tokens = tokenize(sample.text);
+    classTotals[sample.label]++;
+    tokenTotals[sample.label] += tokens.length;
+    for (const t of tokens) {
+      vocabulary.add(t);
+      tokenCounts[sample.label][t] = (tokenCounts[sample.label][t] || 0) + 1;
+    }
+  }
+  return {
+    vocabulary: Array.from(vocabulary),
+    classTotals,
+    tokenTotals,
+    tokenCounts
+  };
+}
+
+async function readDataset(file: string): Promise<Sample[]> {
+  const ext = path.extname(file).toLowerCase();
+  const raw = await fs.promises.readFile(file, 'utf8');
+  if (ext === '.json') {
+    const data = JSON.parse(raw);
+    if (Array.isArray(data)) return data as Sample[];
+    throw new Error('Invalid JSON dataset');
+  }
+  if (ext === '.csv') {
+    const lines = raw.split(/\r?\n/).filter(Boolean);
+    const header = lines.shift();
+    if (!header) return [];
+    const cols = header.split(',');
+    const textIdx = cols.indexOf('text');
+    const labelIdx = cols.indexOf('label');
+    if (textIdx === -1 || labelIdx === -1) throw new Error('Invalid CSV header');
+    return lines.map((l) => {
+      const parts = l.split(',');
+      return { text: parts[textIdx] ?? '', label: parts[labelIdx] as Label };
+    });
+  }
+  throw new Error('Unsupported dataset format');
+}
+
+export async function trainModel(datasetPath: string, outPath: string): Promise<void> {
+  const samples = await readDataset(datasetPath);
+  if (!samples.length) throw new Error('No training data');
+  const model = trainFromSamples(samples);
+  const baseDir = path.resolve(getUserDataPath(), settings.ai.dataPath);
+  const dest = path.resolve(baseDir, outPath);
+  if (dest !== baseDir && !dest.startsWith(baseDir + path.sep)) {
+    throw new Error('Invalid model path');
+  }
+  await fs.promises.mkdir(path.dirname(dest), { recursive: true });
+  await fs.promises.writeFile(dest, JSON.stringify(model));
+  debug(`Model written to ${dest}`);
+}
+
+export type { Model } from './availabilityModel.js';

--- a/app/ts/cli.ts
+++ b/app/ts/cli.ts
@@ -18,6 +18,7 @@ import { downloadModel } from './ai/modelDownloader.js';
 import { suggestWords } from './ai/openaiSuggest.js';
 import { readLines } from './common/wordlist.js';
 import { createProgressRenderer } from './cli/progress.js';
+import { trainModel } from './ai/trainModel.js';
 
 requestCache.startAutoPurge(settings.requestCache.purgeInterval);
 
@@ -42,6 +43,7 @@ export interface CliOptions {
   lookupType?: 'whois' | 'dns' | 'rdap';
   maxCacheEntries?: number;
   progress?: boolean;
+  trainModel?: string;
 }
 
 export function parseArgs(argv: string[]): CliOptions {
@@ -65,6 +67,7 @@ export function parseArgs(argv: string[]): CliOptions {
     .option('purge-cache', { type: 'boolean' })
     .option('clear-cache', { type: 'boolean' })
     .option('download-model', { type: 'boolean' })
+    .option('train-model', { type: 'string' })
     .option('suggest', { type: 'string' })
     .option('suggest-count', { type: 'number', default: 5 })
     .option('limit', { type: 'number', default: CONCURRENCY_LIMIT })
@@ -80,7 +83,8 @@ export function parseArgs(argv: string[]): CliOptions {
         !args.suggest &&
         !args['download-model'] &&
         !args['purge-cache'] &&
-        !args['clear-cache']
+        !args['clear-cache'] &&
+        !args['train-model']
       ) {
         throw new Error('Either --domain or --wordlist must be provided');
       }
@@ -115,6 +119,7 @@ export function parseArgs(argv: string[]): CliOptions {
     purgeCache: args['purge-cache'],
     clearCache: args['clear-cache'],
     downloadModel: args['download-model'],
+    trainModel: args['train-model'],
     suggest: args.suggest,
     suggestCount: args['suggest-count'],
     limit: args.limit,
@@ -265,6 +270,12 @@ if (require.main === module) {
       await downloadModel(url, settings.ai.modelPath);
       process.stdout.write('Model downloaded\n');
       debug('Model downloaded');
+      return;
+    }
+    if (opts.trainModel) {
+      await trainModel(opts.trainModel, settings.ai.modelPath);
+      process.stdout.write('Model trained\n');
+      debug('Model trained');
       return;
     }
     if (opts.purgeCache || opts.clearCache) {

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -1,0 +1,33 @@
+# AI Dataset Format
+
+The CLI can train a local availability model using `--train-model <dataset>`.
+
+## Dataset structure
+
+Datasets may be provided as **JSON** or **CSV** files.
+
+### JSON
+
+A JSON file must contain an array of objects:
+
+```json
+[
+  { "text": "WHOIS reply here", "label": "available" },
+  { "text": "Another reply", "label": "unavailable" }
+]
+```
+
+### CSV
+
+CSV files require a header row with `text` and `label` columns:
+
+```
+text,label
+"WHOIS reply here",available
+"Another reply",unavailable
+```
+
+The `label` value must be either `available` or `unavailable`.
+
+`--train-model` writes the resulting model to `settings.ai.modelPath` within
+`settings.ai.dataPath`.

--- a/readme.md
+++ b/readme.md
@@ -302,6 +302,14 @@ Configure these features in the `ai` section of `appsettings.ts`:
 - `ai.modelURL` - remote URL to download the model
 - `ai.openai.url` and `ai.openai.apiKey` - OpenAI endpoint and API key
 
+Train a local model from a labelled dataset via the CLI:
+
+```
+node dist/app/cli.js --train-model path/to/dataset.json
+```
+
+The dataset format is documented in [docs/ai.md](docs/ai.md).
+
 ## Building
 
 Whoisdigger uses a small build step before packaging. Each packaging command

--- a/test/trainAi.test.ts
+++ b/test/trainAi.test.ts
@@ -1,39 +1,43 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { jest } from '@jest/globals';
-import { trainFromSamples, predict } from '../scripts/train-ai';
-import DomainStatus from '../app/ts/common/status';
 
-describe('train-ai', () => {
-  test('predicts labels after training', () => {
+describe('trainModel', () => {
+  test('builds vocabulary and class totals from dataset', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'train-'));
+    jest.resetModules();
+    jest.doMock('../app/ts/common/settings.js', () => {
+      const actual = jest.requireActual('../app/ts/common/settings.js');
+      return { ...actual, getUserDataPath: () => tmp };
+    });
+    const { trainModel } = await import('../app/ts/ai/trainModel.js');
+    const { settings } = await import('../app/ts/common/settings.js');
+    const dataset = path.join(tmp, 'dataset.json');
     const samples = [
       { text: 'No match for domain example.com', label: 'available' },
       { text: 'Domain Status:ok\nExpiry Date:2030-01-01', label: 'unavailable' }
     ];
-    const model = trainFromSamples(samples);
-    expect(predict(model, 'Domain Status:ok')).toBe(DomainStatus.Unavailable);
-    expect(predict(model, 'No match for domain test')).toBe(DomainStatus.Available);
-  });
-
-  test('runs with default lists when none supplied', async () => {
-    jest.resetModules();
-    const lookupMock = jest.fn(async () => 'No match for domain example.com');
-    jest.doMock('../app/ts/common/lookup.js', () => ({ __esModule: true, lookup: lookupMock }));
-    jest.doMock('../app/ts/common/parser.js', () => ({ __esModule: true, toJSON: () => ({}) }));
-    jest.doMock('../app/ts/common/availability.js', () => ({
-      __esModule: true,
-      isDomainAvailable: () => 'available'
-    }));
-    const readdirSpy = jest.spyOn(fs, 'readdirSync').mockReturnValue(['foo.list'] as any);
-    const readFileSpy = jest.spyOn(fs, 'readFileSync').mockReturnValue('example.com');
-    const mkdirSpy = jest.spyOn(fs.promises, 'mkdir').mockResolvedValue(undefined as any);
-    const writeFileSpy = jest.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined as any);
-    const { main } = await import('../scripts/train-ai');
-    await expect(main()).resolves.toBeUndefined();
-    expect(readFileSpy).toHaveBeenCalledWith(path.join('sample_lists', 'foo.list'), 'utf8');
-    readdirSpy.mockRestore();
-    readFileSpy.mockRestore();
-    mkdirSpy.mockRestore();
-    writeFileSpy.mockRestore();
+    fs.writeFileSync(dataset, JSON.stringify(samples));
+    await trainModel(dataset, 'model.json');
+    const modelPath = path.join(tmp, settings.ai.dataPath, 'model.json');
+    const model = JSON.parse(fs.readFileSync(modelPath, 'utf8'));
+    expect(model.classTotals).toEqual({ available: 1, unavailable: 1 });
+    expect(new Set(model.vocabulary)).toEqual(
+      new Set([
+        'no',
+        'match',
+        'for',
+        'domain',
+        'example',
+        'com',
+        'status',
+        'ok',
+        'expiry',
+        'date',
+        '2030',
+        '01'
+      ])
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add `trainModel` to build AI model from labeled datasets
- support `--train-model` CLI option to train and overwrite the local model
- document dataset format and usage

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Jest failed to parse ESM modules)*
- `npm run test:e2e` *(fails: WebDriver session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68aecc1232a0832584b9cff2d64a0c7b