### PR TITLE
feat: add navigator language fallback

### DIFF
--- a/app/ts/common/settings-base.ts
+++ b/app/ts/common/settings-base.ts
@@ -102,7 +102,7 @@ export interface Settings {
   };
   customConfiguration: { filepath: string; load: boolean; save: boolean };
   theme: { darkMode: boolean; followSystem: boolean };
-  ui: { liveReload: boolean; confirmExit: boolean; language: string };
+  ui: { liveReload: boolean; confirmExit: boolean; language?: string };
   ai: {
     enabled: boolean;
     modelPath: string;
@@ -240,7 +240,7 @@ export const SettingsSchema = z
     ui: z.object({
       liveReload: z.boolean(),
       confirmExit: z.boolean(),
-      language: z.string()
+      language: z.string().optional()
     }),
     ai: z.object({
       enabled: z.boolean(),

--- a/app/ts/renderer/i18n.ts
+++ b/app/ts/renderer/i18n.ts
@@ -9,9 +9,10 @@ const debug = debugFactory('renderer.i18n');
 debug('loaded');
 let translations: Record<string, string> = {};
 
-export async function loadTranslations(lang: string): Promise<void> {
+export async function loadTranslations(lang?: string): Promise<void> {
+  const detected = (lang ?? navigator.language ?? 'en').split('-')[0];
   const htmlDir = window.location.pathname.split('/').slice(0, -1).join('/');
-  const file = await electron.path.join(htmlDir, '..', 'locales', `${lang}.json`);
+  const file = await electron.path.join(htmlDir, '..', 'locales', `${detected}.json`);
   try {
     const raw = (await electron.invoke('fs:readFile', file, 'utf8')) as string;
     translations = JSON.parse(raw) as Record<string, string>;

--- a/readme.md
+++ b/readme.md
@@ -351,8 +351,10 @@ npm run package-all
 ### Adding translations
 
 Translation files live under `app/locales/` and are simple JSON maps of keys to translated strings.
-Add a new `<lang>.json` file (e.g. `fr.json`) with your translations and include the language code in
-`ui.language` inside `appsettings.ts`. Templates reference strings using the `{{t}}` helper.
+Add a new `<lang>.json` file (e.g. `fr.json`) with your translations. When `ui.language` is
+omitted, the application falls back to `navigator.language` (first segment before `-`) to select the
+locale file. To force a specific language, set `ui.language` inside `appsettings.ts`. Templates
+reference strings using the `{{t}}` helper.
 
 ## Docker
 

--- a/test/i18n.test.ts
+++ b/test/i18n.test.ts
@@ -29,4 +29,19 @@ describe('i18n loader', () => {
     expect(_getTranslations()).toEqual({ hello: 'world' });
     expect(Handlebars.helpers.t('hello')).toBe('world');
   });
+
+  test('falls back to navigator language when setting missing', async () => {
+    invokeMock.mockResolvedValue('{"hello":"bonjour"}');
+    Object.defineProperty(window.navigator, 'language', {
+      value: 'fr-FR',
+      configurable: true
+    });
+    const { loadTranslations, _getTranslations } = require('../app/ts/renderer/i18n');
+
+    await loadTranslations();
+
+    const args = joinMock.mock.calls[0];
+    expect(args[args.length - 1]).toBe('fr.json');
+    expect(_getTranslations()).toEqual({ hello: 'bonjour' });
+  });
 });


### PR DESCRIPTION
## Summary
- fall back to `navigator.language` when no `ui.language` is set
- allow optional `ui.language` in settings defaults
- document locale detection and add tests for translation fallback

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run test:e2e` *(fails: WebDriverError: session not created)*

------
https://chatgpt.com/codex/tasks/task_e_68af4dc693888325802af8c1b29c8678