### PR TITLE
fix: use native path for renderer partials

### DIFF
--- a/app/ts/renderer/registerPartials.ts
+++ b/app/ts/renderer/registerPartials.ts
@@ -1,6 +1,7 @@
 import Handlebars from '../../vendor/handlebars.runtime.js';
 import { debugFactory } from '../common/logger.js';
 import type * as fs from 'fs';
+import { fileURLToPath } from 'node:url';
 import type { RendererElectronAPI } from '../../../types/renderer-electron-api.js';
 
 const electron = (window as any).electron as RendererElectronAPI & {
@@ -27,7 +28,7 @@ export async function registerPartials(): Promise<void> {
     // glob helper isn't available, load them using the filesystem helpers
     // exposed via the preload script.
     const dirUrl = new URL('../../compiled-templates/', import.meta.url);
-    const files = (await electron.readdir(dirUrl.pathname)) as string[];
+    const files = (await electron.readdir(fileURLToPath(dirUrl))) as string[];
     for (const file of files) {
       if (!file.endsWith('.js') || file === 'mainPanel.js') continue;
       const spec = await import(/* @vite-ignore */ new URL(file, dirUrl).href);


### PR DESCRIPTION
## Summary
- switch renderer partials fallback to use `fileURLToPath` before readdir to avoid encoded paths

## Testing
- `npm run format`
- `npx tsc --noEmit`
- `npm run lint`
- `npm test` *(fails: Jest encountered unexpected token)*
- `npm run test:e2e` *(fails: WebDriverError: session not created, user data dir in use)*

------
https://chatgpt.com/codex/tasks/task_e_68b0797fc9f88325b571c769dc2c6c2c