### PR TITLE
fix: validate ttl for request cache

### DIFF
--- a/app/ts/common/requestCache.ts
+++ b/app/ts/common/requestCache.ts
@@ -46,6 +46,7 @@ export class RequestCache {
     const { requestCache } = settings;
     const enabled = cacheOpts.enabled ?? requestCache.enabled;
     const ttl = cacheOpts.ttl ?? requestCache.ttl;
+    const ttlMs = typeof ttl === 'number' && Number.isFinite(ttl) ? ttl * 1000 : undefined;
     if (!enabled) return undefined;
     const database = await this.init();
     if (!database) return undefined;
@@ -55,7 +56,7 @@ export class RequestCache {
         .prepare('SELECT response, timestamp FROM cache WHERE key = ?')
         .get(key) as { response: string; timestamp: number } | undefined;
       if (!row) return undefined;
-      if (Date.now() - row.timestamp > ttl * 1000) {
+      if (ttlMs !== undefined && Date.now() - row.timestamp > ttlMs) {
         database.prepare('DELETE FROM cache WHERE key = ?').run(key);
         return undefined;
       }


### PR DESCRIPTION
## Summary
- ensure request cache TTL values are finite before use
- avoid expiring cache entries when TTL is undefined or invalid

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm test` *(fails: better_sqlite3.node compiled for wrong Node.js version)*
- `npm run test:e2e` *(fails: WebDriver session not created due to user-data-dir in use)*

------
https://chatgpt.com/codex/tasks/task_e_68b17d365d5c832594984582e4306602