### PR TITLE
fix: close settings watcher on shutdown

### DIFF
--- a/app/ts/main/settings-main.ts
+++ b/app/ts/main/settings-main.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { ipcMain, BrowserWindow } from 'electron';
+import { ipcMain, BrowserWindow, app } from 'electron';
 import { debugFactory } from '../common/logger.js';
 import {
   settings,
@@ -74,6 +74,19 @@ function watchConfig(): void {
     void reload();
   });
 }
+
+export function cleanup(): void {
+  if (watcher) {
+    watcher.close();
+    watcher = undefined;
+  }
+}
+
+if (app && typeof app.on === 'function') {
+  app.on('will-quit', cleanup);
+}
+
+process.on('exit', cleanup);
 
 export async function loadSettings(): Promise<Settings> {
   const result = await baseLoad();


### PR DESCRIPTION
## Summary
- export a cleanup routine for the settings watcher
- close watcher on `app.will-quit` and process `exit`

## Testing
- `npm run format`
- `npm run lint` *(fails: Empty block statement in workerPool.ts; unused directive in fsIpc.ts)*
- `npx tsc --noEmit`
- `npm test` *(fails: better-sqlite3 module did not self-register, etc.)*
- `npm run test:e2e` *(fails: TypeError cannot read properties of null in settings.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e91159848325925344ff82846b20