### PR TITLE
fix: escape replacement tokens in formatString

### DIFF
--- a/app/ts/common/stringformat.ts
+++ b/app/ts/common/stringformat.ts
@@ -9,7 +9,7 @@
 export function formatString(str: string, ...args: unknown[]): string {
   let result = str;
   args.forEach((arg, i) => {
-    result = result.replace(new RegExp(`\\{${i}\\}`, 'g'), String(arg));
+    result = result.replace(new RegExp(`\\{${i}\\}`, 'g'), () => String(arg));
   });
   return result;
 }

--- a/test/stringformat.test.ts
+++ b/test/stringformat.test.ts
@@ -12,4 +12,16 @@ describe('stringformat', () => {
   test('leaves unused placeholders unchanged', () => {
     expect(formatString('Unused {2} {0}', 'a')).toBe('Unused {2} a');
   });
+
+  test('handles values with replacement tokens', () => {
+    expect(formatString('Value {0}', '$1')).toBe('Value $1');
+  });
+
+  test('handles values with backslashes', () => {
+    expect(formatString('Path {0}', 'C:\\temp\\file')).toBe('Path C:\\temp\\file');
+  });
+
+  test('handles values with braces', () => {
+    expect(formatString('Data {0}', '{test}')).toBe('Data {test}');
+  });
 });


### PR DESCRIPTION
## Summary
- treat replacement tokens like `$` literally by using callback in `formatString`
- test formatting of strings containing replacement tokens, backslashes, and braces

## Testing
- `npm run format`
- `npx tsc --noEmit`
- `npm run lint` *(fails: Empty block statement in main.ts etc.)*
- `npm test` *(fails: cache override ttl refresh case)*
- `npm run test:e2e` *(fails: missing libatk-1.0.so.0 library)*
- `npm test test/stringformat.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b5e4a8d7308325b79ae7f3f776535e