### PR TITLE
fix: harden analyser table rendering

### DIFF
--- a/app/ts/main/fsIpc.ts
+++ b/app/ts/main/fsIpc.ts
@@ -34,7 +34,6 @@ process.on('exit', cleanupWatchers);
 // Avoid direct import.meta usage for CJS test environment
 const hot = (() => {
   try {
-    // eslint-disable-next-line no-eval
     return (eval('import.meta') as any)?.hot as undefined | { dispose: (cb: () => void) => void };
   } catch {
     return undefined;

--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -1,4 +1,3 @@
-import * as conversions from '../../common/conversions.js';
 import { qs, on } from '../../utils/dom.js';
 // jQuery and DataTables are loaded globally via renderer/index.ts
 
@@ -9,8 +8,6 @@ const electron = (window as any).electron as RendererElectronAPI;
 
 const debug = debugFactory('renderer.bwa.analyser');
 debug('loaded');
-
-import { formatString } from '../../common/stringformat.js';
 
 let bwaFileContents: any;
 
@@ -58,35 +55,36 @@ void on('click', '#bwaAnalyserModalCloseButtonNo', () => {
     ipsum
  */
 async function showTable() {
-  const header: Record<string, any> = {},
-    body: Record<string, any> = {};
-  header.columns = Object.keys(bwaFileContents.data[0]);
-  body.records = bwaFileContents.data;
+  const records = Array.isArray(bwaFileContents?.data) ? bwaFileContents.data : [];
 
-  // Generate header column content
-  header.content = '<tr>\n';
-  for (const column of header.columns) {
-    header.content += formatString(
-      '\t<th><abbr title="{0}">{1}</abbr></th>\n',
-      column,
-      getInitials(column)
-    );
-  }
-  header.content += '</tr>';
+  const thead = qs('#bwaAnalyserTableThead')!;
+  const tbody = qs('#bwaAnalyserTableTbody')!;
+  thead.textContent = '';
+  tbody.textContent = '';
 
-  qs('#bwaAnalyserTableThead')!.innerHTML = header.content;
-
-  // Generate record fields
-  body.content = '';
-  for (const record of body.records) {
-    body.content += '<tr>\n';
-
-    for (const value of Object.values(record)) {
-      body.content += formatString('\t<td>{0}</td>\n', value);
+  if (records.length > 0) {
+    const columns = Object.keys(records[0]);
+    const headerRow = document.createElement('tr');
+    for (const column of columns) {
+      const th = document.createElement('th');
+      const abbr = document.createElement('abbr');
+      abbr.title = column;
+      abbr.textContent = getInitials(column);
+      th.appendChild(abbr);
+      headerRow.appendChild(th);
     }
-    body.content += '</tr>\n';
+    thead.appendChild(headerRow);
+
+    for (const record of records) {
+      const row = document.createElement('tr');
+      for (const value of Object.values(record)) {
+        const td = document.createElement('td');
+        td.textContent = String(value);
+        row.appendChild(td);
+      }
+      tbody.appendChild(row);
+    }
   }
-  qs('#bwaAnalyserTableTbody')!.innerHTML = body.content;
 
   qs('#bwaFileinputconfirm')!.classList.add('is-hidden');
   qs('#bwaAnalyser')!.classList.remove('is-hidden');
@@ -94,8 +92,6 @@ async function showTable() {
   if (typeof DT === 'function') {
     new DT('#bwaAnalyserTable', { destroy: true });
   }
-
-  return;
 }
 
 /*

--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -89,7 +89,7 @@ async function showTable() {
   qs('#bwaFileinputconfirm')!.classList.add('is-hidden');
   qs('#bwaAnalyser')!.classList.remove('is-hidden');
   const DT = (window as any).DataTable;
-  if (typeof DT === 'function') {
+  if (typeof DT === 'function' && records.length > 0) {
     new DT('#bwaAnalyserTable', { destroy: true });
   }
 }

--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -57,6 +57,11 @@ void on('click', '#bwaAnalyserModalCloseButtonNo', () => {
 async function showTable() {
   const records = Array.isArray(bwaFileContents?.data) ? bwaFileContents.data : [];
 
+  const DT = (window as any).DataTable;
+  if (typeof DT === 'function' && DT.isDataTable?.('#bwaAnalyserTable')) {
+    DT('#bwaAnalyserTable').destroy();
+  }
+
   const thead = qs('#bwaAnalyserTableThead')!;
   const tbody = qs('#bwaAnalyserTableTbody')!;
   thead.textContent = '';
@@ -88,9 +93,8 @@ async function showTable() {
 
   qs('#bwaFileinputconfirm')!.classList.add('is-hidden');
   qs('#bwaAnalyser')!.classList.remove('is-hidden');
-  const DT = (window as any).DataTable;
   if (typeof DT === 'function' && records.length > 0) {
-    new DT('#bwaAnalyserTable', { destroy: true });
+    new DT('#bwaAnalyserTable');
   }
 }
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,7 +38,8 @@ export default [
       'no-fallthrough': 'off',
       'no-prototype-builtins': 'off',
       'no-control-regex': 'off',
-      'no-useless-escape': 'off'
+      'no-useless-escape': 'off',
+      'no-empty': ['error', { allowEmptyCatch: true }]
     }
   }
 ];

--- a/test/bwaAnalyserRenderer.test.ts
+++ b/test/bwaAnalyserRenderer.test.ts
@@ -19,9 +19,12 @@ beforeEach(() => {
 
 afterEach(() => {
   delete (window as any).electron;
+  delete (window as any).DataTable;
 });
 
 test('handles empty dataset without errors', async () => {
+  const dtMock = jest.fn();
+  (window as any).DataTable = dtMock;
   await renderAnalyser({ data: [] });
   expect(document.querySelector('#bwaAnalyserTableThead')!.children.length).toBe(0);
   expect(document.querySelector('#bwaAnalyserTableTbody')!.children.length).toBe(0);
@@ -29,11 +32,15 @@ test('handles empty dataset without errors', async () => {
   expect(document.querySelector('#bwaFileinputconfirm')!.classList.contains('is-hidden')).toBe(
     true
   );
+  expect(dtMock).not.toHaveBeenCalled();
 });
 
 test('escapes html values in table', async () => {
+  const dtMock = jest.fn();
+  (window as any).DataTable = dtMock;
   await renderAnalyser({ data: [{ name: '<b>bold</b>' }] });
   const cell = document.querySelector('#bwaAnalyserTableTbody td')!;
   expect(cell.textContent).toBe('<b>bold</b>');
   expect(cell.innerHTML).toBe('&lt;b&gt;bold&lt;/b&gt;');
+  expect(dtMock).toHaveBeenCalledTimes(1);
 });

--- a/test/bwaAnalyserRenderer.test.ts
+++ b/test/bwaAnalyserRenderer.test.ts
@@ -1,0 +1,39 @@
+/** @jest-environment jsdom */
+
+let renderAnalyser: (contents: any) => Promise<void>;
+
+beforeEach(() => {
+  jest.resetModules();
+  document.body.innerHTML = `
+    <div id="bwaFileinputconfirm"></div>
+    <div id="bwaAnalyser" class="is-hidden">
+      <table id="bwaAnalyserTable">
+        <thead id="bwaAnalyserTableThead"></thead>
+        <tbody id="bwaAnalyserTableTbody"></tbody>
+      </table>
+    </div>
+  `;
+  (window as any).electron = {};
+  ({ renderAnalyser } = require('../app/ts/renderer/bwa/analyser'));
+});
+
+afterEach(() => {
+  delete (window as any).electron;
+});
+
+test('handles empty dataset without errors', async () => {
+  await renderAnalyser({ data: [] });
+  expect(document.querySelector('#bwaAnalyserTableThead')!.children.length).toBe(0);
+  expect(document.querySelector('#bwaAnalyserTableTbody')!.children.length).toBe(0);
+  expect(document.querySelector('#bwaAnalyser')!.classList.contains('is-hidden')).toBe(false);
+  expect(document.querySelector('#bwaFileinputconfirm')!.classList.contains('is-hidden')).toBe(
+    true
+  );
+});
+
+test('escapes html values in table', async () => {
+  await renderAnalyser({ data: [{ name: '<b>bold</b>' }] });
+  const cell = document.querySelector('#bwaAnalyserTableTbody td')!;
+  expect(cell.textContent).toBe('<b>bold</b>');
+  expect(cell.innerHTML).toBe('&lt;b&gt;bold&lt;/b&gt;');
+});

--- a/test/bwaAnalyserRenderer.test.ts
+++ b/test/bwaAnalyserRenderer.test.ts
@@ -23,7 +23,9 @@ afterEach(() => {
 });
 
 test('handles empty dataset without errors', async () => {
-  const dtMock = jest.fn();
+  const dtMock = Object.assign(jest.fn(), {
+    isDataTable: jest.fn().mockReturnValue(false)
+  });
   (window as any).DataTable = dtMock;
   await renderAnalyser({ data: [] });
   expect(document.querySelector('#bwaAnalyserTableThead')!.children.length).toBe(0);
@@ -32,15 +34,31 @@ test('handles empty dataset without errors', async () => {
   expect(document.querySelector('#bwaFileinputconfirm')!.classList.contains('is-hidden')).toBe(
     true
   );
+  expect(dtMock.isDataTable).toHaveBeenCalledWith('#bwaAnalyserTable');
   expect(dtMock).not.toHaveBeenCalled();
 });
 
+test('destroys existing DataTable when dataset becomes empty', async () => {
+  const destroyMock = jest.fn();
+  const dtMock = Object.assign(jest.fn().mockReturnValue({ destroy: destroyMock }), {
+    isDataTable: jest.fn().mockReturnValue(true)
+  });
+  (window as any).DataTable = dtMock;
+  await renderAnalyser({ data: [] });
+  expect(dtMock.isDataTable).toHaveBeenCalledWith('#bwaAnalyserTable');
+  expect(dtMock).toHaveBeenCalledWith('#bwaAnalyserTable');
+  expect(destroyMock).toHaveBeenCalled();
+});
+
 test('escapes html values in table', async () => {
-  const dtMock = jest.fn();
+  const dtMock = Object.assign(jest.fn(), {
+    isDataTable: jest.fn().mockReturnValue(false)
+  });
   (window as any).DataTable = dtMock;
   await renderAnalyser({ data: [{ name: '<b>bold</b>' }] });
   const cell = document.querySelector('#bwaAnalyserTableTbody td')!;
   expect(cell.textContent).toBe('<b>bold</b>');
   expect(cell.innerHTML).toBe('&lt;b&gt;bold&lt;/b&gt;');
+  expect(dtMock.isDataTable).toHaveBeenCalledWith('#bwaAnalyserTable');
   expect(dtMock).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
## Summary
- guard analyser table generation against missing data
- build analyser table cells safely to avoid HTML injection
- cover analyser table edge cases with unit tests

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test test/bwaAnalyserRenderer.test.ts`
- `npm test`
- `npm run test:e2e` *(fails: libatk-1.0.so.0 missing)*


------
https://chatgpt.com/codex/tasks/task_e_68b60546355c83259cf29f38b40b922e