### PR TITLE
fix: sanitize custom config paths

### DIFF
--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -26,9 +26,15 @@ export function getUserDataPath(): string {
 }
 
 export function resolveUserDataPath(filepath: string): string {
-  const target = path.resolve(getUserDataPath(), filepath);
-  if (!target.startsWith(userDataPath + path.sep)) {
-    return path.join(userDataPath, path.basename(filepath));
+  const base = getUserDataPath();
+  const target = path.resolve(base, filepath);
+  if (!target.startsWith(base + path.sep)) {
+    const name = path.basename(filepath);
+    const sanitized = path.resolve(base, name);
+    if (name === '.' || name === '..' || !sanitized.startsWith(base + path.sep)) {
+      throw new Error('Invalid path');
+    }
+    return sanitized;
   }
   return target;
 }

--- a/app/ts/main/settings-main.ts
+++ b/app/ts/main/settings-main.ts
@@ -13,6 +13,7 @@ import {
   setSettings,
   load as baseLoad,
   save as baseSave,
+  resolveUserDataPath,
   type Settings
 } from '../common/settings.js';
 
@@ -27,7 +28,7 @@ function getCustomConfiguration() {
 
 function getConfigFile(): string {
   const { filepath } = getCustomConfiguration();
-  return path.join(getUserDataPath(), filepath);
+  return resolveUserDataPath(filepath);
 }
 
 function watchConfig(): void {
@@ -119,7 +120,7 @@ if (ipcMain && typeof ipcMain.handle === 'function') {
   });
 
   ipcMain.handle('config:delete', (_e, filePath: string) => {
-    return fs.promises.unlink(filePath);
+    return fs.promises.unlink(resolveUserDataPath(filePath));
   });
 }
 export {

--- a/test/settingsPath.test.ts
+++ b/test/settingsPath.test.ts
@@ -1,0 +1,22 @@
+import path from 'path';
+import { resolveUserDataPath, getUserDataPath } from '../app/ts/common/settings';
+
+describe('resolveUserDataPath', () => {
+  const base = getUserDataPath();
+
+  test('keeps relative paths inside user data directory', () => {
+    const result = resolveUserDataPath('valid.json');
+    expect(result).toBe(path.join(base, 'valid.json'));
+  });
+
+  test('sanitizes absolute paths outside user data directory', () => {
+    const outside = path.resolve(base, '..', 'abs.json');
+    const result = resolveUserDataPath(outside);
+    expect(result).toBe(path.join(base, 'abs.json'));
+  });
+
+  test('sanitizes traversal attempts', () => {
+    const result = resolveUserDataPath(path.join('..', 'trav.json'));
+    expect(result).toBe(path.join(base, 'trav.json'));
+  });
+});

--- a/test/settingsPath.test.ts
+++ b/test/settingsPath.test.ts
@@ -19,4 +19,9 @@ describe('resolveUserDataPath', () => {
     const result = resolveUserDataPath(path.join('..', 'trav.json'));
     expect(result).toBe(path.join(base, 'trav.json'));
   });
+
+  test('rejects paths ending with traversal segments', () => {
+    expect(() => resolveUserDataPath('..')).toThrow();
+    expect(() => resolveUserDataPath(path.join('foo', '..'))).toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
- resolve custom configuration paths inside user data directory
- guard main-process delete handler against path traversal
- test resolving paths for normal, absolute and traversal inputs

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: shared object file not found / ECONNREFUSED)*


------
https://chatgpt.com/codex/tasks/task_e_68b61b8559ac83259c1f00764e2a1a20