### PR TITLE
fix: reject traversal segments in config paths

### DIFF
--- a/app/ts/common/settings.ts
+++ b/app/ts/common/settings.ts
@@ -26,9 +26,15 @@ export function getUserDataPath(): string {
 }
 
 export function resolveUserDataPath(filepath: string): string {
-  const target = path.resolve(getUserDataPath(), filepath);
-  if (!target.startsWith(userDataPath + path.sep)) {
-    return path.join(userDataPath, path.basename(filepath));
+  const base = getUserDataPath();
+  const target = path.resolve(base, filepath);
+  if (!target.startsWith(base + path.sep)) {
+    const name = path.basename(filepath);
+    const sanitized = path.resolve(base, name);
+    if (name === '.' || name === '..' || !sanitized.startsWith(base + path.sep)) {
+      throw new Error('Invalid path');
+    }
+    return sanitized;
   }
   return target;
 }

--- a/test/settingsPath.test.ts
+++ b/test/settingsPath.test.ts
@@ -19,4 +19,9 @@ describe('resolveUserDataPath', () => {
     const result = resolveUserDataPath(path.join('..', 'trav.json'));
     expect(result).toBe(path.join(base, 'trav.json'));
   });
+
+  test('rejects paths ending with traversal segments', () => {
+    expect(() => resolveUserDataPath('..')).toThrow();
+    expect(() => resolveUserDataPath(path.join('foo', '..'))).toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
- reject config paths ending in '.' or '..' to prevent directory traversal
- test traversal suffix handling
- restore default history data

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test` *(fails: cache override test)*
- `npm run test:e2e` *(fails: libatk-1.0.so.0 missing / ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68b61fc6ae608325806fe2462b458c6b