### PR TITLE
refactor: type renderer tools options

### DIFF
--- a/app/ts/renderer/to.ts
+++ b/app/ts/renderer/to.ts
@@ -1,7 +1,8 @@
 // In the renderer process we access IPC methods exposed from the preload script
 // via the `window.electron` bridge instead of importing from 'electron'.
 import type { RendererElectronAPI } from '../../../types/renderer-electron-api.js';
-const { invoke } = (window as any).electron as RendererElectronAPI;
+import type { ProcessOptions } from '../common/tools.js';
+const { invoke } = (window as unknown as { electron: RendererElectronAPI }).electron;
 import { IpcChannel } from '../common/ipcChannels.js';
 import { debugFactory, errorFactory } from '../common/logger.js';
 
@@ -36,8 +37,8 @@ document.addEventListener('click', async (event) => {
   }
 });
 
-function collectOptions() {
-  const opts: any = {};
+function collectOptions(): ProcessOptions {
+  const opts: ProcessOptions = {};
   const prefixInput = document.querySelector<HTMLInputElement>('#toPrefix');
   const suffixInput = document.querySelector<HTMLInputElement>('#toSuffix');
   const prefix = prefixInput?.value ?? '';

--- a/test/toMain.test.ts
+++ b/test/toMain.test.ts
@@ -1,14 +1,16 @@
-const ipcMainHandlers: Record<string, (...args: any[]) => any> = {};
-var mockShowDialog = jest.fn();
+import type { ProcessOptions } from '../app/ts/common/tools';
+
+const ipcMainHandlers: Record<string, (...args: unknown[]) => unknown> = {};
+const mockShowDialog = jest.fn();
 
 jest.mock('electron', () => ({
   ipcMain: {
-    handle: (channel: string, listener: (...args: any[]) => any) => {
+    handle: (channel: string, listener: (...args: unknown[]) => unknown) => {
       ipcMainHandlers[channel] = listener;
     },
     on: jest.fn()
   },
-  dialog: { showOpenDialogSync: (...args: any[]) => mockShowDialog(...args) },
+  dialog: { showOpenDialogSync: (...args: unknown[]) => mockShowDialog(...args) },
   app: undefined,
   BrowserWindow: class {},
   Menu: {}
@@ -18,13 +20,13 @@ const mockReadFile = jest.fn();
 
 jest.mock('fs', () => ({
   ...jest.requireActual('fs'),
-  promises: { readFile: (...args: any[]) => mockReadFile(...args) }
+  promises: { readFile: (...args: unknown[]) => mockReadFile(...args) }
 }));
 
-const mockProcessLines = jest.fn();
+const mockProcessLines = jest.fn((lines: string[], options: ProcessOptions): string[] => []);
 
 jest.mock('../app/ts/common/tools.js', () => ({
-  processLines: (...args: any[]) => mockProcessLines(...args)
+  processLines: (...args: Parameters<typeof mockProcessLines>) => mockProcessLines(...args)
 }));
 import '../app/ts/main/to';
 
@@ -41,27 +43,30 @@ describe('to main handler', () => {
   test('returns processed result', async () => {
     mockReadFile.mockResolvedValue('a\nb');
     mockProcessLines.mockReturnValue(['x', 'y']);
-    const result = await processHandler()({} as any, '/tmp/list.txt', { opt: 1 } as any);
+    const opts: ProcessOptions = { prefix: 'pre' };
+    const result = await processHandler()({} as unknown, '/tmp/list.txt', opts);
 
     expect(mockReadFile).toHaveBeenCalledWith('/tmp/list.txt', 'utf8');
-    expect(mockProcessLines).toHaveBeenCalledWith(['a', 'b'], { opt: 1 });
+    expect(mockProcessLines).toHaveBeenCalledWith(['a', 'b'], opts);
     expect(result).toBe('x\ny');
   });
 
   test('throws error when read fails', async () => {
     mockReadFile.mockRejectedValue(new Error('fail'));
-    await expect(processHandler()({} as any, '/tmp/list.txt', {})).rejects.toThrow('fail');
+    await expect(
+      processHandler()({} as unknown, '/tmp/list.txt', {} as ProcessOptions)
+    ).rejects.toThrow('fail');
   });
 
   test('returns selected input path', async () => {
     mockShowDialog.mockReturnValue('/tmp/list.txt');
-    const result = await inputHandler()({} as any);
+    const result = await inputHandler()({} as unknown);
     expect(result).toBe('/tmp/list.txt');
   });
 
   test('returns undefined when canceled', async () => {
     mockShowDialog.mockReturnValue(undefined);
-    const result = await inputHandler()({} as any);
+    const result = await inputHandler()({} as unknown);
     expect(result).toBeUndefined();
   });
 });

--- a/test/toRenderer.test.ts
+++ b/test/toRenderer.test.ts
@@ -1,8 +1,9 @@
 /** @jest-environment jsdom */
 
 import jQuery from 'jquery';
+import type { ProcessOptions } from '../app/ts/common/tools';
 
-const handlers: Record<string, (...args: any[]) => void> = {};
+const handlers: Record<string, (...args: unknown[]) => void> = {};
 const mockSend = jest.fn();
 const mockInvoke = jest.fn();
 
@@ -28,6 +29,8 @@ beforeEach(() => {
     <input id="toDeleteBlank" type="checkbox" />
     <input id="toDedupe" type="checkbox" />
     <input type="radio" name="toSort" value="asc" id="radioAsc" />
+    <input type="radio" name="toSort" value="desc" id="radioDesc" />
+    <input type="radio" name="toSort" value="random" id="radioRandom" />
     <div id="toOutput"></div>
   `;
   (window as any).$ = (window as any).jQuery = jQuery;
@@ -51,31 +54,45 @@ afterEach(() => {
   for (const key in handlers) delete handlers[key];
 });
 
-test('select and process file flow', async () => {
+test('process with no additional options', async () => {
+  mockInvoke.mockResolvedValueOnce('/tmp/list.txt');
+  jQuery('#toButtonSelect').trigger('click');
+  await new Promise((r) => setTimeout(r, 0));
+
+  mockInvoke.mockResolvedValueOnce('ok');
+  jQuery('#toButtonProcess').trigger('click');
+  await new Promise((r) => setTimeout(r, 0));
+
+  const expected: ProcessOptions = {};
+  expect(mockInvoke).toHaveBeenLastCalledWith('to:process', '/tmp/list.txt', expected);
+  expect(jQuery('#toOutput').text()).toBe('ok');
+});
+
+test.each(['asc', 'desc', 'random'] as const)('select and process file flow (%s)', async (sort) => {
   mockInvoke.mockResolvedValueOnce('/tmp/list.txt');
   jQuery('#toButtonSelect').trigger('click');
   await new Promise((r) => setTimeout(r, 0));
   expect(mockInvoke).toHaveBeenCalledWith('to:input.file');
-  expect(jQuery('#toFileSelected').text()).toBe('/tmp/list.txt');
 
   jQuery('#toPrefix').val('pre');
   jQuery('#toSuffix').val('suf');
   jQuery('#toTrimSpaces').prop('checked', true);
   jQuery('#toDeleteBlank').prop('checked', true);
   jQuery('#toDedupe').prop('checked', true);
-  jQuery('#radioAsc').prop('checked', true);
+  jQuery(`#radio${sort[0].toUpperCase()}${sort.slice(1)}`).prop('checked', true);
 
   mockInvoke.mockResolvedValueOnce('ok');
   jQuery('#toButtonProcess').trigger('click');
   await new Promise((r) => setTimeout(r, 0));
 
-  expect(mockInvoke).toHaveBeenCalledWith('to:process', '/tmp/list.txt', {
+  const expected: ProcessOptions = {
     prefix: 'pre',
     suffix: 'suf',
     trimSpaces: true,
     deleteBlankLines: true,
     dedupe: true,
-    sort: 'asc'
-  });
+    sort
+  };
+  expect(mockInvoke).toHaveBeenLastCalledWith('to:process', '/tmp/list.txt', expected);
   expect(jQuery('#toOutput').text()).toBe('ok');
 });


### PR DESCRIPTION
## Summary
- type collectOptions in renderer so callers work with `ProcessOptions`
- remove `any` and tighten mocks in tests
- test renderer option combinations and main handler typing

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e` *(fails: shared object file missing / browser connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b6db9dd53c8325947260e1cce75f29