### PR TITLE
refactor: add typed export interfaces

### DIFF
--- a/app/data/profiles/default/history.json
+++ b/app/data/profiles/default/history.json
@@ -1,1 +1,1 @@
-[{"domain":"example.com","timestamp":1756646868912,"status":"unavailable"},{"domain":"example.com","timestamp":1756646868869,"status":"available"}]
+[]

--- a/app/ts/common/ipcContracts.ts
+++ b/app/ts/common/ipcContracts.ts
@@ -2,6 +2,8 @@ import type { IpcChannel } from './ipcChannels.js';
 import type DomainStatus from './status.js';
 import type { WhoisResult } from './availability.js';
 import type { ProcessOptions } from './tools.js';
+import type { BulkWhoisResults } from '#main/bulkwhois/types';
+import type { ExportOptions } from '#main/bulkwhois/export-helpers';
 
 /**
  * Mapping between IPC channels and their request/response payloads.
@@ -32,9 +34,9 @@ export interface IpcContracts {
     request: [string | string[] | null, boolean?];
     response: void;
   };
-  [IpcChannel.BulkwhoisResultReceive]: { request: [unknown]; response: void };
+  [IpcChannel.BulkwhoisResultReceive]: { request: [BulkWhoisResults]; response: void };
   [IpcChannel.BulkwhoisExport]: {
-    request: [any, any];
+    request: [BulkWhoisResults, ExportOptions];
     response: void;
   };
   [IpcChannel.BulkwhoisExportCancel]: { request: []; response: void };

--- a/app/ts/renderer/bulkwhois/auxiliary.ts
+++ b/app/ts/renderer/bulkwhois/auxiliary.ts
@@ -1,4 +1,5 @@
 import { debugFactory } from '../../common/logger.js';
+import type { ExportOptions } from '#main/bulkwhois/export-helpers';
 
 const debug = debugFactory('bulkwhois.auxiliary');
 debug('loaded');
@@ -37,13 +38,13 @@ function tableReset(dLength = 0, tLength = 0) {
   getExportOptions
     Get export options after bulk whois processing is finished
  */
-function getExportOptions() {
+function getExportOptions(): ExportOptions {
   return {
-    filetype: (qs('#bwExportSelectFiletype') as HTMLSelectElement | null)?.value,
-    domains: (qs('#bwExportSelectDomains') as HTMLSelectElement | null)?.value,
-    errors: (qs('#bwExportSelectErrors') as HTMLSelectElement | null)?.value,
-    information: (qs('#bwExportSelectInformation') as HTMLSelectElement | null)?.value,
-    whoisreply: (qs('#bwExportSelectReply') as HTMLSelectElement | null)?.value
+    filetype: (qs('#bwExportSelectFiletype') as HTMLSelectElement | null)?.value ?? '',
+    domains: (qs('#bwExportSelectDomains') as HTMLSelectElement | null)?.value ?? '',
+    errors: (qs('#bwExportSelectErrors') as HTMLSelectElement | null)?.value ?? '',
+    information: (qs('#bwExportSelectInformation') as HTMLSelectElement | null)?.value ?? '',
+    whoisreply: (qs('#bwExportSelectReply') as HTMLSelectElement | null)?.value ?? ''
   };
 }
 

--- a/app/ts/renderer/bulkwhois/export.defaults.ts
+++ b/app/ts/renderer/bulkwhois/export.defaults.ts
@@ -1,10 +1,11 @@
 // Default export options values
 import { debugFactory } from '../../common/logger.js';
+import type { ExportOptions } from '#main/bulkwhois/export-helpers';
 
 const debug = debugFactory('bulkwhois.export.defaults');
 debug('loaded');
 
-const defaultExportOptions = {
+const defaultExportOptions: ExportOptions = {
   filetype: 'csv', // Filetype to export
   domains: 'available', // Export only available domains
   errors: 'no', // Do not export lookup errors


### PR DESCRIPTION
## Summary
- type export results and options
- update bulk whois export helpers to return typed options
- refine IPC contracts for export

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68b71f580ea88325bf9dcaec06035edb