### PR TITLE
refactor: tighten bulkwhois event typing

### DIFF
--- a/app/ts/renderer/bulkwhois/event-bindings.ts
+++ b/app/ts/renderer/bulkwhois/event-bindings.ts
@@ -1,12 +1,19 @@
 import { qs, on } from '../../utils/dom.js';
 import { IpcChannel } from '../../common/ipcChannels.js';
 import { debugFactory } from '../../common/logger.js';
+import type { RendererElectronAPI } from '../../../../types/renderer-electron-api.js';
 
 const debug = debugFactory('bulkwhois.events');
 
-export function bindProcessingEvents(electron: {
-  send: (channel: string, ...args: any[]) => void;
-}): void {
+type BwProcessingChannels = {
+  [IpcChannel.BulkwhoisLookupContinue]: [];
+  [IpcChannel.BulkwhoisLookupPause]: [];
+  [IpcChannel.BulkwhoisLookupStop]: [];
+};
+
+export type BwProcessingElectron = Pick<RendererElectronAPI<BwProcessingChannels>, 'send'>;
+
+export function bindProcessingEvents(electron: BwProcessingElectron): void {
   void on('click', '#bwProcessingButtonPause', () => {
     const searchStatus = qs('#bwProcessingButtonPauseSpanText')?.textContent ?? '';
     switch (searchStatus) {

--- a/test/bulkwhoisEventBindings.test.ts
+++ b/test/bulkwhoisEventBindings.test.ts
@@ -1,12 +1,22 @@
 /** @jest-environment jsdom */
 import jQuery from 'jquery';
-import { bindProcessingEvents } from '../app/ts/renderer/bulkwhois/event-bindings';
+import {
+  bindProcessingEvents,
+  BwProcessingElectron
+} from '../app/ts/renderer/bulkwhois/event-bindings';
 import { IpcChannel } from '../app/ts/common/ipcChannels';
 
 describe('event bindings', () => {
   test('pause button toggles state', () => {
-    const sendMock = jest.fn();
-    const electron = { send: sendMock } as any;
+    const sendMock: jest.Mock<
+      void,
+      [
+        | IpcChannel.BulkwhoisLookupContinue
+        | IpcChannel.BulkwhoisLookupPause
+        | IpcChannel.BulkwhoisLookupStop
+      ]
+    > = jest.fn();
+    const electron: BwProcessingElectron = { send: sendMock };
     document.body.innerHTML = `
       <button id="bwProcessingButtonPause" class="is-success">
         <i id="bwProcessingButtonPauseicon" class="fa-pause"></i>


### PR DESCRIPTION
## Summary
- refine bulkwhois processing events to use typed RendererElectronAPI send
- update unit test to work with stricter typing

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: required environment not available)*

------
https://chatgpt.com/codex/tasks/task_e_68b7309890a48325a66017ebe2b36b42