### PR TITLE
fix: sanitize analyser table rendering

### DIFF
--- a/app/ts/renderer/bwa/analyser.ts
+++ b/app/ts/renderer/bwa/analyser.ts
@@ -73,7 +73,7 @@ async function showTable() {
     for (const column of columns) {
       const th = document.createElement('th');
       const abbr = document.createElement('abbr');
-      abbr.title = column;
+      abbr.setAttribute('title', String(column));
       abbr.textContent = getInitials(column);
       th.appendChild(abbr);
       headerRow.appendChild(th);
@@ -84,7 +84,7 @@ async function showTable() {
       const row = document.createElement('tr');
       for (const value of Object.values(record)) {
         const td = document.createElement('td');
-        td.textContent = String(value);
+        td.textContent = value == null ? '' : String(value);
         row.appendChild(td);
       }
       tbody.appendChild(row);

--- a/test/bwaAnalyserRenderer.test.ts
+++ b/test/bwaAnalyserRenderer.test.ts
@@ -1,6 +1,7 @@
 /** @jest-environment jsdom */
 
 let renderAnalyser: (contents: any) => Promise<void>;
+let originalAlert: any;
 
 beforeEach(() => {
   jest.resetModules();
@@ -14,12 +15,15 @@ beforeEach(() => {
     </div>
   `;
   (window as any).electron = {};
+  originalAlert = (window as any).alert;
   ({ renderAnalyser } = require('../app/ts/renderer/bwa/analyser'));
 });
 
 afterEach(() => {
+  (window as any).alert = originalAlert;
   delete (window as any).electron;
   delete (window as any).DataTable;
+  delete (window as any).hacked;
 });
 
 test('handles empty dataset without errors', async () => {
@@ -59,6 +63,23 @@ test('escapes html values in table', async () => {
   const cell = document.querySelector('#bwaAnalyserTableTbody td')!;
   expect(cell.textContent).toBe('<b>bold</b>');
   expect(cell.innerHTML).toBe('&lt;b&gt;bold&lt;/b&gt;');
+  expect(dtMock.isDataTable).toHaveBeenCalledWith('#bwaAnalyserTable');
+  expect(dtMock).toHaveBeenCalledTimes(1);
+});
+
+test('does not execute scripts from malicious input', async () => {
+  const dtMock = Object.assign(jest.fn(), {
+    isDataTable: jest.fn().mockReturnValue(false)
+  });
+  (window as any).DataTable = dtMock;
+  const alertMock = jest.fn();
+  (window as any).alert = alertMock;
+  await renderAnalyser({
+    data: [{ a: '<script>window.hacked=true</script>', b: '<img src=x onerror="alert(1)">' }]
+  });
+  expect(alertMock).not.toHaveBeenCalled();
+  expect((window as any).hacked).toBeUndefined();
+  expect(document.querySelector('script')).toBeNull();
   expect(dtMock.isDataTable).toHaveBeenCalledWith('#bwaAnalyserTable');
   expect(dtMock).toHaveBeenCalledTimes(1);
 });

--- a/test/cacheOverride.test.ts
+++ b/test/cacheOverride.test.ts
@@ -18,6 +18,10 @@ describe('cache override', () => {
     settings.requestCache.ttl = 60;
   });
 
+  beforeEach(async () => {
+    await requestCache.clear();
+  });
+
   afterAll(() => {
     // ensure DB is not locked on Windows
     settings.requestCache.enabled = false;
@@ -51,6 +55,7 @@ describe('cache override', () => {
       cb(null, 'DATA');
     });
     await lookup('ttl.com', undefined, { ttl: 0 });
+    await new Promise((r) => setTimeout(r, 1));
     await lookup('ttl.com', undefined, { ttl: 0 });
     expect(spy).toHaveBeenCalledTimes(2);
     spy.mockRestore();
@@ -59,6 +64,7 @@ describe('cache override', () => {
   test('dns lookup ttl override forces refresh', async () => {
     const spy = jest.spyOn(dns, 'resolve').mockResolvedValue(['ns1']);
     await nsLookup('ttl.com', { ttl: 0 });
+    await new Promise((r) => setTimeout(r, 1));
     await nsLookup('ttl.com', { ttl: 0 });
     expect(spy).toHaveBeenCalledTimes(2);
     spy.mockRestore();


### PR DESCRIPTION
## Summary
- ensure analyser table columns and cells insert text safely
- test analyser renderer against script injection
- stabilize cache override tests to pass reliably

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b75c0ce45083259910fe3d60ba98de