### PR TITLE
fix: deduplicate lookup domains

### DIFF
--- a/app/ts/cli.ts
+++ b/app/ts/cli.ts
@@ -151,7 +151,7 @@ export async function lookupDomains(opts: CliOptions): Promise<WhoisResult[]> {
     settings.lookupProxy.single = opts.proxy;
   }
 
-  let domains: string[] = opts.domains;
+  let domains: string[] = [...opts.domains];
   if (opts.wordlist) {
     for await (const line of readLines(opts.wordlist)) {
       const word = line.trim();
@@ -161,6 +161,8 @@ export async function lookupDomains(opts: CliOptions): Promise<WhoisResult[]> {
       }
     }
   }
+
+  domains = Array.from(new Set(domains));
 
   const report =
     opts.progress && domains.length > 0 ? createProgressRenderer(domains.length) : undefined;

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -202,6 +202,24 @@ describe('cli utility', () => {
     fs.unlinkSync(wl);
   });
 
+  test('lookupDomains does not mutate input domains and skips duplicates', async () => {
+    mockLookup.mockClear();
+    const wl = path.join(__dirname, 'wl_dup.txt');
+    fs.writeFileSync(wl, 'dup\ndup');
+    mockLookup.mockResolvedValue('data');
+    const opts: CliOptions = {
+      domains: ['dup.com', 'dup.com'],
+      tlds: ['com'],
+      wordlist: wl,
+      format: 'txt'
+    };
+    const originalDomains = [...opts.domains];
+    await lookupDomains(opts);
+    expect(opts.domains).toEqual(originalDomains);
+    expect(mockLookup).toHaveBeenCalledTimes(1);
+    fs.unlinkSync(wl);
+  });
+
   test('lookupDomains enforces concurrency limit with many domains', async () => {
     mockLookup.mockClear();
     let active = 0;


### PR DESCRIPTION
## Summary
- prevent `lookupDomains` from mutating input list and remove duplicate entries
- test that the CLI respects the original domain array and deduplicates lookups

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: AggregateError [ECONNREFUSED])*

------
https://chatgpt.com/codex/tasks/task_e_68b8809cd5e48325b9c6c8b42a18cda2