### PR TITLE
refactor(utils): use debugFactory in fetchCompat

### DIFF
--- a/app/ts/utils/fetchCompat.ts
+++ b/app/ts/utils/fetchCompat.ts
@@ -1,14 +1,24 @@
+import { debugFactory } from '../common/logger.js';
+
+/**
+ * Ensure a global `fetch` implementation is available.
+ * Attempts to use `node-fetch` first and falls back to `undici` with debug logging.
+ */
 export async function ensureFetch(): Promise<void> {
   if (typeof globalThis.fetch === 'undefined') {
     try {
+      // Prefer node-fetch to polyfill the Fetch API in Node.js environments.
       const { default: fetchImpl } = await import('node-fetch');
       (globalThis as any).fetch = fetchImpl as unknown as typeof fetch;
     } catch (err) {
-      console.warn('Failed to load node-fetch, attempting to use undici', err);
+      // Log the failure and try to fall back to undici's fetch implementation.
+      debugFactory('utils.fetchCompat')('Failed to load node-fetch, attempting to use undici', err);
       try {
+        // If undici is available, use its fetch polyfill.
         const { fetch: undiciFetch } = await import('undici');
         (globalThis as any).fetch = undiciFetch as unknown as typeof fetch;
       } catch {
+        // Neither polyfill could be loaded; surface a clear error.
         throw new Error('Fetch API is not available and no polyfill could be loaded.');
       }
     }


### PR DESCRIPTION
## Summary
- use debugFactory for fetch polyfill logging
- test fallback logging via debugFactory

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b889c2660083259a628e06f591e214