### PR TITLE
fix: ensure CLI export creates directories

### DIFF
--- a/app/ts/cli.ts
+++ b/app/ts/cli.ts
@@ -228,6 +228,7 @@ export async function exportResults(results: WhoisResult[], opts: CliOptions): P
           .join(lookupExport.separator)
       );
       const content = [header.join(lookupExport.separator), ...lines].join(lookupExport.linebreak);
+      await fs.promises.mkdir(path.dirname(file), { recursive: true });
       await fs.promises.writeFile(file, content);
       return file;
     }
@@ -238,11 +239,13 @@ export async function exportResults(results: WhoisResult[], opts: CliOptions): P
           zip.file(`${r.domain}${lookupExport.filetypeText}`, r.whoisreply);
       }
       const data = await zip.generateAsync({ type: 'uint8array' });
+      await fs.promises.mkdir(path.dirname(file), { recursive: true });
       await fs.promises.writeFile(file, data);
       return file;
     }
     case 'json': {
       const content = JSON.stringify(results, null, 2);
+      await fs.promises.mkdir(path.dirname(file), { recursive: true });
       await fs.promises.writeFile(file, content);
       return file;
     }
@@ -250,6 +253,7 @@ export async function exportResults(results: WhoisResult[], opts: CliOptions): P
       const content = results
         .map((r) => `==== ${r.domain} ====` + lookupExport.linebreak + (r.whoisreply ?? ''))
         .join(lookupExport.linebreak + lookupExport.linebreak);
+      await fs.promises.mkdir(path.dirname(file), { recursive: true });
       await fs.promises.writeFile(file, content);
       return file;
     }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -329,6 +329,41 @@ describe('cli utility', () => {
     fs.unlinkSync(file);
   });
 
+  test.each(['csv', 'json', 'zip', 'txt'])(
+    'exportResults writes %s to nested directories',
+    async (format) => {
+      const base = path.join(__dirname, `nested_${format}`, 'dir');
+      const ext = format === 'txt' ? 'txt' : format;
+      const file = path.join(base, `out.${ext}`);
+      await fs.promises.rm(path.join(__dirname, `nested_${format}`), {
+        recursive: true,
+        force: true
+      });
+      await exportResults(
+        [
+          {
+            domain: 'example.com',
+            status: 'available',
+            registrar: 'reg',
+            company: 'comp',
+            creationDate: 'c',
+            updateDate: 'u',
+            expiryDate: 'e',
+            whoisreply: 'r',
+            whoisJson: {}
+          }
+        ],
+        { domains: [], tlds: ['com'], format: format as CliOptions['format'], out: file }
+      );
+      const stat = await fs.promises.stat(file);
+      expect(stat.isFile()).toBe(true);
+      await fs.promises.rm(path.join(__dirname, `nested_${format}`), {
+        recursive: true,
+        force: true
+      });
+    }
+  );
+
   test('parseArgs requires domain or wordlist', () => {
     expect(() => parseArgs([])).toThrow('Either --domain or --wordlist must be provided');
   });


### PR DESCRIPTION
## Summary
- ensure CLI exports create parent directories for all formats
- add tests verifying export to nested directories

## Testing
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run test:e2e` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ff08a3288325b7332aa8b5d69f43