### PR TITLE
fix: create export directories before writing

### DIFF
--- a/app/ts/main/bulkwhois/export.ts
+++ b/app/ts/main/bulkwhois/export.ts
@@ -1,5 +1,6 @@
 import { dialog, shell } from 'electron';
 import fs from 'fs';
+import path from 'path';
 import { debugFactory } from '../../common/logger.js';
 const debug = debugFactory('bulkwhois.export');
 import { formatString } from '../../common/stringformat.js';
@@ -85,6 +86,7 @@ handle(IpcChannel.BulkwhoisExport, async function (event, results, options) {
     exportSettings
   );
   if (content) {
+    await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
     await fs.promises.writeFile(filePath, content);
     debug(formatString('File was saved, {0}', filePath));
   }


### PR DESCRIPTION
## Summary
- ensure bulk WHOIS export creates parent directories before saving

## Testing
- `npm run lint`
- `npm run format`
- `npx tsc --noEmit`
- `npm run build`
- `npm test`
- `npm run test:e2e` *(fails: Missing X server or $DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_68c49a678b8c8325a0755f4844ae4c18